### PR TITLE
Updated email regex to filter emails with invalid domains

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EmailPattern.kt
@@ -6,7 +6,7 @@ import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 import java.util.*
 
-private const val EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\$"
+private const val EMAIL_REGEX = "^[a-zA-Z0-9](?:[\\w.-]{0,62}[a-zA-Z0-9])?@[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,253}[a-zA-Z0-9])?\\.[a-zA-Z]{2,}\$"
 
 class EmailPattern (private val stringPatternDelegate: StringPattern) :
     Pattern by stringPatternDelegate, ScalarType {

--- a/core/src/test/kotlin/io/specmatic/core/pattern/EmailPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/EmailPatternTest.kt
@@ -44,6 +44,9 @@ class EmailPatternTest {
             "hello@world,com",    // Comma instead of dot
             "hello@world@com",    // Multiple @ symbols
             "hello@world.com.",   // Trailing dot
+            "hello@-world.com",   // Invalid domain starting with a hyphen
+            "hello@world-.com",   // Invalid domain ending with a hyphen
+            "hello@world..com",   // Double dots in domain
         )
 
         invalidEmails.forEach { email ->


### PR DESCRIPTION
- Updated email regex to filter emails with invalid domains
- Limit the quantifiers to prevent uncontrolled expansion of the `*` operator
- Added character limits for local and domain parts as per RFC 5322 compliance