### PR TITLE
Remove "---" and unnecessary quotes from the generated YAML

### DIFF
--- a/application/src/main/kotlin/application/ConfigCommand.kt
+++ b/application/src/main/kotlin/application/ConfigCommand.kt
@@ -3,6 +3,7 @@ package application
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToLatestVersionedConfig
@@ -85,7 +86,10 @@ class ConfigCommand : Callable<Int> {
         }
 
         private fun getObjectMapper(): ObjectMapper {
-            val objectMapper = ObjectMapper(YAMLFactory()).apply {
+            val objectMapper = ObjectMapper(YAMLFactory().apply {
+                disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+                enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
+            }).apply {
                 registerKotlinModule()
                 setDefaultPropertyInclusion(
                     JsonInclude.Value.construct(

--- a/application/src/test/kotlin/application/ConfigCommandTest.kt
+++ b/application/src/test/kotlin/application/ConfigCommandTest.kt
@@ -1,0 +1,54 @@
+package application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.mockkConstructor
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ConfigCommandTest {
+    @Test
+    fun `should write SpecmaticConfig without doc start marker and quotes`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml")
+        configFile.writeText(
+            """
+            sources:
+              - provider: git
+                repository: https://github.com/znsio/specmatic-order-contracts.git
+                test:
+                  - io/specmatic/examples/store/openapi/api_order_v3.yaml
+              - test:
+                  - order.yaml
+        """.trimIndent()
+        )
+
+        mockkConstructor(ObjectMapper::class)
+        var capturedYamlString = ""
+        every { anyConstructed<ObjectMapper>().writeValueAsString(any()) } answers {
+            val yamlString = callOriginal() as String
+            capturedYamlString = yamlString
+            yamlString
+        }
+
+        val configUpgradeCommand = ConfigCommand.Upgrade()
+        configUpgradeCommand.inputFile = configFile
+
+        configUpgradeCommand.call()
+
+        val expectedOutput = """
+            version: 2
+            contracts:
+            - git:
+                url: https://github.com/znsio/specmatic-order-contracts.git
+              provides:
+              - io/specmatic/examples/store/openapi/api_order_v3.yaml
+            - provides:
+              - order.yaml
+            
+        """.trimIndent()
+
+        assertEquals(expectedOutput, capturedYamlString)
+    }
+}


### PR DESCRIPTION
Updated config command to generate YAML without:
- YAML Document start marker "---"
- Unnecessary quotes on String values