### PR TITLE
Adding inline example validation when spec directory is provided as input

### DIFF
--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -211,14 +211,14 @@ For example, to filter by HTTP methods:
 
                 val feature = parseContractFileWithNoMissingConfigWarning(specFile)
                 val inlineExampleValidationResults = validateInlineExamples(feature)
-                printValidationResult(inlineExampleValidationResults.exampleValidationResults, "Inline example")
+                printValidationResult(inlineExampleValidationResults, "Inline example")
                 logger.log(System.lineSeparator())
 
                 val externalExampleValidationResult = validateExamplesDir(feature, associatedExamplesDir).second
                 printValidationResult(externalExampleValidationResult.exampleValidationResults, "Example file")
                 logger.log(System.lineSeparator())
 
-                listOf(inlineExampleValidationResults, externalExampleValidationResult).mergedAsOne()
+                externalExampleValidationResult.withAdditional(inlineExampleValidationResults)
             }.toList()
 
             logger.log("Summary:")
@@ -234,7 +234,7 @@ For example, to filter by HTTP methods:
 
             val inlineExampleValidationResults =
                 if (!validateInline)
-                    ValidationResults.forNoExamples()
+                    emptyMap()
                 else
                     validateInlineExamples(feature)
 
@@ -248,16 +248,16 @@ For example, to filter by HTTP methods:
                     validationResults
                 }
 
-            printValidationResult(inlineExampleValidationResults.exampleValidationResults, "Inline example")
+            printValidationResult(inlineExampleValidationResults, "Inline example")
             printValidationResult(externalExampleValidationResults.exampleValidationResults, "Example file")
 
-            if (inlineExampleValidationResults.exampleValidationResults.containsOnlyCompleteFailures())
+            if (inlineExampleValidationResults.containsOnlyCompleteFailures())
                 return FAILURE_EXIT_CODE
 
             return externalExampleValidationResults.exitCode
         }
 
