### PR TITLE
Fix filter execution on APIs which were "not in spec"

### DIFF
--- a/application/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -1,0 +1,42 @@
+package io.specmatic.test
+
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.*
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScenarioAsTestTest {
+    @Test
+    fun `should return scenario metadata`() {
+        val httpRequestPattern = mockk<HttpRequestPattern> {
+            every {
+                getHeaderKeys()
+            } returns setOf("Authorization", "X-Request-ID")
+
+            every {
+                getQueryParamKeys()
+            } returns setOf("productId", "orderId")
+
+            every { method } returns "POST"
+            every { httpPathPattern } returns HttpPathPattern(emptyList(), "/createProduct")
+        }
+
+        val scenario = Scenario(
+            "",
+            httpRequestPattern,
+            HttpResponsePattern(status = 200),
+            exampleName = "example"
+        )
+
+        val scenarioAsTest = ScenarioAsTest(scenario, Feature(name = ""), flagsBased = DefaultStrategies, originalScenario = scenario)
+        val scenarioMetadata = scenarioAsTest.toScenarioMetadata()
+
+        assertThat(scenarioMetadata.method).isEqualTo("POST")
+        assertThat(scenarioMetadata.path).isEqualTo("/createProduct")
+        assertThat(scenarioMetadata.query).isEqualTo(setOf("productId", "orderId"))
+        assertThat(scenarioMetadata.header).isEqualTo(setOf("Authorization", "X-Request-ID"))
+        assertThat(scenarioMetadata.statusCode).isEqualTo(200)
+        assertThat(scenarioMetadata.exampleName).isEqualTo("example")
+    }
+}

--- a/application/src/test/kotlin/io/specmatic/test/ScenarioTestGenerationExceptionTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/ScenarioTestGenerationExceptionTest.kt
@@ -1,0 +1,45 @@
+package io.specmatic.test
+
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.*
+import io.specmatic.core.pattern.ContractException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScenarioTestGenerationExceptionTest {
+    @Test
+    fun `should return scenario metadata`() {
+        val httpRequestPattern = mockk<HttpRequestPattern> {
+            every {
+                getHeaderKeys()
+            } returns setOf("Authorization", "X-Request-ID")
+
+            every {
+                getQueryParamKeys()
+            } returns setOf("productId", "orderId")
+
+            every { method } returns "POST"
+            every { httpPathPattern } returns HttpPathPattern(emptyList(), "/createProduct")
+        }
+
+        val scenario = Scenario(
+            "",
+            httpRequestPattern,
+            HttpResponsePattern(status = 200),
+            exampleName = "example"
+        )
+
+        val testGenerationException =
+            ScenarioTestGenerationException(scenario, ContractException(), "", null)
+        val scenarioMetadata = testGenerationException.toScenarioMetadata()
+
+        assertThat(scenarioMetadata.method).isEqualTo("POST")
+        assertThat(scenarioMetadata.path).isEqualTo("/createProduct")
+        assertThat(scenarioMetadata.query).isEqualTo(setOf("productId", "orderId"))
+        assertThat(scenarioMetadata.header).isEqualTo(setOf("Authorization", "X-Request-ID"))
+        assertThat(scenarioMetadata.statusCode).isEqualTo(200)
+        assertThat(scenarioMetadata.exampleName).isEqualTo("example")
+
+    }
+}

