### PR TITLE
chore(workflow): Trigger workflow only on active PRs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,9 +5,11 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types: [opened, ready_for_review, synchronize, reopened]
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]


### PR DESCRIPTION
This will ensure that the workflow will get trigger only on active PRs and not Draft PRs.