### PR TITLE
Make virtualService field of Specmatic Config nullable 

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -117,12 +117,8 @@ data class StubConfiguration(
 }
 
 data class VirtualServiceConfiguration(
-    private val nonPatchableKeys: Set<String> = emptySet()
-) {
-    fun getNonPatchableKeys(): Set<String> {
-        return nonPatchableKeys
-    }
-}
+    val nonPatchableKeys: Set<String>? = null
+)
 
 data class WorkflowIDOperation(
     val extract: String? = null,
@@ -196,7 +192,7 @@ data class SpecmaticConfig(
     private val security: SecurityConfiguration? = null,
     private val test: TestConfiguration? = TestConfiguration(),
     private val stub: StubConfiguration = StubConfiguration(),
-    private val virtualService: VirtualServiceConfiguration = VirtualServiceConfiguration(),
+    private val virtualService: VirtualServiceConfiguration? = null,
     private val examples: List<String>? = null,
     private val workflow: WorkflowConfiguration? = null,
     private val ignoreInlineExamples: Boolean? = null,
@@ -242,7 +238,7 @@ data class SpecmaticConfig(
         }
 
         @JsonIgnore
-        fun getVirtualServiceConfiguration(specmaticConfig: SpecmaticConfig): VirtualServiceConfiguration {
+        fun getVirtualServiceConfiguration(specmaticConfig: SpecmaticConfig): VirtualServiceConfiguration? {
             return specmaticConfig.virtualService
         }
 
@@ -511,7 +507,7 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun getVirtualServiceNonPatchableKeys(): Set<String> {
-        return virtualService.getNonPatchableKeys()
+        return virtualService?.nonPatchableKeys ?: emptySet()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
@@ -9,7 +9,7 @@ import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 
-data class SpecmaticConfigV1 (
+data class SpecmaticConfigV1(
 	@field:JsonAlias("contract_repositories")
 	val sources: List<Source> = emptyList(),
 	val auth: Auth? = null,
@@ -22,7 +22,7 @@ data class SpecmaticConfigV1 (
 	val test: TestConfiguration? = TestConfiguration(),
 	val stub: StubConfiguration = StubConfiguration(),
 	@field:JsonAlias("virtual_service")
-	val virtualService: VirtualServiceConfiguration = VirtualServiceConfiguration(),
+	val virtualService: VirtualServiceConfiguration? = null,
 	val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
 	val workflow: WorkflowConfiguration? = null,
 	val ignoreInlineExamples: Boolean? = null,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -2,15 +2,15 @@ package io.specmatic.core.config.v2
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import io.specmatic.core.*
-import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getAllPatternsMandatory
+import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getPipeline
 import io.specmatic.core.SpecmaticConfig.Companion.getRepository
 import io.specmatic.core.SpecmaticConfig.Companion.getSecurityConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
 import io.specmatic.core.SpecmaticConfig.Companion.getStubConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticVersionedConfig
 import io.specmatic.core.config.SpecmaticVersionedConfigLoader
@@ -30,7 +30,7 @@ data class SpecmaticConfigV2(
     val security: SecurityConfiguration? = null,
     val test: TestConfiguration? = TestConfiguration(),
     val stub: StubConfiguration = StubConfiguration(),
-    @field:JsonAlias("virtual_service") val virtualService: VirtualServiceConfiguration = VirtualServiceConfiguration(),
+    @field:JsonAlias("virtual_service") val virtualService: VirtualServiceConfiguration? = null,
     val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
     val workflow: WorkflowConfiguration? = null,
     val ignoreInlineExamples: Boolean? = null,

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -10,8 +10,8 @@ import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.Source
 import io.specmatic.core.SourceProvider.filesystem
 import io.specmatic.core.SourceProvider.git
-import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToLatestVersionedConfig
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToLatestVersionedConfig
 import io.specmatic.core.config.v1.SpecmaticConfigV1
 import io.specmatic.core.config.v2.ContractConfig
 import io.specmatic.core.config.v2.ContractConfig.FileSystemContractSource
@@ -456,7 +456,7 @@ internal class SpecmaticConfigAllTest {
         val config = objectMapper.readValue(configYaml, SpecmaticConfigV1::class.java).transform()
         val configV2 = SpecmaticConfigV2.loadFrom(config) as SpecmaticConfigV2
 
-        assertThat(configV2.virtualService.getNonPatchableKeys()).containsExactly("description", "url")
+        assertThat(configV2.virtualService?.nonPatchableKeys).containsExactly("description", "url")
     }
 
     @Test
@@ -472,7 +472,7 @@ internal class SpecmaticConfigAllTest {
         val config = objectMapper.readValue(configYaml, SpecmaticConfigV2::class.java).transform()
         val configV3 = SpecmaticConfigV2.loadFrom(config) as SpecmaticConfigV2
 
-        assertThat(configV3.virtualService.getNonPatchableKeys()).containsExactly("description", "url")
+        assertThat(configV3.virtualService?.nonPatchableKeys).containsExactly("description", "url")
     }
 
     @Test


### PR DESCRIPTION
- Made the `virtualService` field nullable
- Moved defaults for `virtualService` field and it's children to wrapper methods