### PR TITLE
Allow optional headers, in case of stub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/KeyCheck.kt
+++ b/core/src/main/kotlin/io/specmatic/core/KeyCheck.kt
@@ -3,16 +3,18 @@ package io.specmatic.core
 import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.value.StringValue
 
-data class KeyCheck(val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
-               var unexpectedKeyCheck: UnexpectedKeyCheck = ValidateUnexpectedKeys,
-               val overrideUnexpectedKeyCheck: OverrideUnexpectedKeyCheck? = ::overrideUnexpectedKeyCheck
+data class KeyCheck(
+    val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
+    var unexpectedKeyCheck: UnexpectedKeyCheck = ValidateUnexpectedKeys,
+    val overrideUnexpectedKeyCheck: OverrideUnexpectedKeyCheck? = ::overrideUnexpectedKeyCheck
 ) {
     fun disableOverrideUnexpectedKeycheck(): KeyCheck {
         return KeyCheck(patternKeyCheck, unexpectedKeyCheck, null)
     }
 
     fun withUnexpectedKeyCheck(unexpectedKeyCheck: UnexpectedKeyCheck): KeyCheck {
-        return this.overrideUnexpectedKeyCheck?.invoke(this, unexpectedKeyCheck) ?: this
+        return this.overrideUnexpectedKeyCheck?.invoke(this, unexpectedKeyCheck)
+            ?: this.copy(unexpectedKeyCheck = unexpectedKeyCheck)
     }
 
     fun validate(
@@ -30,7 +32,8 @@ data class KeyCheck(val patternKeyCheck: KeyErrorCheck = CheckOnlyPatternKeys,
     }
 
     fun validateAllCaseInsensitive(pattern: Map<String, Pattern>, actual: Map<String, StringValue>): List<KeyError> {
-        return patternKeyCheck.validateListCaseInsensitive(pattern, actual).plus(unexpectedKeyCheck.validateListCaseInsensitive(pattern, actual))
+        return patternKeyCheck.validateListCaseInsensitive(pattern, actual)
+            .plus(unexpectedKeyCheck.validateListCaseInsensitive(pattern, actual))
     }
 
 }

--- a/core/src/test/kotlin/io/specmatic/core/KeyCheckTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/KeyCheckTest.kt
@@ -172,4 +172,40 @@ internal class KeyCheckTest {
         assertThat(errors[0].name).isEqualTo("key1")
         assertThat(errors[1].name).isEqualTo("key2")
     }
+
+    @Test
+    fun `withUnexpectedKeyCheck should return new instance`() {
+        // Arrange
+        val originalCheck = KeyCheck()
+        val newUnexpectedKeyCheck = IgnoreUnexpectedKeys
+
+        // Act
+        val updatedCheck = originalCheck.withUnexpectedKeyCheck(newUnexpectedKeyCheck)
+
+        // Assert
+        assertThat(updatedCheck).isNotSameAs(originalCheck)
+        assertThat(updatedCheck.unexpectedKeyCheck).isSameAs(newUnexpectedKeyCheck)
+        assertThat(originalCheck.unexpectedKeyCheck).isSameAs(ValidateUnexpectedKeys)
+    }
+
+    @Test
+    fun `withUnexpectedKeyCheck should preserve pattern check in new instance`() {
+        // Arrange
+        val customPatternCheck = object : KeyErrorCheck {
+            override fun validate(pattern: Map<String, Any>, actual: Map<String, Any>): KeyError? = null
+            override fun validateList(pattern: Map<String, Any>, actual: Map<String, Any>): List<KeyError> = emptyList()
+            override fun validateListCaseInsensitive(
+                pattern: Map<String, Pattern>,
+                actual: Map<String, StringValue>
+            ): List<KeyError> = emptyList()
+        }
+
+        val originalCheck = KeyCheck(patternKeyCheck = customPatternCheck)
+
+        // Act
+        val updatedCheck = originalCheck.withUnexpectedKeyCheck(IgnoreUnexpectedKeys)
+
+        // Assert
+        assertThat(updatedCheck.patternKeyCheck).isSameAs(customPatternCheck)
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
1. For the 'stub' command, added the handling to allow optional headers
2. Added tests for the same.

<!-- Why are these changes necessary? -->

**Why**:
1. On the 'Test' side we have now allowed optional headers to be loaded and sent as part of reqest
2. So 'stub' needs to handle the same.

<!-- How were these changes implemented? -->

**How**:
1. KeyCheck already had a method to handle 'unexpected keys' but wasn't handling null case properly.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation. N/A
- [x] Tests
- [ ] Sonar Quality Gate. N/A

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
--

<!-- feel free to add additional comments -->
