### PR TITLE
Filter Excluded Endpoints Config Removal

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -422,8 +422,7 @@ data class APICoverage (
 )
 
 data class APICoverageConfiguration(
-    val successCriteria: SuccessCriteria = SuccessCriteria(),
-    val excludedEndpoints: List<String> = emptyList()
+    val successCriteria: SuccessCriteria = SuccessCriteria()
 )
 
 data class SuccessCriteria(

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigKtTest.kt
@@ -53,8 +53,7 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
         assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
         assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
+
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token
@@ -148,8 +147,6 @@ internal class SpecmaticConfigKtTest {
         assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.minThresholdPercentage).isEqualTo(70)
         assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.maxMissedEndpointsInSpec).isEqualTo(3)
         assertThat(config.report?.types?.apiCoverage?.openAPI?.successCriteria?.enforce).isTrue()
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(0)).isEqualTo("/heartbeat")
-        assertThat(config.report?.types?.apiCoverage?.openAPI?.excludedEndpoints?.get(1)).isEqualTo("/health")
 
         assertThat(
             (config.getOpenAPISecurityConfigurationScheme("oAuth2AuthCode") as OAuth2SecuritySchemeConfiguration).token

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.json
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.json
@@ -51,11 +51,7 @@
             "minThresholdPercentage": 70,
             "maxMissedEndpointsInSpec": 3,
             "enforce": true
-          },
-          "excludedEndpoints": [
-            "/heartbeat",
-            "/health"
-          ]
+          }
         }
       }
     }

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yaml
@@ -38,9 +38,6 @@ report:
           minThresholdPercentage: 70
           maxMissedEndpointsInSpec: 3
           enforce: true
-        excludedEndpoints:
-          - /heartbeat
-          - /health
 
 security:
   OpenAPI:

--- a/core/src/test/resources/specmaticConfigFiles/specmatic.yml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic.yml
@@ -38,9 +38,6 @@ report:
           minThresholdPercentage: 70
           maxMissedEndpointsInSpec: 3
           enforce: true
-        excludedEndpoints:
-          - /heartbeat
-          - /health
 
 security:
   OpenAPI:

--- a/core/src/test/resources/specmaticConfigFiles/specmatic_alias.json
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic_alias.json
@@ -45,11 +45,7 @@
             "minThresholdPercentage": 70,
             "maxMissedEndpointsInSpec": 3,
             "enforce": true
-          },
-          "excludedEndpoints": [
-            "/heartbeat",
-            "/health"
-          ]
+          }
         }
       }
     }

--- a/core/src/test/resources/specmaticConfigFiles/specmatic_alias.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic_alias.yaml
@@ -34,9 +34,6 @@ report:
           minThresholdPercentage: 70
           maxMissedEndpointsInSpec: 3
           enforce: true
-        excludedEndpoints:
-          - /heartbeat
-          - /health
 
 security:
   OpenAPI:

--- a/core/src/test/resources/specmaticConfigFiles/specmatic_alias.yml
+++ b/core/src/test/resources/specmaticConfigFiles/specmatic_alias.yml
@@ -34,9 +34,6 @@ report:
           minThresholdPercentage: 70
           maxMissedEndpointsInSpec: 3
           enforce: true
-        excludedEndpoints:
-          - /heartbeat
-          - /health
 
 security:
   OpenAPI:

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -24,11 +24,10 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
     override fun process(specmaticConfig: SpecmaticConfig) {
         val reportConfiguration = specmaticConfig.report!!
 
-        openApiCoverageReportInput.addExcludedAPIs(reportConfiguration.types.apiCoverage.openAPI.excludedEndpoints + excludedEndpointsFromEnv())
         val openAPICoverageReport = openApiCoverageReportInput.generate()
 
         if (openAPICoverageReport.coverageRows.isEmpty()) {
-            logger.log("The Open API coverage report generated is blank.\nThis can happen if you have included all the endpoints in the 'excludedEndpoints' array in the report section in specmatic.json, or if your open api specification does not have any paths documented.")
+            logger.log("The Open API coverage report generated is blank.\nThis can happen if your open api specification does not have any paths documented.")
         } else {
             val renderers = configureReportRenderers(reportConfiguration)
             renderers.forEach { renderer ->
@@ -48,10 +47,6 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
             }
         }
     }
-
-    private fun excludedEndpointsFromEnv() = System.getenv("SPECMATIC_EXCLUDED_ENDPOINTS")?.let { excludedEndpoints ->
-        excludedEndpoints.split(",").map { it.trim() }
-    } ?: emptyList()
 
     private fun saveAsJson(openApiCoverageJsonReport: OpenApiCoverageJsonReport) {
         println("Saving Open API Coverage Report json to $JSON_REPORT_PATH ...")


### PR DESCRIPTION
**What**: Removed Config for Filter Exclusion - `excludedEndpoints`

**Why**: As we currently have filter in place to exclude endpoints validating with filter PATH
