### PR TITLE
Make auth field of Specmatic Config nullable 

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -461,7 +461,7 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun getAuthBearerFile(): String? {
-        return auth?.bearerFile
+        return auth?.let { it.bearerFile ?: "bearer.txt" }
     }
 
     @JsonIgnore
@@ -588,7 +588,7 @@ data class ResiliencyTestsConfig(
 }
 
 data class Auth(
-    @param:JsonProperty("bearer-file") val bearerFile: String = "bearer.txt",
+    @param:JsonProperty("bearer-file") val bearerFile: String? = null,
     @param:JsonProperty("bearer-environment-variable") val bearerEnvironmentVariable: String? = null
 )
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -461,7 +461,7 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun getAuthBearerFile(): String? {
-        return auth?.let { it.bearerFile ?: "bearer.txt" }
+        return auth?.bearerFile
     }
 
     @JsonIgnore


### PR DESCRIPTION
- Made the `bearerFile` field of `auth` nullable
- Moved default value for `bearerFile` field to the wrapper methods