### PR TITLE
chore(workflow): added security-events permission for dependency submission

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,8 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: write # This is required so that the dependency check can push dependency graph to the github repository
+      contents: write
+      security-events: write # This is required so that the dependency check can push dependency graph to the github repository
     steps:
       - uses: specmatic/specmatic-github-workflows/action-build-gradle@main
         with:


### PR DESCRIPTION
Dependency submission is considered as a security event in the github and therefore `security-events: write` permission is required for the dependency submission using the workflow.