### PR TITLE
Make hooks field of Specmatic Config nullable 

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -195,7 +195,7 @@ data class SpecmaticConfig(
     private val auth: Auth? = null,
     private val pipeline: Pipeline? = null,
     private val environments: Map<String, Environment>? = null,
-    private val hooks: Map<String, String> = emptyMap(),
+    private val hooks: Map<String, String>? = null,
     private val repository: RepositoryInfo? = null,
     private val report: ReportConfigurationDetails? = null,
     private val security: SecurityConfiguration? = null,
@@ -273,6 +273,10 @@ data class SpecmaticConfig(
 
         fun getEnvironments(specmaticConfig: SpecmaticConfig): Map<String, Environment>? {
             return specmaticConfig.environments
+        }
+
+        fun getHooks(specmaticConfig: SpecmaticConfig): Map<String, String>? {
+            return specmaticConfig.hooks
         }
     }
 
@@ -452,7 +456,7 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun getHooks(): Map<String, String> {
-        return hooks
+        return hooks ?: emptyMap()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
@@ -9,13 +9,13 @@ import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 
-data class SpecmaticConfigV1 (
+data class SpecmaticConfigV1(
 	@field:JsonAlias("contract_repositories")
 	val sources: List<Source> = emptyList(),
 	val auth: Auth? = null,
 	val pipeline: Pipeline? = null,
 	val environments: Map<String, Environment>? = null,
-	val hooks: Map<String, String> = emptyMap(),
+	val hooks: Map<String, String>? = null,
 	val repository: RepositoryInfo? = null,
 	val report: ReportConfigurationDetails? = null,
 	val security: SecurityConfiguration? = null,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -2,15 +2,15 @@ package io.specmatic.core.config.v2
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import io.specmatic.core.*
-import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getAllPatternsMandatory
+import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getPipeline
 import io.specmatic.core.SpecmaticConfig.Companion.getRepository
 import io.specmatic.core.SpecmaticConfig.Companion.getSecurityConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
 import io.specmatic.core.SpecmaticConfig.Companion.getStubConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticVersionedConfig
 import io.specmatic.core.config.SpecmaticVersionedConfigLoader
@@ -24,7 +24,7 @@ data class SpecmaticConfigV2(
     val auth: Auth? = null,
     val pipeline: Pipeline? = null,
     val environments: Map<String, Environment>? = null,
-    val hooks: Map<String, String> = emptyMap(),
+    val hooks: Map<String, String>? = null,
     val repository: RepositoryInfo? = null,
     val report: ReportConfigurationDetails? = null,
     val security: SecurityConfiguration? = null,
@@ -78,7 +78,7 @@ data class SpecmaticConfigV2(
                 auth = config.getAuth(),
                 pipeline = getPipeline(config),
                 environments = SpecmaticConfig.getEnvironments(config),
-                hooks = config.getHooks(),
+                hooks = SpecmaticConfig.getHooks(config),
                 repository = getRepository(config),
                 report = SpecmaticConfig.getReport(config)?.validatePresenceOfExcludedEndpoints(currentConfigVersion()),
                 security = getSecurityConfiguration(config),


### PR DESCRIPTION
- Made the hooks field nullable
- Moved defaults for hooks field and it's children to wrapper methods