### PR TITLE
Make security field of Specmatic Config nullable 

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -226,9 +226,8 @@ data class SpecmaticConfig(
             return specmaticConfig.pipeline
         }
 
-        @JsonIgnore
-        fun getSecurityConfiguration(specmaticConfig: SpecmaticConfig?): SecurityConfigurationDetails? {
-            return specmaticConfig?.security
+        fun getSecurityConfiguration(specmaticConfig: SpecmaticConfig): SecurityConfigurationDetails? {
+            return specmaticConfig.security
         }
 
         @JsonIgnore
@@ -547,6 +546,10 @@ data class SpecmaticConfig(
         } catch(e: Throwable) {
             throw ContractException("Error loading Specmatic configuration: ${e.message}")
         }
+    }
+
+    fun getSecurityConfiguration(): SecurityConfiguration? {
+        return security
     }
 }
 
@@ -884,6 +887,7 @@ data class SecurityConfigurationDetails(
     @param:JsonProperty("OpenAPI")
     val OpenAPI: OpenAPISecurityConfiguration? = null
 ) : SecurityConfiguration {
+    @JsonIgnore
     override fun getOpenAPISecurityScheme(scheme: String): SecuritySchemeConfiguration? {
         return OpenAPI?.securitySchemes?.get(scheme)
     }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -548,6 +548,7 @@ data class SpecmaticConfig(
         }
     }
 
