### PR TITLE
Make attributeSelectionPattern field of Specmatic Config nullable 

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -338,7 +338,7 @@ data class Scenario(
     }
 
     private fun isRequestAttributeSelected(httpRequest: HttpRequest): Boolean {
-        return httpRequest.queryParams.containsKey(attributeSelectionPattern.getQueryParamKey())
+        return httpRequest.queryParams.containsKey(attributeSelectionPattern.getQueryParamKeyOrDefault())
     }
 
     fun matches(httpResponse: HttpResponse, mismatchMessages: MismatchMessages = DefaultMismatchMessages, unexpectedKeyCheck: UnexpectedKeyCheck? = null): Result {
@@ -827,8 +827,8 @@ data class Scenario(
     }
 
     fun getFieldsToBeMadeMandatoryBasedOnAttributeSelection(queryParams: QueryParameters?): Set<String> {
-        val defaultAttributeSelectionFields = attributeSelectionPattern.getDefaultFields().toSet()
-        val attributeSelectionQueryParamKey = attributeSelectionPattern.getQueryParamKey()
+        val defaultAttributeSelectionFields = attributeSelectionPattern.getDefaultFieldsOrDefault().toSet()
+        val attributeSelectionQueryParamKey = attributeSelectionPattern.getQueryParamKeyOrDefault()
 
         if(queryParams?.containsKey(attributeSelectionQueryParamKey) != true) return emptySet()
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -156,8 +156,8 @@ data class WorkflowConfiguration(
 }
 
 interface AttributeSelectionPatternDetails {
-    fun getDefaultFields(): List<String>
-    fun getQueryParamKey(): String
+    fun getDefaultFieldsOrDefault(): List<String>
+    fun getQueryParamKeyOrDefault(): String
 
     companion object {
         val default: AttributeSelectionPatternDetails = AttributeSelectionPattern()
@@ -170,14 +170,16 @@ data class AttributeSelectionPattern(
     @field:JsonAlias("query_param_key")
     val queryParamKey: String? = null
 ) : AttributeSelectionPatternDetails {
-    override fun getDefaultFields(): List<String> {
+    @JsonIgnore
+    override fun getDefaultFieldsOrDefault(): List<String> {
         return defaultFields ?: readEnvVarOrProperty(
             ATTRIBUTE_SELECTION_DEFAULT_FIELDS,
             ATTRIBUTE_SELECTION_DEFAULT_FIELDS
         ).orEmpty().split(",").filter { it.isNotBlank() }
     }
 
-    override fun getQueryParamKey(): String {
+    @JsonIgnore
+    override fun getQueryParamKeyOrDefault(): String {
         return queryParamKey ?: readEnvVarOrProperty(
             ATTRIBUTE_SELECTION_QUERY_PARAM_KEY,
             ATTRIBUTE_SELECTION_QUERY_PARAM_KEY
@@ -356,8 +358,8 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun attributeSelectionQueryParamKey(): String {
-        return attributeSelectionPattern?.getQueryParamKey()
-            ?: AttributeSelectionPatternDetails.default.getQueryParamKey()
+        return attributeSelectionPattern?.getQueryParamKeyOrDefault()
+            ?: AttributeSelectionPatternDetails.default.getQueryParamKeyOrDefault()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -166,9 +166,9 @@ interface AttributeSelectionPatternDetails {
 
 data class AttributeSelectionPattern(
     @field:JsonAlias("default_fields")
-    private val defaultFields: List<String>? = null,
+    val defaultFields: List<String>? = null,
     @field:JsonAlias("query_param_key")
-    private val queryParamKey: String? = null
+    val queryParamKey: String? = null
 ) : AttributeSelectionPatternDetails {
     override fun getDefaultFields(): List<String> {
         return defaultFields ?: readEnvVarOrProperty(
@@ -201,7 +201,7 @@ data class SpecmaticConfig(
     private val workflow: WorkflowConfiguration? = null,
     private val ignoreInlineExamples: Boolean? = null,
     private val additionalExampleParamsFilePath: String? = null,
-    private val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
+    private val attributeSelectionPattern: AttributeSelectionPattern? = null,
     private val allPatternsMandatory: Boolean? = null,
     private val defaultPatternValues: Map<String, Any> = emptyMap(),
     private val version: SpecmaticConfigVersion? = null
@@ -257,7 +257,7 @@ data class SpecmaticConfig(
         }
 
         @JsonIgnore
-        fun getAttributeSelectionPattern(specmaticConfig: SpecmaticConfig): AttributeSelectionPattern {
+        fun getAttributeSelectionPattern(specmaticConfig: SpecmaticConfig): AttributeSelectionPattern? {
             return specmaticConfig.attributeSelectionPattern
         }
 
@@ -295,7 +295,7 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun getAttributeSelectionPattern(): AttributeSelectionPatternDetails {
-        return attributeSelectionPattern
+        return attributeSelectionPattern ?: AttributeSelectionPatternDetails.default
     }
 
     @JsonIgnore
@@ -356,7 +356,8 @@ data class SpecmaticConfig(
 
     @JsonIgnore
     fun attributeSelectionQueryParamKey(): String {
-        return attributeSelectionPattern.getQueryParamKey()
+        return attributeSelectionPattern?.getQueryParamKey()
+            ?: AttributeSelectionPatternDetails.default.getQueryParamKey()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
@@ -9,7 +9,7 @@ import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 
-data class SpecmaticConfigV1 (
+data class SpecmaticConfigV1(
 	@field:JsonAlias("contract_repositories")
 	val sources: List<Source> = emptyList(),
 	val auth: Auth? = null,
@@ -28,7 +28,7 @@ data class SpecmaticConfigV1 (
 	val ignoreInlineExamples: Boolean? = null,
 	val additionalExampleParamsFilePath: String? = getStringValue(Flags.ADDITIONAL_EXAMPLE_PARAMS_FILE),
 	@field:JsonAlias("attribute_selection_pattern")
-	val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
+	val attributeSelectionPattern: AttributeSelectionPattern? = null,
 	@field:JsonAlias("all_patterns_mandatory")
 	val allPatternsMandatory: Boolean? = null,
 	@field:JsonAlias("default_pattern_values")

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -2,15 +2,15 @@ package io.specmatic.core.config.v2
 
 import com.fasterxml.jackson.annotation.JsonAlias
 import io.specmatic.core.*
-import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getAllPatternsMandatory
+import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
 import io.specmatic.core.SpecmaticConfig.Companion.getPipeline
 import io.specmatic.core.SpecmaticConfig.Companion.getRepository
 import io.specmatic.core.SpecmaticConfig.Companion.getSecurityConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
-import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
 import io.specmatic.core.SpecmaticConfig.Companion.getStubConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getTestConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getVirtualServiceConfiguration
+import io.specmatic.core.SpecmaticConfig.Companion.getWorkflowConfiguration
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.SpecmaticVersionedConfig
 import io.specmatic.core.config.SpecmaticVersionedConfigLoader
@@ -36,7 +36,7 @@ data class SpecmaticConfigV2(
     val ignoreInlineExamples: Boolean? = null,
     val additionalExampleParamsFilePath: String? = getStringValue(Flags.ADDITIONAL_EXAMPLE_PARAMS_FILE),
     @field:JsonAlias("attribute_selection_pattern")
-    val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
+    val attributeSelectionPattern: AttributeSelectionPattern? = null,
     @field:JsonAlias("all_patterns_mandatory")
     val allPatternsMandatory: Boolean? = null,
     @field:JsonAlias("default_pattern_values")

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ExamplesInteractiveServer.kt
@@ -622,7 +622,7 @@ class ExamplesInteractiveServer(
 
         private fun HttpRequest.removeAttrSelection(attributeSelectionPattern: AttributeSelectionPatternDetails): HttpRequest {
             return this.copy(
-                queryParams = this.queryParams.remove(attributeSelectionPattern.getQueryParamKey())
+                queryParams = this.queryParams.remove(attributeSelectionPattern.getQueryParamKeyOrDefault())
             )
         }
 

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -489,11 +489,11 @@ internal class SpecmaticConfigAllTest {
 
         val specmaticConfig = configFile.toSpecmaticConfig()
 
-        assertThat(specmaticConfig.getAttributeSelectionPattern().getDefaultFields()).containsExactly(
+        assertThat(specmaticConfig.getAttributeSelectionPattern().getDefaultFieldsOrDefault()).containsExactly(
             "description",
             "url"
         )
-        assertThat(specmaticConfig.getAttributeSelectionPattern().getQueryParamKey()).isEqualTo("web")
+        assertThat(specmaticConfig.getAttributeSelectionPattern().getQueryParamKeyOrDefault()).isEqualTo("web")
     }
 
     @Test
@@ -509,8 +509,9 @@ internal class SpecmaticConfigAllTest {
         val config = objectMapper.readValue(configYaml, SpecmaticConfigV1::class.java).transform()
         val configV2 = SpecmaticConfigV2.loadFrom(config) as SpecmaticConfigV2
 
-        assertThat(configV2.attributeSelectionPattern?.getDefaultFields()).containsExactly("description", "url")
-        assertThat(configV2.attributeSelectionPattern?.getQueryParamKey()).isEqualTo("web")
+        assertThat(configV2.attributeSelectionPattern?.getDefaultFieldsOrDefault())
+            .containsExactly("description", "url")
+        assertThat(configV2.attributeSelectionPattern?.getQueryParamKeyOrDefault()).isEqualTo("web")
     }
 
     @Test
@@ -527,8 +528,9 @@ internal class SpecmaticConfigAllTest {
         val config = objectMapper.readValue(configYaml, SpecmaticConfigV2::class.java).transform()
         val configV3 = SpecmaticConfigV2.loadFrom(config) as SpecmaticConfigV2
 
-        assertThat(configV3.attributeSelectionPattern?.getDefaultFields()).containsExactly("description", "url")
-        assertThat(configV3.attributeSelectionPattern?.getQueryParamKey()).isEqualTo("web")
+        assertThat(configV3.attributeSelectionPattern?.getDefaultFieldsOrDefault())
+            .containsExactly("description", "url")
+        assertThat(configV3.attributeSelectionPattern?.getQueryParamKeyOrDefault()).isEqualTo("web")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -10,8 +10,8 @@ import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.Source
 import io.specmatic.core.SourceProvider.filesystem
 import io.specmatic.core.SourceProvider.git
-import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToLatestVersionedConfig
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToLatestVersionedConfig
 import io.specmatic.core.config.v1.SpecmaticConfigV1
 import io.specmatic.core.config.v2.ContractConfig
 import io.specmatic.core.config.v2.ContractConfig.FileSystemContractSource
@@ -509,8 +509,8 @@ internal class SpecmaticConfigAllTest {
         val config = objectMapper.readValue(configYaml, SpecmaticConfigV1::class.java).transform()
         val configV2 = SpecmaticConfigV2.loadFrom(config) as SpecmaticConfigV2
 
-        assertThat(configV2.attributeSelectionPattern.getDefaultFields()).containsExactly("description", "url")
-        assertThat(configV2.attributeSelectionPattern.getQueryParamKey()).isEqualTo("web")
+        assertThat(configV2.attributeSelectionPattern?.getDefaultFields()).containsExactly("description", "url")
+        assertThat(configV2.attributeSelectionPattern?.getQueryParamKey()).isEqualTo("web")
     }
 
     @Test
@@ -527,8 +527,8 @@ internal class SpecmaticConfigAllTest {
         val config = objectMapper.readValue(configYaml, SpecmaticConfigV2::class.java).transform()
         val configV3 = SpecmaticConfigV2.loadFrom(config) as SpecmaticConfigV2
 
-        assertThat(configV3.attributeSelectionPattern.getDefaultFields()).containsExactly("description", "url")
-        assertThat(configV3.attributeSelectionPattern.getQueryParamKey()).isEqualTo("web")
+        assertThat(configV3.attributeSelectionPattern?.getDefaultFields()).containsExactly("description", "url")
+        assertThat(configV3.attributeSelectionPattern?.getQueryParamKey()).isEqualTo("web")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/stub/stateful/StatefulHttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/stateful/StatefulHttpStubTest.kt
@@ -1,11 +1,14 @@
 package io.specmatic.stub.stateful
 
 import io.specmatic.conversions.OpenApiSpecification
-import io.specmatic.core.*
-import io.specmatic.core.SpecmaticConfig.Companion.getAttributeSelectionPattern
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.QueryParameters
+import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.utilities.ContractPathData
-import io.specmatic.core.value.*
+import io.specmatic.core.value.JSONArrayValue
+import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.core.value.StringValue
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.loadContractStubsFromImplicitPaths
 import org.assertj.core.api.Assertions.assertThat
@@ -336,7 +339,7 @@ class StatefulHttpStubWithAttributeSelectionTest {
             ).toFeature()
             val specmaticConfig = loadSpecmaticConfig("$SPEC_DIR_PATH/specmatic.yaml")
             val scenarios = feature.scenarios.map {
-                it.copy(attributeSelectionPattern = getAttributeSelectionPattern(specmaticConfig))
+                it.copy(attributeSelectionPattern = specmaticConfig.getAttributeSelectionPattern())
             }
             httpStub = StatefulHttpStub(
                 specmaticConfigPath = "$SPEC_DIR_PATH/specmatic.yaml",


### PR DESCRIPTION
- Made the `attributeSelectionPattern` field nullable
- Moved defaults for `attributeSelectionPattern` field and it's children to wrapper methods