### PR TITLE
Improvements to filtering and handling of non-patchable keys in Virtual Service

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/QueryParameters.kt
+++ b/core/src/main/kotlin/io/specmatic/core/QueryParameters.kt
@@ -1,8 +1,7 @@
 package io.specmatic.core
 
-import io.specmatic.core.pattern.Pattern
-import io.specmatic.core.pattern.parsedJSONArray
-import io.specmatic.core.value.Value
+import io.specmatic.core.pattern.*
+import io.specmatic.core.value.*
 
 data class QueryParameters(val paramPairs: List<Pair<String, String>> = emptyList())  {
 
@@ -44,6 +43,16 @@ data class QueryParameters(val paramPairs: List<Pair<String, String>> = emptyLis
                 parameterName to parameterValues.map { it.second }
             } else {
                 parameterName to parameterValues.single().second
+            }
+        }.toMap()
+    }
+
+    fun asValueMap(): Map<String, Value> {
+        return paramPairs.groupBy { it.first }.map { (parameterName, parameterValues) ->
+            if (parameterValues.size > 1) {
+                parameterName to JSONArrayValue(parameterValues.map { parsedScalarValue(it.second) })
+            } else {
+                parameterName to parsedScalarValue(parameterValues.first().second)
             }
         }.toMap()
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -163,6 +163,14 @@ data class AnyPattern(
         return Result.fromFailures(failuresWithUpdatedBreadcrumbs)
     }
 
+    fun getUpdatedPattern(resolver: Resolver): List<Pattern> {
+        return if (discriminator != null) {
+            discriminator.updatePatternsWithDiscriminator(pattern, resolver).listFold().takeIf {
+                it is HasValue<List<Pattern>>
+            }?.value ?: return emptyList()
+        } else pattern
+    }
+
     override fun generate(resolver: Resolver): Value {
         return resolver.resolveExample(example, pattern)
             ?: generateValue(resolver)

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.MismatchMessages
 import io.specmatic.core.utilities.jsonStringToValueArray
 import io.specmatic.core.utilities.jsonStringToValueMap
 import io.specmatic.core.value.*
+import javax.validation.constraints.Null
 
 const val XML_ATTR_OPTIONAL_SUFFIX = ".opt"
 const val DEFAULT_OPTIONAL_SUFFIX = "?"
@@ -360,4 +361,16 @@ fun parsedValue(content: String?): Value {
             StringValue(it)
         }
     } ?: EmptyString
+}
+
+fun parsedScalarValue(content: String?): Value {
+    val trimmed = content?.trim() ?: return NullValue
+    return when {
+        trimmed.toIntOrNull() != null -> NumberValue(trimmed.toInt())
+        trimmed.toLongOrNull() != null -> NumberValue(trimmed.toLong())
+        trimmed.toFloatOrNull() != null -> NumberValue(trimmed.toFloat())
+        trimmed.toDoubleOrNull() != null -> NumberValue(trimmed.toDouble())
+        trimmed.lowercase() in setOf("true", "false") -> BooleanValue(trimmed.toBoolean())
+        else -> StringValue(trimmed)
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
@@ -657,7 +657,9 @@ class StatefulHttpStub(
 
         val results = queryParametersValue.entries.mapNotNull { (key, value) ->
             val patterns = this.getKeyPattern(key, resolver).takeIf { it.isNotEmpty() } ?: return@mapNotNull null
-            patterns.map { it.matches(value.getMatchingValue(it), adjustedResolver) }.let { Results(it).toResultIfAny() }
+            patterns.map {
+                it.matches(value.getMatchingValue(it), adjustedResolver).breadCrumb(key)
+            }.let { Results(it).toResultIfAny() }
         }
 
         return Result.fromResults(results).breadCrumb("QUERY-PARAMS").breadCrumb("REQUEST")

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
@@ -657,7 +657,7 @@ class StatefulHttpStub(
 
         val results = queryParametersValue.entries.mapNotNull { (key, value) ->
             val pattern = this.getKeyPattern(key, resolver) ?: return@mapNotNull null
-            pattern.matches(value.getMatchingValue(pattern), adjustedResolver)
+            pattern.matches(value.getMatchingValue(pattern), adjustedResolver).breadCrumb(key)
         }
 
         return Result.fromResults(results).breadCrumb("QUERY-PARAMS").breadCrumb("REQUEST")

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
@@ -320,11 +320,17 @@ class StatefulHttpStub(
         }
 
         if(method == "GET" && pathSegments.size == 1) {
+            val keysToFilterOut = scenario.httpRequestPattern.httpQueryParamPattern.queryKeyNames.map {
+                withoutOptionality(it)
+            }.plus(scenario.attributeSelectionPattern.queryParamKey)
+
             val responseBody = stubCache.findAllResponsesFor(
                 resourcePath,
                 attributeSelectionKeys,
-                httpRequest.getAttributeFilters(scenario)
+                httpRequest.queryParams.asMap(),
+                ifKeyNotExist = { key -> key in keysToFilterOut }
             )
+
             return generatedResponse.withUpdated(responseBody, attributeSelectionKeys)
         }
 
@@ -638,9 +644,5 @@ class StatefulHttpStub(
         }
 
         return Result.fromResults(results).breadCrumb("REQUEST.BODY")
-    }
-
-    private fun HttpRequest.getAttributeFilters(scenario: Scenario): Map<String, String> {
-        return this.queryParams.asMap().filterKeys { it != scenario.attributeSelectionPattern.queryParamKey }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StatefulHttpStub.kt
@@ -296,7 +296,7 @@ class StatefulHttpStub(
                 val unprocessableEntity = responses.responseWithStatusCodeStartingWith("422")
                 val (errorStatusCode, errorResponseBodyPattern) = if (unprocessableEntity?.successResponse != null) {
                     Pair(422, unprocessableEntity.successResponse.responseBodyPattern)
-                } else Pair(400, responses.responseWithStatusCodeStartingWith("400")?.successResponse?.responseBodyPattern)
+                } else Pair(409, responses.responseWithStatusCodeStartingWith("409")?.successResponse?.responseBodyPattern)
 
                 return generate4xxResponseWithMessage(
                     errorResponseBodyPattern,

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StubCache.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StubCache.kt
@@ -57,12 +57,13 @@ class StubCache {
     fun findAllResponsesFor(
         path: String,
         attributeSelectionKeys: Set<String>,
-        filter: Map<String, String> = emptyMap()
+        filter: Map<String, String> = emptyMap(),
+        ifKeyNotExist: (String) -> Boolean = { true }
     ): JSONArrayValue = lock.withLock {
         val responseBodies = cachedResponses.filter {
             it.path == path
         }.map{ it.responseBody }.filter {
-            it.jsonObject.satisfiesFilter(filter)
+            it.jsonObject.satisfiesFilter(filter, ifKeyNotExist)
         }.map {
             it.removeKeysNotPresentIn(attributeSelectionKeys)
         }
@@ -76,11 +77,11 @@ class StubCache {
         }
     }
 
-    private fun Map<String, Value>.satisfiesFilter(filter: Map<String, String>): Boolean {
+    private fun Map<String, Value>.satisfiesFilter(filter: Map<String, String>, ifKeyNotExist: (String) -> Boolean): Boolean {
         if(filter.isEmpty()) return true
 
         return filter.all { (filterKey, filterValue) ->
-            if(this.containsKey(filterKey).not()) return@all false
+            if(this.containsKey(filterKey).not()) return@all ifKeyNotExist(filterKey)
 
             val actualValue = this.getValue(filterKey)
             actualValue.toStringLiteral() == filterValue

--- a/core/src/main/kotlin/io/specmatic/stub/stateful/StubCache.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/stateful/StubCache.kt
@@ -80,7 +80,7 @@ class StubCache {
         if(filter.isEmpty()) return true
 
         return filter.all { (filterKey, filterValue) ->
-            if(this.containsKey(filterKey).not()) return@all true
+            if(this.containsKey(filterKey).not()) return@all false
 
             val actualValue = this.getValue(filterKey)
             actualValue.toStringLiteral() == filterValue

--- a/core/src/test/kotlin/io/specmatic/stub/stateful/StatefulHttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/stateful/StatefulHttpStubTest.kt
@@ -699,6 +699,7 @@ class StatefulHttpStubAttributeFilteringTest {
 
         assertThat(response.status).isEqualTo(200)
         assertThat(responseBody.list.size).isEqualTo(1)
+        assertThat((responseBody.list.first() as JSONObjectValue).getStringValue("units")).isEqualTo("20")
     }
 
     @Test
@@ -715,6 +716,10 @@ class StatefulHttpStubAttributeFilteringTest {
         println(response.toLogString())
 
         assertThat(response.status).isEqualTo(400)
+        assertThat(responseBody.toStringLiteral())
+            .contains(">> REQUEST.QUERY-PARAMS").contains(">> units")
+            .contains("Expected number <= 10, actual was 99999999 (number)")
+            .contains("Expected number <= 100, actual was 99999999 (number)")
     }
 }
 

--- a/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis.yaml
+++ b/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis.yaml
@@ -120,6 +120,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Product'
+        '422':
+          description: Product update failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnprocessableEntityError'
         '404':
           description: Product not found
 
@@ -215,6 +221,14 @@ components:
           type: string
 
     BadRequestError:
+      type: object
+      properties:
+        error:
+          type: string
+        reason:
+          type: string
+
+    UnprocessableEntityError:
       type: object
       properties:
         error:

--- a/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis.yaml
+++ b/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis.yaml
@@ -151,6 +151,19 @@ paths:
           description: Product deleted successfully
         '404':
           description: Product not found
+  /orders:
+    get:
+      summary: Get all orders
+      description: Retrieve a list of all orders.
+      responses:
+        '200':
+          description: A list of orders
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Order'
 
 components:
   schemas:
@@ -211,6 +224,40 @@ components:
         inStock:
           type: boolean
           example: false
+
+    Order:
+      allOf:
+        - $ref: '#/components/schemas/SmallOrder'
+        - $ref: '#/components/schemas/BigOrder'
+      discriminator:
+        propertyName: type
+        mapping:
+          small: '#/components/schemas/SmallOrder'
+          large: '#/components/schemas/LargeOrder'
+
+    SmallOrder:
+      type: object
+      properties:
+        id:
+          type: integer
+        type:
+          type: string
+        units:
+          type: integer
+          minimum: 1
+          maximum: 10
+
+    LargeOrder:
+      type: object
+      properties:
+        id:
+          type: integer
+        type:
+          type: string
+        units:
+          type: integer
+          minimum: 10
+          maximum: 100
 
     NotFoundError:
       type: object

--- a/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis_examples/get_all_orders.json
+++ b/core/src/test/resources/openapi/spec_with_strictly_restful_apis/spec_with_strictly_restful_apis_examples/get_all_orders.json
@@ -1,0 +1,25 @@
+{
+    "http-request": {
+        "path": "/orders",
+        "method": "GET"
+    },
+    "http-response": {
+        "status": 200,
+        "body": [
+            {
+                "id": 100,
+                "type": "small",
+                "units": 5
+            },
+            {
+                "id": 200,
+                "type": "large",
+                "units": 20
+            }
+        ],
+        "status-text": "OK",
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}


### PR DESCRIPTION
**What**: Improvements to filtering and handling of non-patchable keys in Virtual Service

**How**:
- On any attempts made to patch a non-patchable key with a new value, the server will respond with a 4xx response and will not silently ignore the value being patched.
- The values in attribute filtering are now being validated against their corresponding keys in the response schemas.
- Attribute filtering is now possible on extensible keys, which are not defined in the spec but present in examples when extensible schema is enabled.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the README.md OR link to PR on https://github.com/specmatic/specmatic-documentation
- [x] Tests
- [ ] Sonar Quality Gate


<!-- feel free to add additional comments -->