-        private fun validateInlineExamples(feature: Feature): ValidationResults {
+        private fun validateInlineExamples(feature: Feature): Map<String, Result> {
             return exampleValidationModule.validateInlineExamples(
                 feature,
                 examples = feature.stubsFromExamples.mapValues { (_, stub) ->

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -212,13 +212,13 @@ For example, to filter by HTTP methods:
                 val feature = parseContractFileWithNoMissingConfigWarning(specFile)
                 val inlineExampleValidationResults = validateInlineExamples(feature)
                 printValidationResult(inlineExampleValidationResults, "Inline example")
-                logger.log(System.lineSeparator())
+                logger.boundary()
 
                 val externalExampleValidationResult = validateExamplesDir(feature, associatedExamplesDir).second
                 printValidationResult(externalExampleValidationResult.exampleValidationResults, "Example file")
-                logger.log(System.lineSeparator())
+                logger.boundary()
 
-                externalExampleValidationResult.withAdditional(inlineExampleValidationResults)
+                externalExampleValidationResult.plus(inlineExampleValidationResults)
             }.toList()
 
             logger.log("Summary:")

--- a/application/src/test/kotlin/application/ExamplesCommandTest.kt
+++ b/application/src/test/kotlin/application/ExamplesCommandTest.kt
@@ -348,6 +348,59 @@ paths:
     }
 
     @Nested
+    inner class CLIBasedValidateTests {
+        private val cli = CommandLine(ExamplesCommand.Validate(), CommandLine.defaultFactory())
+
+        @Test
+        fun `should validate both inline and external examples when --specs-dir is provided`() {
+            val (stdOut, exitCode) = captureStandardOutput {
+                cli.execute("--specs-dir", "src/test/resources/examples/multiple/products")
+            }
+
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Inline Example Validation Summary ===============
+            All 1 example(s) are valid.
+            =================================================================
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Example File Validation Summary ===============
+            All 2 example(s) are valid.
+            ===============================================================
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Overall Validation Summary ===============
+            All 3 example(s) are valid.
+            ==========================================================
+            """.trimIndent())
+        }
+
+        @Test
+        fun `should validate both inline and external examples when --specs-dir and --examples-base-dir is provided`() {
+            val (stdOut, exitCode) = captureStandardOutput {
+                cli.execute("--specs-dir", "src/test/resources/examples/only_specs/products",
+                    "--examples-base-dir", "src/test/resources/examples/only_examples/products")
+            }
+
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Inline Example Validation Summary ===============
+            All 1 example(s) are valid.
+            =================================================================
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Example File Validation Summary ===============
+            All 2 example(s) are valid.
+            ===============================================================
+            """.trimIndent())
+            assertThat(stdOut).containsIgnoringWhitespaces("""
+            =============== Overall Validation Summary ===============
+            All 3 example(s) are valid.
+            ==========================================================
+            """.trimIndent())
+        }
+    }
+    @Nested
     inner class ValidateLifeCycleTests {
         private val hook = AfterLoadingStaticExamples { examplesUsedFor, examples ->
             logger.log("life cycle hook called for '$examplesUsedFor'")

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -18,7 +18,7 @@ class ExampleValidationModule {
         feature: Feature,
         examples: Map<String, List<ScenarioStub>> = emptyMap(),
         scenarioFilter: ScenarioFilter = ScenarioFilter()
-    ): ValidationResults {
+    ): Map<String, Result> {
         val updatedFeature = scenarioFilter.filter(feature)
 
         val results = examples.mapValues { (name, exampleList) ->
@@ -32,7 +32,7 @@ class ExampleValidationModule {
             }
         }
 
-        return ValidationResults.forOnlyExamples(results)
+        return results
     }
 
     fun validateExamples(

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -18,7 +18,7 @@ class ExampleValidationModule {
         feature: Feature,
         examples: Map<String, List<ScenarioStub>> = emptyMap(),
         scenarioFilter: ScenarioFilter = ScenarioFilter()
-    ): Map<String, Result> {
+    ): ValidationResults {
         val updatedFeature = scenarioFilter.filter(feature)
 
         val results = examples.mapValues { (name, exampleList) ->
@@ -32,7 +32,8 @@ class ExampleValidationModule {
             }
         }
 
-        return results
+        //TODO - When inline/external/both are decided for each param-wise execution code paths, evaluate if adding a lifecycle hook here is appropriate. And if so, Result.Success() need to be replaced with the result of the hook
+        return ValidationResults(results, Result.Success())
     }
 
     fun validateExamples(

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleValidationModule.kt
@@ -32,8 +32,7 @@ class ExampleValidationModule {
             }
         }
 
-        //TODO - When inline/external/both are decided for each param-wise execution code paths, evaluate if adding a lifecycle hook here is appropriate. And if so, Result.Success() need to be replaced with the result of the hook
-        return ValidationResults(results, Result.Success())
+        return ValidationResults.forOnlyExamples(results)
     }
 
     fun validateExamples(

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
@@ -2,7 +2,7 @@ package io.specmatic.core.examples.module
 
 import io.specmatic.core.Result
 
-class ValidationResults(val exampleValidationResults: Map<String, Result>, val hookValidationResult: Result) {
+class ValidationResults(val exampleValidationResults: Map<String, Result>, private val hookValidationResult: Result) {
     val success: Boolean
         get() {
             if(exampleValidationResults.containsOnlyCompleteFailures())
@@ -25,22 +25,18 @@ class ValidationResults(val exampleValidationResults: Map<String, Result>, val h
         return this.any { it.value is Result.Failure && !it.value.isPartialFailure() }
     }
 
+    fun withAdditional(exampleValidationResults: Map<String, Result>) =
+        ValidationResults(this.exampleValidationResults + exampleValidationResults, hookValidationResult)
+
     companion object {
         fun forNoExamples(): ValidationResults {
             return ValidationResults(emptyMap(), Result.Success())
-        }
-
-        fun forOnlyExamples(exampleValidationResults: Map<String, Result>): ValidationResults {
-            return ValidationResults(exampleValidationResults, Result.Success())
         }
     }
 }
 
 fun List<ValidationResults>.ofAllExamples() =
     flatMap { it.exampleValidationResults.entries }.associate { entry -> entry.toPair() }
-
-fun List<ValidationResults>.mergedAsOne() =
-    ValidationResults(ofAllExamples(), Result.fromResults(this.map { it.hookValidationResult }))
 
 fun List<ValidationResults>.exitCode(): Int {
     return if (any { !it.success })

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
@@ -2,7 +2,7 @@ package io.specmatic.core.examples.module
 
 import io.specmatic.core.Result
 
-class ValidationResults(val exampleValidationResults: Map<String, Result>, private val hookValidationResult: Result) {
+class ValidationResults(val exampleValidationResults: Map<String, Result>, val hookValidationResult: Result) {
     val success: Boolean
         get() {
             if(exampleValidationResults.containsOnlyCompleteFailures())
@@ -34,6 +34,9 @@ class ValidationResults(val exampleValidationResults: Map<String, Result>, priva
 
 fun List<ValidationResults>.ofAllExamples() =
     flatMap { it.exampleValidationResults.entries }.associate { entry -> entry.toPair() }
+
+fun List<ValidationResults>.mergedAsOne() =
+    ValidationResults(ofAllExamples(), Result.fromResults(this.map { it.hookValidationResult }))
 
 fun List<ValidationResults>.exitCode(): Int {
     return if (any { !it.success })

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
@@ -29,6 +29,10 @@ class ValidationResults(val exampleValidationResults: Map<String, Result>, val h
         fun forNoExamples(): ValidationResults {
             return ValidationResults(emptyMap(), Result.Success())
         }
+
+        fun forOnlyExamples(exampleValidationResults: Map<String, Result>): ValidationResults {
+            return ValidationResults(exampleValidationResults, Result.Success())
+        }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ValidationResults.kt
@@ -25,7 +25,7 @@ class ValidationResults(val exampleValidationResults: Map<String, Result>, priva
         return this.any { it.value is Result.Failure && !it.value.isPartialFailure() }
     }
 
-    fun withAdditional(exampleValidationResults: Map<String, Result>) =
+    fun plus(exampleValidationResults: Map<String, Result>) =
         ValidationResults(this.exampleValidationResults + exampleValidationResults, hookValidationResult)
 
     companion object {


### PR DESCRIPTION
This commit will allow validating inline examples (in addition to external examples) when `example validate` command is used with `--spec-dir` as parameter.  