### PR TITLE
Decouple the dictionary configuration from stub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -173,7 +173,7 @@ class OpenApiSpecification(
         }
 
         private fun getDictionaryFile(openApiFile: File, dictionaryPathFromConfig: String?): File? {
-            val explicitDictionaryPath = dictionaryPathFromConfig ?: Flags.getStringValue(SPECMATIC_STUB_DICTIONARY)
+            val explicitDictionaryPath = dictionaryPathFromConfig ?: Flags.getStringValue(SPECMATIC_DICTIONARY)
             if (!explicitDictionaryPath.isNullOrEmpty()) return File(explicitDictionaryPath)
 
             val implicitPaths = sequenceOf("_dictionary.yml", "_dictionary.yaml", "_dictionary.json")

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -69,7 +69,7 @@ class OpenApiSpecification(
     private val specificationPath: String? = null,
     private val securityConfiguration: SecurityConfiguration? = null,
     private val specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
-    private val dictionary: Dictionary = loadDictionary(openApiFilePath, specmaticConfig.getStubDictionary()),
+    private val dictionary: Dictionary = loadDictionary(openApiFilePath, specmaticConfig.getDictionary()),
     private val strictMode: Boolean = false
 ) : IncludedSpecification, ApiSpecification {
     init {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -104,7 +104,6 @@ fun String.loadContract(): Feature {
 data class StubConfiguration(
     private val generative: Boolean? = null,
     private val delayInMilliseconds: Long? = null,
-    private val dictionary: String? = null,
     private val includeMandatoryAndRequestedKeysInResponse: Boolean? = null,
     private val startTimeoutInMilliseconds: Long? = null
 ) {
@@ -114,10 +113,6 @@ data class StubConfiguration(
 
     fun getDelayInMilliseconds(): Long? {
         return delayInMilliseconds ?: getLongValue(SPECMATIC_STUB_DELAY)
-    }
-
-    fun getDictionary(): String? {
-        return dictionary ?: getStringValue(SPECMATIC_DICTIONARY)
     }
 
     fun getIncludeMandatoryAndRequestedKeysInResponse(): Boolean? {
@@ -217,7 +212,8 @@ data class SpecmaticConfig(
     private val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
     private val allPatternsMandatory: Boolean? = null,
     private val defaultPatternValues: Map<String, Any> = emptyMap(),
-    private val version: SpecmaticConfigVersion? = null
+    private val version: SpecmaticConfigVersion? = null,
+    private val dictionary: String? = null
 ) {
     companion object {
         fun getReport(specmaticConfig: SpecmaticConfig): ReportConfigurationDetails? {
@@ -459,11 +455,6 @@ data class SpecmaticConfig(
     }
 
     @JsonIgnore
-    fun getStubDictionary(): String? {
-        return stub.getDictionary()
-    }
-
-    @JsonIgnore
     fun getIgnoreInlineExamples(): Boolean {
         return ignoreInlineExamples ?: getBooleanValue(Flags.IGNORE_INLINE_EXAMPLES)
     }
@@ -585,6 +576,11 @@ data class SpecmaticConfig(
         } catch(e: Throwable) {
             throw ContractException("Error loading Specmatic configuration: ${e.message}")
         }
+    }
+
+    @JsonIgnore
+    fun getDictionary(): String? {
+        return dictionary ?: getStringValue(SPECMATIC_DICTIONARY)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -73,8 +73,7 @@ const val TEST_DIR_SUFFIX = "_tests"
 const val EXAMPLES_DIR_SUFFIX = "_examples"
 const val SPECMATIC_GITHUB_ISSUES = "https://github.com/znsio/specmatic/issues"
 const val DEFAULT_WORKING_DIRECTORY = ".$APPLICATION_NAME_LOWER_CASE"
-
-const val SPECMATIC_STUB_DICTIONARY = "SPECMATIC_STUB_DICTIONARY"
+const val SPECMATIC_DICTIONARY = "SPECMATIC_DICTIONARY"
 
 const val MISSING_CONFIG_FILE_MESSAGE = "Config file does not exist. (Could not find file ./specmatic.json OR ./specmatic.yaml OR ./specmatic.yml)"
 
@@ -118,7 +117,7 @@ data class StubConfiguration(
     }
 
     fun getDictionary(): String? {
-        return dictionary ?: getStringValue(SPECMATIC_STUB_DICTIONARY)
+        return dictionary ?: getStringValue(SPECMATIC_DICTIONARY)
     }
 
     fun getIncludeMandatoryAndRequestedKeysInResponse(): Boolean? {

--- a/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
@@ -33,7 +33,8 @@ data class SpecmaticConfigV1 (
 	val allPatternsMandatory: Boolean? = null,
 	@field:JsonAlias("default_pattern_values")
 	val defaultPatternValues: Map<String, Any> = emptyMap(),
-	val version: SpecmaticConfigVersion? = null
+	val version: SpecmaticConfigVersion? = null,
+	val dictionary: String? = null,
 ): SpecmaticVersionedConfig {
 	override fun transform(): SpecmaticConfig {
 		return SpecmaticConfig(
@@ -55,6 +56,7 @@ data class SpecmaticConfigV1 (
 			attributeSelectionPattern = this.attributeSelectionPattern,
 			allPatternsMandatory = this.allPatternsMandatory,
 			defaultPatternValues = this.defaultPatternValues,
+			dictionary = this.dictionary,
 			version = SpecmaticConfigVersion.VERSION_1
 		)
 	}

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -40,7 +40,8 @@ data class SpecmaticConfigV2(
     @field:JsonAlias("all_patterns_mandatory")
     val allPatternsMandatory: Boolean? = null,
     @field:JsonAlias("default_pattern_values")
-    val defaultPatternValues: Map<String, Any> = emptyMap()
+    val defaultPatternValues: Map<String, Any> = emptyMap(),
+    val dictionary: String? = null,
 ) : SpecmaticVersionedConfig {
     override fun transform(): SpecmaticConfig {
         return SpecmaticConfig(
@@ -62,7 +63,8 @@ data class SpecmaticConfigV2(
             additionalExampleParamsFilePath = this.additionalExampleParamsFilePath,
             attributeSelectionPattern = this.attributeSelectionPattern,
             allPatternsMandatory = this.allPatternsMandatory,
-            defaultPatternValues = this.defaultPatternValues
+            defaultPatternValues = this.defaultPatternValues,
+            dictionary = dictionary
         )
     }
 
@@ -91,7 +93,8 @@ data class SpecmaticConfigV2(
                 additionalExampleParamsFilePath = config.getAdditionalExampleParamsFilePath(),
                 attributeSelectionPattern = getAttributeSelectionPattern(config),
                 allPatternsMandatory = getAllPatternsMandatory(config),
-                defaultPatternValues = config.getDefaultPatternValues()
+                defaultPatternValues = config.getDefaultPatternValues(),
+                dictionary = config.getDictionary()
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Grammar.kt
@@ -397,7 +397,8 @@ private fun processContent(content: String?, extension: String): Value {
             else -> parsedScalarValue(trimmedContent)
         }
     }.getOrElse { e ->
-        logger.debug(e)
+        logger.log(e)
+        logger.log("Failed to parse value, trying to parse as string..")
         StringValue(trimmedContent)
     }
 }

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -331,7 +331,7 @@ class DictionaryTest {
         println("Tests WITH the dictionary")
 
         val testCountWithDictionary = try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, dictionaryPath)
+            System.setProperty(SPECMATIC_DICTIONARY, dictionaryPath)
 
             OpenApiSpecification
         .fromFile(openApiFilePath)
@@ -351,7 +351,7 @@ class DictionaryTest {
             })
         }.testCount
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
 
         assertThat(testCountWithDictionary).isEqualTo(testCountWithoutDictionary)

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -2,7 +2,7 @@ package integration_tests
 
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
-import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
+import io.specmatic.core.SPECMATIC_DICTIONARY
 import io.specmatic.core.log.DebugLogger
 import io.specmatic.core.log.withLogger
 import io.specmatic.core.pattern.parsedJSONObject
@@ -394,7 +394,7 @@ class PartialExampleTest {
     @Test
     fun `partial example using dictionary populates mandatory key and header but not non-mandatory missing ones`() {
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(
                 listOf("src/test/resources/openapi/substitutions/partial_using_dictionary.yaml"),
@@ -413,14 +413,14 @@ class PartialExampleTest {
                     }
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
     @Test
     fun `partial example using dictionary populates missing mandatory key from the dictionary`() {
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(
                 listOf("src/test/resources/openapi/substitutions/partial_using_dictionary_testing_mandarory_key_generation.yaml"),
@@ -439,7 +439,7 @@ class PartialExampleTest {
                     }
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
@@ -447,7 +447,7 @@ class PartialExampleTest {
     @Test
     fun `partial example using invalid dictionary should throw an error at runtime`() {
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(
                 listOf("src/test/resources/openapi/substitutions/partial_with_invalid_dictionary_value.yaml"),
@@ -465,7 +465,7 @@ class PartialExampleTest {
                 assertThat(response.body.toStringLiteral()).contains(">> RESPONSE.BODY.id")
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
@@ -491,7 +491,7 @@ class PartialExampleTest {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml")
 
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
                 val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Janet"}"""))
@@ -504,7 +504,7 @@ class PartialExampleTest {
                 assertThat(responseBody.findFirstChildByPath("address.street")).isEqualTo(StringValue("Baker Street"))
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
@@ -513,7 +513,7 @@ class PartialExampleTest {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array.yaml")
 
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
                 val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Janet"}"""))
@@ -526,7 +526,7 @@ class PartialExampleTest {
                 assertThat(responseBody.findFirstChildByPath("addresses.[0].street")).isEqualTo(StringValue("Baker Street"))
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
@@ -535,7 +535,7 @@ class PartialExampleTest {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/complicated_spec_with_dictionary_substitutions.yaml")
 
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/complicated_dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/complicated_dictionary.json")
 
             createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
                 stub.client.execute(
@@ -553,7 +553,7 @@ class PartialExampleTest {
 
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 

--- a/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
+++ b/core/src/test/kotlin/integration_tests/StubSubstitutionTest.kt
@@ -3,7 +3,7 @@ package integration_tests
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
-import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
+import io.specmatic.core.SPECMATIC_DICTIONARY
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
@@ -659,7 +659,7 @@ class StubSubstitutionTest {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/spec_with_no_substitutions.yaml")
 
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
                 val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Charles"}"""))
@@ -674,7 +674,7 @@ class StubSubstitutionTest {
                 assertThat(responseBody.findFirstChildByPath("name")).isEqualTo(StringValue("George"))
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
@@ -683,7 +683,7 @@ class StubSubstitutionTest {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml")
 
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
                 val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Charles"}"""))
@@ -696,7 +696,7 @@ class StubSubstitutionTest {
                 assertThat(responseBody.findFirstChildByPath("address.street")).isEqualTo(StringValue("Baker Street"))
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
@@ -705,7 +705,7 @@ class StubSubstitutionTest {
         val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level_with_array.yaml")
 
         try {
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(SPECMATIC_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
 
             createStubFromContracts(listOf(specWithSubstitution), timeoutMillis = 0).use { stub ->
                 val request = HttpRequest("POST", "/person", body = parsedJSONObject("""{"name": "Charles"}"""))
@@ -718,7 +718,7 @@ class StubSubstitutionTest {
                 assertThat(responseBody.findFirstChildByPath("addresses.[0].street")).isEqualTo(StringValue("Baker Street"))
             }
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 
@@ -727,7 +727,7 @@ class StubSubstitutionTest {
         try {
             val specWithSubstitution = osAgnosticPath("src/test/resources/openapi/substitutions/dictionary_value_at_second_level.yaml")
             val brokenDictionaryPath = "src/test/resources/openapi/substitutions/broken-dictionary.json"
-            System.setProperty(SPECMATIC_STUB_DICTIONARY, brokenDictionaryPath)
+            System.setProperty(SPECMATIC_DICTIONARY, brokenDictionaryPath)
 
             val (output, _) = captureStandardOutput {
                 try {
@@ -742,7 +742,7 @@ class StubSubstitutionTest {
 
             assertThat(output).contains(osAgnosticPath(brokenDictionaryPath))
         } finally {
-            System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(SPECMATIC_DICTIONARY)
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -354,7 +354,7 @@ Pet:
         val specmaticConfig = mockk<SpecmaticConfig> {
             every { isResponseValueValidationEnabled() } returns true
             every { getIgnoreInlineExamples() } returns false
-            every { getStubDictionary() } returns null
+            every { getDictionary() } returns null
         }
         val openApiSpecification = OpenApiSpecification(
             openApiFilePath = openApiFile,

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -608,6 +608,36 @@ internal class SpecmaticConfigAllTest {
     }
 
     @Test
+    fun `should be able to load config V1 or V2 with dictionary field at top-level`() {
+        val configV1Yaml = """
+        dictionary: ./dictionary.json
+        """.trimIndent()
+
+        val configV1 = objectMapper.readValue(configV1Yaml, SpecmaticConfigV1::class.java).transform()
+        assertThat(configV1.getDictionary()).isEqualTo("./dictionary.json")
+
+        val configV2Yaml = """
+        version: 2
+        dictionary: ./dictionary.yaml
+        """.trimIndent()
+
+        val configV2 = objectMapper.readValue(configV2Yaml, SpecmaticConfigV2::class.java).transform()
+        assertThat(configV2.getDictionary()).isEqualTo("./dictionary.yaml")
+    }
+
+    @Test
+    fun `should be able to convert v1 config to v2 with dictionary field present`() {
+        val configV1Yaml = """
+        dictionary: ./dictionary.json
+        """.trimIndent()
+
+        val configV1 = objectMapper.readValue(configV1Yaml, SpecmaticConfigV1::class.java).transform()
+        val configV2 = SpecmaticConfigV2.loadFrom(configV1) as SpecmaticConfigV2
+
+        assertThat(configV2.dictionary).isEqualTo("./dictionary.json")
+    }
+
+    @Test
     fun `should deserialize test configuration in SpecmaticConfig successfully`(@TempDir tempDir: File) {
         val configFile = tempDir.resolve("specmatic.yaml")
         val configYaml = """
@@ -682,7 +712,6 @@ internal class SpecmaticConfigAllTest {
             stub:
                 generative: true
                 delayInMilliseconds: 1000
-                dictionary: stubDictionary
                 includeMandatoryAndRequestedKeysInResponse: true
         """.trimIndent()
         configFile.writeText(configYaml)
@@ -692,7 +721,6 @@ internal class SpecmaticConfigAllTest {
         specmaticConfig.apply {
             assertThat(getStubGenerative()).isTrue()
             assertThat(getStubDelayInMilliseconds()).isEqualTo(1000L)
-            assertThat(getStubDictionary()).isEqualTo("stubDictionary")
             assertThat(getStubIncludeMandatoryAndRequestedKeysInResponse()).isTrue()
         }
     }
@@ -703,7 +731,6 @@ internal class SpecmaticConfigAllTest {
             stub:
                 generative: true
                 delayInMilliseconds: 1000
-                dictionary: stubDictionary
                 includeMandatoryAndRequestedKeysInResponse: true
         """.trimIndent()
 
@@ -713,7 +740,6 @@ internal class SpecmaticConfigAllTest {
         configV2.stub.apply {
             assertThat(getGenerative()).isTrue()
             assertThat(getDelayInMilliseconds()).isEqualTo(1000L)
-            assertThat(getDictionary()).isEqualTo("stubDictionary")
             assertThat(getIncludeMandatoryAndRequestedKeysInResponse()).isTrue()
         }
     }
@@ -725,7 +751,6 @@ internal class SpecmaticConfigAllTest {
             stub:
                 generative: true
                 delayInMilliseconds: 1000
-                dictionary: stubDictionary
                 includeMandatoryAndRequestedKeysInResponse: true
         """.trimIndent()
 
@@ -735,7 +760,6 @@ internal class SpecmaticConfigAllTest {
         configV3.stub.apply {
             assertThat(getGenerative()).isTrue()
             assertThat(getDelayInMilliseconds()).isEqualTo(1000L)
-            assertThat(getDictionary()).isEqualTo("stubDictionary")
             assertThat(getIncludeMandatoryAndRequestedKeysInResponse()).isTrue()
         }
     }


### PR DESCRIPTION
**What**: Decouple the dictionary configuration from stub

**Why**: The Dictionary is no longer linked to HttpStub since it can be utilized for testing, examples, and additional purposes.

**How**:
- Rename system property from `SPECMATIC_STUB_DICTIONARY` to `SPECMATIC_DICTIONARY`
- Relocate the dictionary field in the configuration from stubConfiguration to the top-level field

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)