--- a/application/src/test/kotlin/io/specmatic/test/ScenarioTestGenerationFailureTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/ScenarioTestGenerationFailureTest.kt
@@ -1,0 +1,49 @@
+package io.specmatic.test
+
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.HttpPathPattern
+import io.specmatic.core.HttpRequestPattern
+import io.specmatic.core.HttpResponsePattern
+import io.specmatic.core.Result
+import io.specmatic.core.Scenario
+import io.specmatic.core.pattern.ContractException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScenarioTestGenerationFailureTest {
+    @Test
+    fun `should return scenario metadata`() {
+        val httpRequestPattern = mockk<HttpRequestPattern> {
+            every {
+                getHeaderKeys()
+            } returns setOf("Authorization", "X-Request-ID")
+
+            every {
+                getQueryParamKeys()
+            } returns setOf("productId", "orderId")
+
+            every { method } returns "POST"
+            every { httpPathPattern } returns HttpPathPattern(emptyList(), "/createProduct")
+        }
+
+        val scenario = Scenario(
+            "",
+            httpRequestPattern,
+            HttpResponsePattern(status = 200),
+            exampleName = "example"
+        )
+
+        val testGenerationFailure =
+            ScenarioTestGenerationFailure(scenario, Result.Failure("error"))
+        val scenarioMetadata = testGenerationFailure.toScenarioMetadata()
+
+        assertThat(scenarioMetadata.method).isEqualTo("POST")
+        assertThat(scenarioMetadata.path).isEqualTo("/createProduct")
+        assertThat(scenarioMetadata.query).isEqualTo(setOf("productId", "orderId"))
+        assertThat(scenarioMetadata.header).isEqualTo(setOf("Authorization", "X-Request-ID"))
+        assertThat(scenarioMetadata.statusCode).isEqualTo(200)
+        assertThat(scenarioMetadata.exampleName).isEqualTo("example")
+
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -2,6 +2,7 @@ package io.specmatic.core
 
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
+import io.specmatic.core.filters.HasScenarioMetadata
 import io.specmatic.core.filters.ScenarioMetadata
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
@@ -84,7 +85,7 @@ data class Scenario(
     val dictionary: Map<String, Value> = emptyMap(),
     val attributeSelectionPattern: AttributeSelectionPatternDetails = AttributeSelectionPatternDetails.default,
     val exampleRow: Row? = null
-): ScenarioDetailsForResult {
+): ScenarioDetailsForResult, HasScenarioMetadata {
     constructor(scenarioInfo: ScenarioInfo) : this(
         scenarioInfo.scenarioName,
         scenarioInfo.httpRequestPattern,
@@ -825,7 +826,7 @@ data class Scenario(
         }
     }
 
-    fun toScenarioMetadata(): ScenarioMetadata {
+    override fun toScenarioMetadata(): ScenarioMetadata {
         return ScenarioMetadata(
             method = this.method,
             path = this.path,

--- a/core/src/main/kotlin/io/specmatic/core/examples/server/ScenarioFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/server/ScenarioFilter.kt
@@ -28,9 +28,7 @@ class ScenarioFilter(filterName: String = "", filterNotName: String = "", filter
 
         val scenarioFilter = ScenarioMetadataFilter.from(filter)
 
-        val filteredScenarios = filterUsing(scenariosFilteredByOlderSyntax.asSequence(), scenarioFilter) {
-            it.toScenarioMetadata()
-        }.toList()
+        val filteredScenarios = filterUsing(scenariosFilteredByOlderSyntax.asSequence(), scenarioFilter).toList()
 
 
         return feature.copy(scenarios = filteredScenarios)

--- a/core/src/main/kotlin/io/specmatic/core/filters/HasScenarioMetadata.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/HasScenarioMetadata.kt
@@ -1,0 +1,5 @@
+package io.specmatic.core.filters
+
+interface HasScenarioMetadata {
+    fun toScenarioMetadata(): ScenarioMetadata
+}

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadata.kt
@@ -9,8 +9,8 @@ data class ScenarioMetadata(
     val header: Set<String>,
     val query: Set<String>,
     val exampleName: String
-) : FilterableExpression {
-    override fun populateExpressionData(expression: Expression): Expression {
+) {
+    fun populateExpressionData(expression: Expression): Expression {
         return expression
             .with(ScenarioFilterTags.METHOD.key, method)
             .with(ScenarioFilterTags.PATH.key, path)
@@ -19,5 +19,4 @@ data class ScenarioMetadata(
             .with(ScenarioFilterTags.QUERY.name, query.joinToString(","))
             .with(ScenarioFilterTags.EXAMPLE_NAME.name, exampleName)
     }
-
 }

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -2,15 +2,14 @@ package io.specmatic.core.filters
 
 import com.ezylang.evalex.Expression
 import com.ezylang.evalex.config.ExpressionConfiguration
-import io.specmatic.test.TestResultRecord
 
 data class ScenarioMetadataFilter(
     val expression: Expression? = null
 ) {
-    fun isSatisfiedBy(filterableExpression: FilterableExpression): Boolean {
+    fun isSatisfiedBy(scenarioMetaData: ScenarioMetadata): Boolean {
         val expression = expression ?: return true
 
-        val expressionWithVariables = filterableExpression.populateExpressionData(expression)
+        val expressionWithVariables = scenarioMetaData.populateExpressionData(expression)
 
         return try {
             expressionWithVariables.evaluate().booleanValue ?: false
@@ -45,13 +44,12 @@ data class ScenarioMetadataFilter(
             }
         }
 
-        fun <T> filterUsing(
+        fun <T : HasScenarioMetadata> filterUsing(
             items: Sequence<T>,
-            scenarioMetadataFilter: ScenarioMetadataFilter,
-            toFilterableMetadata: (T) -> FilterableExpression
+            scenarioMetadataFilter: ScenarioMetadataFilter
         ): Sequence<T> {
-            val filteredItems = items.filter {
-                scenarioMetadataFilter.isSatisfiedBy(toFilterableMetadata(it))
+            val filteredItems = items.filter { item ->
+                scenarioMetadataFilter.isSatisfiedBy(item.toScenarioMetadata())
             }
             return filteredItems
         }

--- a/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
+import io.specmatic.core.filters.HasScenarioMetadata
 import io.specmatic.core.filters.ScenarioMetadata
 
 interface ResponseValidator {
@@ -16,8 +17,7 @@ interface ResponseValidator {
     }
 }
 
-interface ContractTest {
-    fun toScenarioMetadata(): ScenarioMetadata
+interface ContractTest : HasScenarioMetadata {
     fun testResultRecord(result: Result, response: HttpResponse?): TestResultRecord?
     fun testDescription(): String
     fun runTest(testBaseURL: String, timeoutInMilliseconds: Long): Pair<Result, HttpResponse?>

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -4,6 +4,7 @@ import com.ezylang.evalex.Expression
 import io.specmatic.core.Result
 import io.specmatic.core.TestResult
 import io.specmatic.core.filters.FilterableExpression
+import io.specmatic.core.filters.HasScenarioMetadata
 import io.specmatic.core.filters.ScenarioFilterTags
 import io.specmatic.core.filters.ScenarioMetadata
 
@@ -22,24 +23,14 @@ data class TestResultRecord(
     val isValid: Boolean = true,
     val isWip: Boolean = false,
     val requestContentType: String? = null
-) : FilterableExpression
+) : HasScenarioMetadata
 {
     val isExercised = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
     val isCovered = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
 
     fun isConnectionRefused() = actualResponseStatus == 0
 
-    fun toScenarioMetadata(): ScenarioMetadata {
+    override fun toScenarioMetadata(): ScenarioMetadata {
         return ScenarioMetadata(method, path, responseStatus, emptySet(), emptySet(), "")
-    }
-
-    override fun populateExpressionData(expression: Expression): Expression {
-        return expression
-            .with(ScenarioFilterTags.METHOD.key, method)
-            .with(ScenarioFilterTags.PATH.key, path)
-            .with(ScenarioFilterTags.STATUS_CODE.key, "")
-            .with(ScenarioFilterTags.HEADER.key, "")
-            .with(ScenarioFilterTags.QUERY.name, "")
-            .with(ScenarioFilterTags.EXAMPLE_NAME.name, "")
     }
 }

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.TestResult
 import io.specmatic.core.filters.FilterableExpression
 import io.specmatic.core.filters.ScenarioFilterTags
+import io.specmatic.core.filters.ScenarioMetadata
 
 data class TestResultRecord(
     val path: String,
@@ -27,7 +28,18 @@ data class TestResultRecord(
     val isCovered = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
 
     fun isConnectionRefused() = actualResponseStatus == 0
+
+    fun toScenarioMetadata(): ScenarioMetadata {
+        return ScenarioMetadata(method, path, responseStatus, emptySet(), emptySet(), "")
+    }
+
     override fun populateExpressionData(expression: Expression): Expression {
-        return expression.with(ScenarioFilterTags.PATH.key, path)
+        return expression
+            .with(ScenarioFilterTags.METHOD.key, method)
+            .with(ScenarioFilterTags.PATH.key, path)
+            .with(ScenarioFilterTags.STATUS_CODE.key, "")
+            .with(ScenarioFilterTags.HEADER.key, "")
+            .with(ScenarioFilterTags.QUERY.name, "")
+            .with(ScenarioFilterTags.EXAMPLE_NAME.name, "")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/TestResultRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/TestResultRecordTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.test
 
 import io.specmatic.core.TestResult
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -57,5 +58,24 @@ class TestResultRecordTest {
             )
             assertFalse(record.isCovered, "Record should not be considered covered for result $it")
         }
+    }
+
+    @Test
+    fun `should return scenario metadata`() {
+        val record = TestResultRecord(
+            path = "/example/path",
+            method = "GET",
+            responseStatus = 200,
+            result = TestResult.Success
+        )
+
+        val scenarioMetadata = record.toScenarioMetadata()
+
+        assertThat(scenarioMetadata.method).isEqualTo("GET")
+        assertThat(scenarioMetadata.path).isEqualTo("/example/path")
+        assertThat(scenarioMetadata.statusCode).isEqualTo(200)
+        assertThat(scenarioMetadata.header).isEmpty()
+        assertThat(scenarioMetadata.query).isEmpty()
+        assertThat(scenarioMetadata.exampleName).isEmpty()
     }
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -307,9 +307,7 @@ open class SpecmaticJUnitSupport {
                 filterNotName
             ) { it.testDescription() }
 
-            filterUsing(filteredTestsBasedOnName, testFilter) {
-                it.toScenarioMetadata()
-            }
+            filterUsing(filteredTestsBasedOnName, testFilter)
         } catch (e: ContractException) {
             return loadExceptionAsTestError(e)
         } catch (e: Throwable) {
@@ -514,9 +512,7 @@ open class SpecmaticJUnitSupport {
         val filteredScenarios = filterUsing(
             filteredScenariosBasedOnName,
             testFilter
-        ) {
-            it.toScenarioMetadata()
-        }
+        )
 
         val filteredScenarioPaths = filteredScenarios.map { convertPathParameterStyle(it.path) }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -159,7 +159,7 @@ class OpenApiCoverageReportInput(
                     )
                 }
             }
-            val filteredItems = filterUsing(testReportRecordsIncludingMissingAPIs.asSequence(), filter) { it.toScenarioMetadata() }
+            val filteredItems = filterUsing(testReportRecordsIncludingMissingAPIs.asSequence(), filter)
             testReportRecordsIncludingMissingAPIs = filteredItems.toMutableList()
         }
         return testReportRecordsIncludingMissingAPIs

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -159,7 +159,7 @@ class OpenApiCoverageReportInput(
                     )
                 }
             }
-            val filteredItems = filterUsing(testReportRecordsIncludingMissingAPIs.asSequence(), filter) { it }
+            val filteredItems = filterUsing(testReportRecordsIncludingMissingAPIs.asSequence(), filter) { it.toScenarioMetadata() }
             testReportRecordsIncludingMissingAPIs = filteredItems.toMutableList()
         }
         return testReportRecordsIncludingMissingAPIs

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -143,26 +143,27 @@ class OpenApiCoverageReportInput(
     }
 
     private fun addTestResultsForMissingEndpoints(testResults: List<TestResultRecord>): List<TestResultRecord> {
-        var testReportRecordsIncludingMissingAPIs = testResults.toMutableList()
+        if(!endpointsAPISet)
+            return testResults
+
         val filter = ScenarioMetadataFilter.from(filterExpression)
-        if(endpointsAPISet) {
-            applicationAPIs.forEach { api ->
-                if (allEndpoints.none { it.path == api.path && it.method == api.method } && excludedAPIs.none { it == api.path }) {
-                    testReportRecordsIncludingMissingAPIs.add(
-                        TestResultRecord(
-                            api.path,
-                            api.method,
-                            0,
-                            TestResult.MissingInSpec,
-                            serviceType = SERVICE_TYPE_HTTP
-                        )
-                    )
-                }
-            }
-            val filteredItems = filterUsing(testReportRecordsIncludingMissingAPIs.asSequence(), filter)
-            testReportRecordsIncludingMissingAPIs = filteredItems.toMutableList()
+
+        val testResultsForMissingAPIs = applicationAPIs.filter { api ->
+            val noTestResultFoundForThisAPI = allEndpoints.none { it.path == api.path && it.method == api.method }
+            val isNotExcluded = api.path !in excludedAPIs
+
+            noTestResultFoundForThisAPI && isNotExcluded
+        }.map { api ->
+            TestResultRecord(
+                api.path,
+                api.method,
+                0,
+                TestResult.MissingInSpec,
+                serviceType = SERVICE_TYPE_HTTP
+            )
         }
-        return testReportRecordsIncludingMissingAPIs
+
+        return filterUsing((testResults + testResultsForMissingAPIs).asSequence(), filter).toList()
     }
 
     private fun calculateTotalCoveragePercentage(methodMap: Map<String, Map<String?, Map<String, List<TestResultRecord>>>>): Int {

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.7.4
+version=2.7.5


### PR DESCRIPTION
**What**:

Fixes a bug in the coverage filter, due to which an exception was thrown while generating the API coverage report when the following conditions were simultaneously true:
- when a filter clause exists
- when any filter criteria other than path is used
- if an actuator or swagger url is available

For example, this would occur when the swagger url is on, and a filter clause such as `"METHOD='post' && PATH='/metrics'"` was used, both using `--filter` on the terminal or `System.setProperty` in a Java application.

**Why**:

When a filter clause exists, the filter clause is executed against metadata extracted from each `Scenario` that comes out of the OpenAPI specification. Only `Scenario`s that pass the filter are run as tests, and appear in the final reports.

Specmatic also detects APIs in the application that were not in the spec, using information from swagger URL or actuator if available. Normally these are added to the report with the result `missing in spec`. But if any of these `missing in spec` APIs do not match the filter criteria, they are supposed to be omitted from the report.

The filter requires metadata. The metadata for `missing in spec` APIs was extracted using a  different code path different from the one used by Scenario, and this code path only generated metadata for the API path. As a result, filter expressions such as `"METHOD='post' && PATH='/metrics'"` would threw an exception, complaining that no data was found for `METHOD`.

**How**:

This was resolved by unifying the code paths used to generate the scenario metadata. Unification of the code paths made it possible to clean up the filter code a little.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [x] Security scans don't report any vulnerabilities
- n/a Documentation added/updated (share link) 
- n/a Sample Project added/updated (share link)
- n/a Demo video (share link)
- n/a Article on Website (share link)
- n/a Roadmap updated (share link)
- n/a Conference Talk (share link)

