### PR TITLE
Extensible schema

### DIFF
--- a/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
@@ -1,17 +1,67 @@
 package `in`.specmatic.conversions
 
-class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<String, String>, val systemProperties: Map<String, String>) {
-    constructor() : this(System.getenv(), System.getProperties().map { it.key.toString() to (it.value?.toString() ?: "") }.toMap())
+import org.apache.commons.lang3.BooleanUtils
 
-    fun getEnvironmentVariable(variableName: String): String? {
+class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<String, String>, val systemProperties: Map<Any?, Any?>) {
+    constructor() : this(System.getenv(), System.getProperties().toMap())
+
+    val VALIDATE_RESPONSE = "VALIDATE_RESPONSE"
+    private val CUSTOM_RESPONSE_NAME = "CUSTOM_RESPONSE"
+    val SPECMATIC_GENERATIVE_TESTS = "SPECMATIC_GENERATIVE_TESTS"
+    private val MAX_TEST_REQUEST_COMBINATIONS = "MAX_TEST_REQUEST_COMBINATIONS"
+    val SCHEMA_EXAMPLE_DEFAULT = "SCHEMA_EXAMPLE_DEFAULT"
+    val ONLY_POSITIVE = "ONLY_POSITIVE"
+    val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
+
+    val EXTENSIBLE_SCHEMA = "EXTENSIBLE_SCHEMA"
+
+    private fun flagValue(flagName: String): String? {
+        return System.getenv(flagName) ?: System.getProperty(flagName)
+    }
+
+    fun customResponse(): Boolean {
+        return flagValue(CUSTOM_RESPONSE_NAME) == "true"
+    }
+
+    private fun booleanFlag(flagName: String, default: String = "false") = BooleanUtils.toBoolean(flagValue(flagName) ?: default)
+
+    fun extensibleSchema(): Boolean {
+        return booleanFlag(EXTENSIBLE_SCHEMA)
+    }
+
+    fun schemaExampleDefaultEnabled(): Boolean {
+        return booleanFlag(SCHEMA_EXAMPLE_DEFAULT)
+    }
+
+    fun generativeTestingEnabled(): Boolean {
+        return booleanFlag(SPECMATIC_GENERATIVE_TESTS)
+    }
+
+    fun maxTestRequestCombinations(): Int {
+        return flagValue(MAX_TEST_REQUEST_COMBINATIONS)?.toInt() ?: Int.MAX_VALUE
+    }
+
+    fun onlyPositive(): Boolean {
+        return booleanFlag(ONLY_POSITIVE)
+    }
+
+    fun testParallelism(): String? {
+        return flagValue(SPECMATIC_TEST_PARALLELISM)
+    }
+
+    fun validateResponse(): Boolean {
+        return booleanFlag(VALIDATE_RESPONSE, "false")
+    }
+
+    fun getCachedEnvironmentVariable(variableName: String): String? {
         return environmentVariables[variableName]
     }
 
-    fun getSystemProperty(variableName: String): String? {
-        return systemProperties[variableName]
+    fun getCachedSystemProperty(variableName: String): String? {
+        return systemProperties[variableName]?.toString()
     }
 
-    fun getSetting(variableName: String): String? {
-        return getEnvironmentVariable(variableName) ?: getSystemProperty(variableName)
+    fun getCachedSetting(variableName: String): String? {
+        return getCachedEnvironmentVariable(variableName) ?: getCachedSystemProperty(variableName)
     }
 }

--- a/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/EnvironmentAndPropertiesConfiguration.kt
@@ -2,7 +2,7 @@ package `in`.specmatic.conversions
 
 import org.apache.commons.lang3.BooleanUtils
 
-class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<String, String>, val systemProperties: Map<Any?, Any?>) {
+data class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<String, String>, val systemProperties: Map<Any?, Any?>) {
     constructor() : this(System.getenv(), System.getProperties().toMap())
 
     val VALIDATE_RESPONSE = "VALIDATE_RESPONSE"
@@ -15,8 +15,18 @@ class EnvironmentAndPropertiesConfiguration(val environmentVariables: Map<String
 
     val EXTENSIBLE_SCHEMA = "EXTENSIBLE_SCHEMA"
 
+    companion object {
+        fun setProperty(name: String, value: String): EnvironmentAndPropertiesConfiguration {
+            return EnvironmentAndPropertiesConfiguration(mapOf(), mapOf(name to value))
+        }
+
+        fun setProperties(properties: Map<String, String>): EnvironmentAndPropertiesConfiguration {
+            return EnvironmentAndPropertiesConfiguration(mapOf(), properties.mapValues { it.value })
+        }
+    }
+
     private fun flagValue(flagName: String): String? {
-        return System.getenv(flagName) ?: System.getProperty(flagName)
+        return environmentVariables[flagName] ?: systemProperties[flagName]?.toString() ?: System.getenv(flagName) ?: System.getProperty(flagName)
     }
 
     fun customResponse(): Boolean {

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -421,7 +421,7 @@ class OpenApiSpecification(
 
         when {
             requestExamples.isNotEmpty() -> {
-                val responseExampleValueForRow = if (environmentAndPropertiesConfiguration.getSetting(Flags.VALIDATE_RESPONSE)?.lowercase() == "true")
+                val responseExampleValueForRow = if (environmentAndPropertiesConfiguration.getCachedSetting(Flags.VALIDATE_RESPONSE)?.lowercase() == "true")
                     responseExample
                 else
                     null

--- a/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/OpenApiSpecification.kt
@@ -138,7 +138,8 @@ class OpenApiSpecification(
             sourceRepositoryBranch = sourceRepositoryBranch,
             specification = specificationPath,
             serviceType = SERVICE_TYPE_HTTP,
-            stubsFromExamples = stubsFromExamples
+            stubsFromExamples = stubsFromExamples,
+            environmentAndPropertiesConfiguration = environmentAndPropertiesConfiguration
         )
     }
 
@@ -421,7 +422,7 @@ class OpenApiSpecification(
 
         when {
             requestExamples.isNotEmpty() -> {
-                val responseExampleValueForRow = if (environmentAndPropertiesConfiguration.getCachedSetting(Flags.VALIDATE_RESPONSE)?.lowercase() == "true")
+                val responseExampleValueForRow = if (environmentAndPropertiesConfiguration.validateResponse())
                     responseExample
                 else
                     null

--- a/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
+++ b/core/src/main/kotlin/in/specmatic/conversions/SecurityToken.kt
@@ -15,9 +15,9 @@ fun getSecurityTokenForBasicAuthScheme(
     environmentVariable: String,
     environmentAndPropertiesConfiguration: EnvironmentAndPropertiesConfiguration
 ): String? {
-    return environmentAndPropertiesConfiguration.getEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
+    return environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
         (securitySchemeConfiguration as BasicAuthSecuritySchemeConfiguration).token
-    } ?: environmentAndPropertiesConfiguration.getEnvironmentVariable(SPECMATIC_BASIC_AUTH_TOKEN)
+    } ?: environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(SPECMATIC_BASIC_AUTH_TOKEN)
 }
 
 fun getSecurityTokenForBearerScheme(
@@ -25,9 +25,9 @@ fun getSecurityTokenForBearerScheme(
     environmentVariable: String,
     environmentAndPropertiesConfiguration: EnvironmentAndPropertiesConfiguration
 ): String? {
-    return environmentAndPropertiesConfiguration.getEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
+    return environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
         (it as SecuritySchemeWithOAuthToken).token
-    } ?: environmentAndPropertiesConfiguration.getEnvironmentVariable(SPECMATIC_OAUTH2_TOKEN)
+    } ?: environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(SPECMATIC_OAUTH2_TOKEN)
 }
 
 fun getSecurityTokenForApiKeyScheme(
@@ -35,7 +35,7 @@ fun getSecurityTokenForApiKeyScheme(
     environmentVariable: String,
     environmentAndPropertiesConfiguration: EnvironmentAndPropertiesConfiguration
 ): String? {
-    return environmentAndPropertiesConfiguration.getEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
+    return environmentAndPropertiesConfiguration.getCachedEnvironmentVariable(environmentVariable) ?: securitySchemeConfiguration?.let {
         (it as APIKeySecuritySchemeConfiguration).value
     }
 }

--- a/core/src/main/kotlin/in/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Feature.kt
@@ -81,7 +81,8 @@ data class Feature(
     val specification:String? = null,
     val serviceType:String? = null,
     val stubsFromExamples: Map<String, List<Pair<HttpRequest, HttpResponse>>> = emptyMap(),
-    val resolverStrategies: ResolverStrategies = strategiesFromFlags()
+    val environmentAndPropertiesConfiguration: EnvironmentAndPropertiesConfiguration = EnvironmentAndPropertiesConfiguration(),
+    val resolverStrategies: ResolverStrategies = strategiesFromFlags(environmentAndPropertiesConfiguration)
 ) {
     fun enableGenerativeTesting(onlyPositive: Boolean = false): Feature {
         return this.copy(resolverStrategies = this.resolverStrategies.copy(generation = GenerativeTestsEnabled(onlyPositive)))

--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -11,7 +11,7 @@ object Flags {
     const val ONLY_POSITIVE = "ONLY_POSITIVE"
     const val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
 
-    const val EXTENDABLE_SCHEMA = "EXTENDABLE_SCHEMA"
+    const val EXTENSIBLE_SCHEMA = "EXTENSIBLE_SCHEMA"
 
     private fun flagValue(flagName: String): String? {
         return System.getenv(flagName) ?: System.getProperty(flagName)
@@ -23,8 +23,8 @@ object Flags {
 
     private fun booleanFlag(flagName: String, default: String = "false") = BooleanUtils.toBoolean(flagValue(flagName) ?: default)
 
-    fun extendableSchemaEnabled(): Boolean {
-        return booleanFlag(EXTENDABLE_SCHEMA)
+    fun extensibleSchema(): Boolean {
+        return booleanFlag(EXTENSIBLE_SCHEMA)
     }
 
     fun schemaExampleDefaultEnabled(): Boolean {

--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -11,6 +11,8 @@ object Flags {
     const val ONLY_POSITIVE = "ONLY_POSITIVE"
     const val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
 
+    const val EXTENDABLE_SCHEMA = "EXTENDABLE_SCHEMA"
+
     private fun flagValue(flagName: String): String? {
         return System.getenv(flagName) ?: System.getProperty(flagName)
     }
@@ -20,6 +22,10 @@ object Flags {
     }
 
     private fun booleanFlag(flagName: String, default: String = "false") = BooleanUtils.toBoolean(flagValue(flagName) ?: default)
+
+    fun extendableSchemaEnabled(): Boolean {
+        return booleanFlag(EXTENDABLE_SCHEMA)
+    }
 
     fun schemaExampleDefaultEnabled(): Boolean {
         return booleanFlag(SCHEMA_EXAMPLE_DEFAULT)

--- a/core/src/main/kotlin/in/specmatic/core/Flags.kt
+++ b/core/src/main/kotlin/in/specmatic/core/Flags.kt
@@ -1,53 +1,5 @@
 package `in`.specmatic.core
 
-import org.apache.commons.lang3.BooleanUtils
+import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
 
-object Flags {
-    const val VALIDATE_RESPONSE = "VALIDATE_RESPONSE"
-    private const val CUSTOM_RESPONSE_NAME = "CUSTOM_RESPONSE"
-    const val SPECMATIC_GENERATIVE_TESTS = "SPECMATIC_GENERATIVE_TESTS"
-    private const val MAX_TEST_REQUEST_COMBINATIONS = "MAX_TEST_REQUEST_COMBINATIONS"
-    const val SCHEMA_EXAMPLE_DEFAULT = "SCHEMA_EXAMPLE_DEFAULT"
-    const val ONLY_POSITIVE = "ONLY_POSITIVE"
-    const val SPECMATIC_TEST_PARALLELISM = "SPECMATIC_TEST_PARALLELISM"
-
-    const val EXTENSIBLE_SCHEMA = "EXTENSIBLE_SCHEMA"
-
-    private fun flagValue(flagName: String): String? {
-        return System.getenv(flagName) ?: System.getProperty(flagName)
-    }
-
-    fun customResponse(): Boolean {
-        return flagValue(CUSTOM_RESPONSE_NAME) == "true"
-    }
-
-    private fun booleanFlag(flagName: String, default: String = "false") = BooleanUtils.toBoolean(flagValue(flagName) ?: default)
-
-    fun extensibleSchema(): Boolean {
-        return booleanFlag(EXTENSIBLE_SCHEMA)
-    }
-
-    fun schemaExampleDefaultEnabled(): Boolean {
-        return booleanFlag(SCHEMA_EXAMPLE_DEFAULT)
-    }
-
-    fun generativeTestingEnabled(): Boolean {
-        return booleanFlag(SPECMATIC_GENERATIVE_TESTS)
-    }
-
-    fun maxTestRequestCombinations(): Int {
-        return flagValue(MAX_TEST_REQUEST_COMBINATIONS)?.toInt() ?: Int.MAX_VALUE
-    }
-
-    fun onlyPositive(): Boolean {
-        return booleanFlag(ONLY_POSITIVE)
-    }
-
-    fun testParallelism(): String? {
-        return flagValue(SPECMATIC_TEST_PARALLELISM)
-    }
-
-    fun validateResponse(): Boolean {
-        return booleanFlag(VALIDATE_RESPONSE, "false")
-    }
-}
+val Flags = EnvironmentAndPropertiesConfiguration()

--- a/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
@@ -25,7 +25,7 @@ data class ResolverStrategies(
 fun strategiesFromFlags() = ResolverStrategies(
     defaultExampleResolver = if(Flags.schemaExampleDefaultEnabled()) UseDefaultExample else DoNotUseDefaultExample,
     generation = if(Flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests,
-    unexpectedKeyCheck = if(Flags.extendableSchemaEnabled()) IgnoreUnexpectedKeys else null
+    unexpectedKeyCheck = if(Flags.extensibleSchema()) IgnoreUnexpectedKeys else null
 )
 
 val DefaultStrategies = ResolverStrategies (

--- a/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
@@ -1,5 +1,6 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
 import `in`.specmatic.core.pattern.IgnoreUnexpectedKeys
 
 data class ResolverStrategies(
@@ -22,10 +23,10 @@ data class ResolverStrategies(
     }
 }
 
-fun strategiesFromFlags() = ResolverStrategies(
-    defaultExampleResolver = if(Flags.schemaExampleDefaultEnabled()) UseDefaultExample else DoNotUseDefaultExample,
-    generation = if(Flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests,
-    unexpectedKeyCheck = if(Flags.extensibleSchema()) IgnoreUnexpectedKeys else null
+fun strategiesFromFlags(flags: EnvironmentAndPropertiesConfiguration) = ResolverStrategies(
+    defaultExampleResolver = if(flags.schemaExampleDefaultEnabled()) UseDefaultExample else DoNotUseDefaultExample,
+    generation = if(flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests,
+    unexpectedKeyCheck = if(flags.extensibleSchema()) IgnoreUnexpectedKeys else null
 )
 
 val DefaultStrategies = ResolverStrategies (

--- a/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
+++ b/core/src/main/kotlin/in/specmatic/core/ResolverStrategies.kt
@@ -1,23 +1,35 @@
 package `in`.specmatic.core
 
+import `in`.specmatic.core.pattern.IgnoreUnexpectedKeys
+
 data class ResolverStrategies(
     val defaultExampleResolver: DefaultExampleResolver,
     val generation: GenerationStrategies,
+    val unexpectedKeyCheck: UnexpectedKeyCheck?
 ) {
     fun update(resolver: Resolver): Resolver {
         return resolver.copy(
             defaultExampleResolver = defaultExampleResolver,
             generation = generation
-        )
+        ).let {
+            if(unexpectedKeyCheck != null) {
+                val keyCheck = resolver.findKeyErrorCheck
+                val updatedKeyCheck = keyCheck.copy(unexpectedKeyCheck = unexpectedKeyCheck)
+                resolver.copy(findKeyErrorCheck = updatedKeyCheck)
+            } else
+                it
+        }
     }
 }
 
 fun strategiesFromFlags() = ResolverStrategies(
     defaultExampleResolver = if(Flags.schemaExampleDefaultEnabled()) UseDefaultExample else DoNotUseDefaultExample,
-    generation = if(Flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests
+    generation = if(Flags.generativeTestingEnabled()) GenerativeTestsEnabled() else NonGenerativeTests,
+    unexpectedKeyCheck = if(Flags.extendableSchemaEnabled()) IgnoreUnexpectedKeys else null
 )
 
 val DefaultStrategies = ResolverStrategies (
     DoNotUseDefaultExample,
-    NonGenerativeTests
+    NonGenerativeTests,
+    null
 )

--- a/core/src/test/kotlin/in/specmatic/TestUtilities.kt
+++ b/core/src/test/kotlin/in/specmatic/TestUtilities.kt
@@ -134,5 +134,6 @@ infix fun <E> List<E>.shouldContainInAnyOrder(elementList: List<E>) {
 
 val DefaultStrategies = ResolverStrategies (
     DoNotUseDefaultExample,
-    NonGenerativeTests
+    NonGenerativeTests,
+    null
 )

--- a/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/in/specmatic/stub/HttpStubTest.kt
@@ -1349,11 +1349,22 @@ paths:
             val request = HttpRequest("GET", "/data", body = NoBodyValue)
 
             val htmlContent = "<html><body>hi</body></html>"
-            val expectation = ScenarioStub(request, HttpResponse(200, headers = mapOf("Content-Type" to "text/plain"), body = htmlContent))
 
-            val expectationResponse = stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = expectation.toJSON()))
+            val incorrectContentType = "text/plain"
+            val expectationWithIncorrectContentType =
+                ScenarioStub(request, HttpResponse(200, headers = mapOf("Content-Type" to incorrectContentType), body = htmlContent))
 
-            assertThat(expectationResponse.status).isEqualTo(400)
+            stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = expectationWithIncorrectContentType.toJSON())).let { response ->
+                assertThat(response.status).isEqualTo(400)
+            }
+
+            val correctContentType = "text/html"
+            val expectationWithValidContentType =
+                ScenarioStub(request, HttpResponse(200, headers = mapOf("Content-Type" to correctContentType), body = htmlContent))
+
+            stub.client.execute(HttpRequest("POST", "/_specmatic/expectations", body = expectationWithValidContentType.toJSON())).let { response ->
+                assertThat(response.status).isEqualTo(200)
+            }
         }
     }
 

--- a/core/src/test/kotlin/integration_tests/ExtendableSchema.kt
+++ b/core/src/test/kotlin/integration_tests/ExtendableSchema.kt
@@ -1,5 +1,6 @@
 package integration_tests
 
+import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
 import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.Flags
 import `in`.specmatic.core.HttpRequest
@@ -13,9 +14,7 @@ import org.junit.jupiter.api.Test
 class ExtendableSchema {
     @Test
     fun `when extendable schema is enabled, a JSON request object with unexpected keys should be accepted when running tests`() {
-        val feature = try {
-            System.setProperty(Flags.EXTENSIBLE_SCHEMA, "true")
-
+        val feature =
             OpenApiSpecification.fromYAML(
                 """
 openapi: 3.0.0
@@ -52,10 +51,8 @@ paths:
                                   value: success
             """.trimIndent(),
                 "",
+                environmentAndPropertiesConfiguration = EnvironmentAndPropertiesConfiguration(mapOf(), mapOf(Flags.EXTENSIBLE_SCHEMA to "true"))
             ).toFeature()
-        } finally {
-            System.clearProperty(Flags.EXTENSIBLE_SCHEMA)
-        }
 
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
@@ -70,9 +67,7 @@ paths:
 
     @Test
     fun `when extendable schema is enabled, a JSON response object with unexpected keys should be accepted when running tests`() {
-        val feature = try {
-            System.setProperty(Flags.EXTENSIBLE_SCHEMA, "true")
-
+        val feature =
             OpenApiSpecification.fromYAML(
                 """
 openapi: 3.0.0
@@ -113,10 +108,8 @@ paths:
                                       name: John
             """.trimIndent(),
                 "",
+                environmentAndPropertiesConfiguration = EnvironmentAndPropertiesConfiguration(mapOf(), mapOf(Flags.EXTENSIBLE_SCHEMA to "true"))
             ).toFeature()
-        } finally {
-            System.clearProperty(Flags.EXTENSIBLE_SCHEMA)
-        }
 
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {

--- a/core/src/test/kotlin/integration_tests/ExtendableSchema.kt
+++ b/core/src/test/kotlin/integration_tests/ExtendableSchema.kt
@@ -1,0 +1,132 @@
+package integration_tests
+
+import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
+import `in`.specmatic.conversions.OpenApiSpecification
+import `in`.specmatic.core.Flags
+import `in`.specmatic.core.HttpRequest
+import `in`.specmatic.core.HttpResponse
+import `in`.specmatic.core.pattern.parsedJSONObject
+import `in`.specmatic.core.value.JSONObjectValue
+import `in`.specmatic.test.TestExecutor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExtendableSchema {
+    @Test
+    fun `when extendable schema is enabled, a JSON request object with unexpected keys should be accepted when running tests`() {
+        val feature = try {
+            System.setProperty(Flags.EXTENDABLE_SCHEMA, "true")
+
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.0
+info:
+    title: Test
+    version: 1.0.0
+paths:
+    /test:
+        post:
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - name
+                            properties:
+                                name:
+                                    type: string
+                        examples:
+                            SUCCESS:
+                                value:
+                                    name: John
+                                    address: "Baker street"
+            responses:
+                '200':
+                    description: OK
+                    content:
+                      text/plain:
+                          schema:
+                              type: string
+                          examples:
+                              SUCCESS:
+                                  value: success
+            """.trimIndent(),
+                "",
+            ).toFeature()
+        } finally {
+            System.clearProperty(Flags.EXTENDABLE_SCHEMA)
+        }
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                println(request.toLogString())
+                assertThat((request.body as JSONObjectValue).jsonObject).containsKey("address")
+                return HttpResponse.ok("success")
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
+    }
+
+    @Test
+    fun `when extendable schema is enabled, a JSON response object with unexpected keys should be accepted when running tests`() {
+        val feature = try {
+            System.setProperty(Flags.EXTENDABLE_SCHEMA, "true")
+
+            OpenApiSpecification.fromYAML(
+                """
+openapi: 3.0.0
+info:
+    title: Test
+    version: 1.0.0
+paths:
+    /test:
+        post:
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - name
+                            properties:
+                                name:
+                                    type: string
+                        examples:
+                            SUCCESS:
+                                value:
+                                    name: John
+                                    address: "Baker street"
+            responses:
+                '200':
+                    description: OK
+                    content:
+                      application/json:
+                          schema:
+                              type: object
+                              properties:
+                                    name:
+                                        type: string
+                          examples:
+                              SUCCESS:
+                                  value:
+                                      name: John
+            """.trimIndent(),
+                "",
+            ).toFeature()
+        } finally {
+            System.clearProperty(Flags.EXTENDABLE_SCHEMA)
+        }
+
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                println(request.toLogString())
+                assertThat((request.body as JSONObjectValue).jsonObject).containsKey("address")
+                return HttpResponse.ok(parsedJSONObject("""{"name": "John", "address": "Baker street"}"""))
+            }
+        })
+
+        assertThat(results.success()).withFailMessage(results.report()).isTrue()
+    }
+}

--- a/core/src/test/kotlin/integration_tests/ExtendableSchema.kt
+++ b/core/src/test/kotlin/integration_tests/ExtendableSchema.kt
@@ -1,6 +1,5 @@
 package integration_tests
 
-import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
 import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.Flags
 import `in`.specmatic.core.HttpRequest
@@ -15,7 +14,7 @@ class ExtendableSchema {
     @Test
     fun `when extendable schema is enabled, a JSON request object with unexpected keys should be accepted when running tests`() {
         val feature = try {
-            System.setProperty(Flags.EXTENDABLE_SCHEMA, "true")
+            System.setProperty(Flags.EXTENSIBLE_SCHEMA, "true")
 
             OpenApiSpecification.fromYAML(
                 """
@@ -55,7 +54,7 @@ paths:
                 "",
             ).toFeature()
         } finally {
-            System.clearProperty(Flags.EXTENDABLE_SCHEMA)
+            System.clearProperty(Flags.EXTENSIBLE_SCHEMA)
         }
 
         val results = feature.executeTests(object : TestExecutor {
@@ -72,7 +71,7 @@ paths:
     @Test
     fun `when extendable schema is enabled, a JSON response object with unexpected keys should be accepted when running tests`() {
         val feature = try {
-            System.setProperty(Flags.EXTENDABLE_SCHEMA, "true")
+            System.setProperty(Flags.EXTENSIBLE_SCHEMA, "true")
 
             OpenApiSpecification.fromYAML(
                 """
@@ -116,7 +115,7 @@ paths:
                 "",
             ).toFeature()
         } finally {
-            System.clearProperty(Flags.EXTENDABLE_SCHEMA)
+            System.clearProperty(Flags.EXTENSIBLE_SCHEMA)
         }
 
         val results = feature.executeTests(object : TestExecutor {

--- a/core/src/test/kotlin/integration_tests/GenerativeTests.kt
+++ b/core/src/test/kotlin/integration_tests/GenerativeTests.kt
@@ -1,6 +1,7 @@
 package integration_tests
 
 import `in`.specmatic.GENERATION
+import `in`.specmatic.conversions.EnvironmentAndPropertiesConfiguration
 import `in`.specmatic.conversions.OpenApiSpecification
 import `in`.specmatic.core.*
 import `in`.specmatic.core.pattern.ContractException
@@ -1131,87 +1132,82 @@ class GenerativeTests {
 
     @Test
     fun `the flag SPECMATIC_GENERATIVE_TESTS should be used`() {
-        try {
-            System.setProperty(Flags.SPECMATIC_GENERATIVE_TESTS, "true")
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.0
+            info:
+              version: 1.0.0
+              title: Product API
+              description: API for creating a product
+            paths:
+              /products:
+                post:
+                  summary: Create a product
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          ${"$"}ref: '#/components/schemas/Product'
+                  responses:
+                    '200':
+                      description: Product created successfully
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '400':
+                      description: Bad request
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            components:
+              schemas:
+                Product:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                      description: The name of the product
+                      example: 'Soap'
+                """, "",
+            environmentAndPropertiesConfiguration = EnvironmentAndPropertiesConfiguration(mapOf(), mapOf(Flags.SPECMATIC_GENERATIVE_TESTS to "true"))
+        ).toFeature()
 
-            val feature = OpenApiSpecification.fromYAML(
-                """
-                openapi: 3.0.0
-                info:
-                  version: 1.0.0
-                  title: Product API
-                  description: API for creating a product
-                paths:
-                  /products:
-                    post:
-                      summary: Create a product
-                      requestBody:
-                        required: true
-                        content:
-                          application/json:
-                            schema:
-                              ${"$"}ref: '#/components/schemas/Product'
-                      responses:
-                        '200':
-                          description: Product created successfully
-                          content:
-                            text/plain:
-                              schema:
-                                type: string
-                        '400':
-                          description: Bad request
-                          content:
-                            text/plain:
-                              schema:
-                                type: string
-                components:
-                  schemas:
-                    Product:
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        name:
-                          type: string
-                          description: The name of the product
-                          example: 'Soap'
-                    """, ""
-            ).toFeature()
+        val testType = mutableListOf<String>()
 
-            val testType = mutableListOf<String>()
+        val results = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                val body = request.body as JSONObjectValue
 
-            val results = feature.executeTests(object : TestExecutor {
-                override fun execute(request: HttpRequest): HttpResponse {
-                    val body = request.body as JSONObjectValue
-
-                    if (body.jsonObject["name"] !is StringValue) {
-                        testType.add("name mutated to " + body.jsonObject["name"]!!.displayableType())
-                        return HttpResponse.ERROR_400
-                    }
-
-                    testType.add("name not mutated")
-
-                    return HttpResponse.OK
+                if (body.jsonObject["name"] !is StringValue) {
+                    testType.add("name mutated to " + body.jsonObject["name"]!!.displayableType())
+                    return HttpResponse.ERROR_400
                 }
 
-                override fun setServerState(serverState: Map<String, Value>) {
+                testType.add("name not mutated")
 
-                }
-            })
+                return HttpResponse.OK
+            }
 
-            assertThat(testType).containsExactlyInAnyOrder(
-                "name not mutated",
-                "name mutated to null",
-                "name mutated to boolean",
-                "name mutated to number"
-            )
+            override fun setServerState(serverState: Map<String, Value>) {
 
-            assertThat(results.failureCount).isEqualTo(0)
+            }
+        })
 
-            assertThat(results.results).hasSize(testType.size)
-        } finally {
-            System.clearProperty(Flags.SPECMATIC_GENERATIVE_TESTS)
-        }
+        assertThat(testType).containsExactlyInAnyOrder(
+            "name not mutated",
+            "name mutated to null",
+            "name mutated to boolean",
+            "name mutated to number"
+        )
+
+        assertThat(results.failureCount).isEqualTo(0)
+
+        assertThat(results.results).hasSize(testType.size)
     }
 
     @Test
@@ -1265,7 +1261,8 @@ class GenerativeTests {
                         price:
                           type: number
                           description: The price of the product
-                    """, ""
+                    """, "",
+                environmentAndPropertiesConfiguration = EnvironmentAndPropertiesConfiguration.setProperties(mapOf(Flags.SPECMATIC_GENERATIVE_TESTS to "true", Flags.ONLY_POSITIVE to "true"))
             ).toFeature()
 
             val testType = mutableListOf<String>()

--- a/core/src/test/kotlin/integration_tests/ValueAssertionsTest.kt
+++ b/core/src/test/kotlin/integration_tests/ValueAssertionsTest.kt
@@ -62,10 +62,7 @@ paths:
                   value: "Product added successfully"
             """.trimIndent(),
             "",
-            environmentAndPropertiesConfiguration = EnvironmentAndPropertiesConfiguration(
-                emptyMap(),
-                mapOf(Flags.VALIDATE_RESPONSE to "true")
-            )
+            environmentAndPropertiesConfiguration = EnvironmentAndPropertiesConfiguration.setProperty(Flags.VALIDATE_RESPONSE, "true")
         ).toFeature()
         feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -579,6 +579,8 @@ internal class UtilitiesTest {
             if(specmaticJSON.exists())
                 specmaticJSON.delete()
 
+            File(".specmatic/web/localhost/random.yaml").delete()
+
             server.stop(0, 0)
         }
     }


### PR DESCRIPTION
**What**:

Use the EXTENSIBLE_SCHEMA=true flag to ask Specmatic to ignore extra keys in JSON payloads.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate

