### PR TITLE
Resolve edge case related to shadowed path matching

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -347,6 +347,7 @@ enum class FailureReason(val fluffLevel: Int, val objectMatchOccurred: Boolean) 
     URLPathMisMatch(2, false),
     URLPathParamMismatchButSameStructure(1, false),
     URLPathParamMatchButConflict(2, false),
+    URLPathParamMismatchAndConflict(2, false),
     SOAPActionMismatch(2, false),
     DiscriminatorMismatch(0, true),
     FailedButDiscriminatorMatched(0, true),

--- a/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
@@ -10,10 +10,11 @@ import io.specmatic.core.value.Value
 data class URLPathSegmentPattern(override val pattern: Pattern, override val key: String? = null, override val typeAlias: String? = null, val conflicts: Set<String> = emptySet()) : Pattern, Keyed {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         val result = resolver.matchesPattern(key, pattern, sampleData ?: NullValue)
-        if (result.isSuccess() && sampleData?.toStringLiteral() in conflicts) {
+        if (sampleData?.toStringLiteral() in conflicts) {
             return Result.Failure(
-                "Value ${sampleData?.displayableValue()} conflicts with an existing path using the same prefix",
-                failureReason = FailureReason.URLPathParamMatchButConflict
+                message = "Value ${sampleData?.displayableValue()} conflicts with an existing path using the same value",
+                cause = result as? Result.Failure,
+                failureReason = if (result.isSuccess()) FailureReason.URLPathParamMatchButConflict else FailureReason.URLPathParamMismatchAndConflict
             )
         }
 


### PR DESCRIPTION
**What**: Resolve edge case related to shadowed path matching

**Reason**: 
- When there is a shadowed path with parameters that do not share the same schema, such as `/orders/(number)` and `/orders/bulk`, or `/(string)/orders/(string)` and `/(string)/orders/bulk` the path matching logic fails to provide the correct failure reason. This issue causes the `interactive server` to erroneously duplicate the example for both paths in the UI

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)