+    @JsonIgnore
     fun getSecurityConfiguration(): SecurityConfiguration? {
         return security
     }

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -193,7 +193,7 @@ data class SpecmaticConfig(
     private val hooks: Map<String, String> = emptyMap(),
     private val repository: RepositoryInfo? = null,
     private val report: ReportConfigurationDetails? = null,
-    private val security: SecurityConfiguration? = null,
+    private val security: SecurityConfigurationDetails? = null,
     private val test: TestConfiguration? = TestConfiguration(),
     private val stub: StubConfiguration = StubConfiguration(),
     private val virtualService: VirtualServiceConfiguration = VirtualServiceConfiguration(),
@@ -227,7 +227,7 @@ data class SpecmaticConfig(
         }
 
         @JsonIgnore
-        fun getSecurityConfiguration(specmaticConfig: SpecmaticConfig?): SecurityConfiguration? {
+        fun getSecurityConfiguration(specmaticConfig: SpecmaticConfig?): SecurityConfigurationDetails? {
             return specmaticConfig?.security
         }
 
@@ -876,17 +876,21 @@ data class SuccessCriteria(
     }
 }
 
-data class SecurityConfiguration(
+fun interface SecurityConfiguration {
+    fun getOpenAPISecurityScheme(scheme: String): SecuritySchemeConfiguration?
+}
+
+data class SecurityConfigurationDetails(
     @param:JsonProperty("OpenAPI")
-    private val OpenAPI: OpenAPISecurityConfiguration?
-) {
-    fun getOpenAPISecurityScheme(scheme: String): SecuritySchemeConfiguration? {
+    val OpenAPI: OpenAPISecurityConfiguration? = null
+) : SecurityConfiguration {
+    override fun getOpenAPISecurityScheme(scheme: String): SecuritySchemeConfiguration? {
         return OpenAPI?.securitySchemes?.get(scheme)
     }
 }
 
 data class OpenAPISecurityConfiguration(
-    val securitySchemes: Map<String, SecuritySchemeConfiguration> = emptyMap()
+    val securitySchemes: Map<String, SecuritySchemeConfiguration>? = null
 )
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")

--- a/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
@@ -18,7 +18,7 @@ data class SpecmaticConfigV1 (
 	val hooks: Map<String, String> = emptyMap(),
 	val repository: RepositoryInfo? = null,
 	val report: ReportConfigurationDetails? = null,
-	val security: SecurityConfiguration? = null,
+	val security: SecurityConfigurationDetails? = null,
 	val test: TestConfiguration? = TestConfiguration(),
 	val stub: StubConfiguration = StubConfiguration(),
 	@field:JsonAlias("virtual_service")

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -6,7 +6,6 @@ import io.specmatic.core.SpecmaticConfig.Companion.getAllPatternsMandatory
 import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getPipeline
 import io.specmatic.core.SpecmaticConfig.Companion.getRepository
-import io.specmatic.core.SpecmaticConfig.Companion.getSecurityConfiguration
 import io.specmatic.core.SpecmaticConfig.Companion.getStubConfiguration
 import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
 import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
@@ -81,7 +80,7 @@ data class SpecmaticConfigV2(
                 hooks = config.getHooks(),
                 repository = getRepository(config),
                 report = SpecmaticConfig.getReport(config)?.validatePresenceOfExcludedEndpoints(currentConfigVersion()),
-                security = getSecurityConfiguration(config),
+                security = SpecmaticConfig.getSecurityConfiguration(config),
                 test = getTestConfiguration(config),
                 stub = getStubConfiguration(config),
                 virtualService = getVirtualServiceConfiguration(config),

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -2,15 +2,15 @@ package io.specmatic.core.config.v2
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import io.specmatic.core.*
-import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getAllPatternsMandatory
+import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getPipeline
 import io.specmatic.core.SpecmaticConfig.Companion.getRepository
 import io.specmatic.core.SpecmaticConfig.Companion.getSecurityConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
 import io.specmatic.core.SpecmaticConfig.Companion.getStubConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticVersionedConfig
 import io.specmatic.core.config.SpecmaticVersionedConfigLoader
@@ -27,7 +27,7 @@ data class SpecmaticConfigV2(
     val hooks: Map<String, String> = emptyMap(),
     val repository: RepositoryInfo? = null,
     val report: ReportConfigurationDetails? = null,
-    val security: SecurityConfiguration? = null,
+    val security: SecurityConfigurationDetails? = null,
     val test: TestConfiguration? = TestConfiguration(),
     val stub: StubConfiguration = StubConfiguration(),
     @field:JsonAlias("virtual_service") val virtualService: VirtualServiceConfiguration = VirtualServiceConfiguration(),

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiIntegrationTest.kt
@@ -132,7 +132,7 @@ Examples:
                 }
             }
 
-            private fun newSecurityConfiguration(token: String) = SecurityConfiguration(
+            private fun newSecurityConfiguration(token: String) = SecurityConfigurationDetails(
                 OpenAPI = OpenAPISecurityConfiguration(
                     securitySchemes = mapOf(
                         "oAuth2AuthCode" to OAuth2SecuritySchemeConfiguration(
@@ -582,7 +582,7 @@ Background:
             assertThat(result.reportString()).contains("Authorization header must be prefixed with \"Bearer\"")
         }
 
-        private fun securityConfigurationForBearerScheme(token: String) = SecurityConfiguration(
+        private fun securityConfigurationForBearerScheme(token: String) = SecurityConfigurationDetails(
             OpenAPI = OpenAPISecurityConfiguration(
                 securitySchemes = mapOf(
                     "BearerAuth" to BearerSecuritySchemeConfiguration(
@@ -961,7 +961,7 @@ Feature: Authenticated
             }
         }
 
-        private fun securityConfigurationForApiKeyInHeaderScheme(token: String) = SecurityConfiguration(
+        private fun securityConfigurationForApiKeyInHeaderScheme(token: String) = SecurityConfigurationDetails(
             OpenAPI = OpenAPISecurityConfiguration(
                 securitySchemes = mapOf(
                     "ApiKeyAuthHeader" to APIKeySecuritySchemeConfiguration(
@@ -971,7 +971,7 @@ Feature: Authenticated
             )
         )
 
-        private fun securityConfigurationForApiKeyInQueryScheme(token: String) = SecurityConfiguration(
+        private fun securityConfigurationForApiKeyInQueryScheme(token: String) = SecurityConfigurationDetails(
             OpenAPI = OpenAPISecurityConfiguration(
                 securitySchemes = mapOf(
                     "ApiKeyAuthQuery" to APIKeySecuritySchemeConfiguration(

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -3,7 +3,6 @@ package io.specmatic.test
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
-import io.specmatic.core.SpecmaticConfig.Companion.getSecurityConfiguration
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsing
 import io.specmatic.core.log.ignoreLog
@@ -284,7 +283,7 @@ open class SpecmaticJUnitSupport {
                             it.repository,
                             it.branch,
                             it.specificationPath,
-                            getSecurityConfiguration(specmaticConfig),
+                            specmaticConfig?.getSecurityConfiguration(),
                             filterName,
                             filterNotName,
                             specmaticConfig = specmaticConfig,


### PR DESCRIPTION
- Introduced interface for abstraction of `SecurityConfiguration`
- Made fields of `SecurityConfigurationDetails` public