### PR TITLE
Improvement for running multiple concurrent in-process instances of test and stub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -598,6 +598,18 @@ data class SpecmaticConfig(
             throw ContractException("Error loading Specmatic configuration: ${e.message}")
         }
     }
+
+    fun enableResiliencyTests(): SpecmaticConfig {
+        return this.copy(
+            test =
+                (test ?: TestConfiguration()).copy(
+                    resiliencyTests =
+                        (test?.resiliencyTests ?: ResiliencyTestsConfig()).copy(
+                            enable = ResiliencyTestSuite.all,
+                        ),
+                ),
+        )
+    }
 }
 
 data class TestConfiguration(

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -974,14 +974,19 @@ data class APIKeySecuritySchemeConfiguration(
 ) : SecuritySchemeConfiguration()
 
 fun loadSpecmaticConfigOrDefault(configFileName: String? = null): SpecmaticConfig {
-    return if(configFileName == null)
+    return loadSpecmaticConfigOrNull(configFileName) ?: SpecmaticConfig()
+}
+
+fun loadSpecmaticConfigOrNull(configFileName: String? = null): SpecmaticConfig? {
+    return if (configFileName == null) {
         SpecmaticConfig()
-    else try {
-        loadSpecmaticConfig(configFileName)
-    }
-    catch (e: ContractException) {
-        logger.log(exceptionCauseMessage(e))
-        SpecmaticConfig()
+    } else {
+        try {
+            loadSpecmaticConfig(configFileName)
+        } catch (e: ContractException) {
+            logger.log(exceptionCauseMessage(e))
+            null
+        }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -79,7 +79,7 @@ class HttpStub(
         it.path to endPointFromHostAndPort(host, port, keyData)
     },
     private val listeners: List<MockEventListener> = emptyList(),
-    private val reportsDirectoryPath: String = JSON_REPORT_PATH,
+    private val reportBaseDirectoryPath: String = ".",
 ) : ContractStub {
     constructor(
         feature: Feature,
@@ -733,7 +733,8 @@ class HttpStub(
                 encodeDefaults = false
             }
             val generatedReport = stubUsageReport.generate()
-            val reportJson: String = File(reportsDirectoryPath).resolve(JSON_REPORT_FILE_NAME).let { reportFile ->
+            val reportPath = File(reportBaseDirectoryPath).resolve(JSON_REPORT_PATH).canonicalFile
+            val reportJson: String = reportPath.resolve(JSON_REPORT_FILE_NAME).let { reportFile ->
                 if (reportFile.exists()) {
                     try {
                         val existingReport = Json.decodeFromString<StubUsageReportJson>(reportFile.readText())
@@ -747,7 +748,7 @@ class HttpStub(
                 }
             }
 
-            saveJsonFile(reportJson, reportsDirectoryPath, JSON_REPORT_FILE_NAME)
+            saveJsonFile(reportJson, reportPath.canonicalPath, JSON_REPORT_FILE_NAME)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -732,7 +732,7 @@ class HttpStub(
                 encodeDefaults = false
             }
             val generatedReport = stubUsageReport.generate()
-            val reportJson: String = File(JSON_REPORT_PATH).resolve(JSON_REPORT_FILE_NAME).let { reportFile ->
+            val reportJson: String = File(workingDirectory?.path ?: ".").resolve(JSON_REPORT_PATH).resolve(JSON_REPORT_FILE_NAME).let { reportFile ->
                 if (reportFile.exists()) {
                     try {
                         val existingReport = Json.decodeFromString<StubUsageReportJson>(reportFile.readText())
@@ -746,7 +746,7 @@ class HttpStub(
                 }
             }
 
-            saveJsonFile(reportJson, JSON_REPORT_PATH, JSON_REPORT_FILE_NAME)
+            saveJsonFile(reportJson, File(workingDirectory?.path ?: ".").resolve(JSON_REPORT_PATH).path, JSON_REPORT_FILE_NAME)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -78,7 +78,8 @@ class HttpStub(
     private val specToStubBaseUrlMap: Map<String, String?> = features.associate {
         it.path to endPointFromHostAndPort(host, port, keyData)
     },
-    private val listeners: List<MockEventListener> = emptyList()
+    private val listeners: List<MockEventListener> = emptyList(),
+    private val reportsDirectoryPath: String = JSON_REPORT_PATH,
 ) : ContractStub {
     constructor(
         feature: Feature,
@@ -732,7 +733,7 @@ class HttpStub(
                 encodeDefaults = false
             }
             val generatedReport = stubUsageReport.generate()
-            val reportJson: String = File(workingDirectory?.path ?: ".").resolve(JSON_REPORT_PATH).resolve(JSON_REPORT_FILE_NAME).let { reportFile ->
+            val reportJson: String = File(reportsDirectoryPath).resolve(JSON_REPORT_FILE_NAME).let { reportFile ->
                 if (reportFile.exists()) {
                     try {
                         val existingReport = Json.decodeFromString<StubUsageReportJson>(reportFile.readText())
@@ -746,7 +747,7 @@ class HttpStub(
                 }
             }
 
-            saveJsonFile(reportJson, File(workingDirectory?.path ?: ".").resolve(JSON_REPORT_PATH).path, JSON_REPORT_FILE_NAME)
+            saveJsonFile(reportJson, reportsDirectoryPath, JSON_REPORT_FILE_NAME)
         }
     }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -2,7 +2,6 @@ package io.specmatic.test
 
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.getConfigFilePath
-import io.specmatic.core.loadSpecmaticConfigOrDefault
 import io.specmatic.core.utilities.readEnvVarOrProperty
 
 data class ContractTestSettings(
@@ -10,20 +9,19 @@ data class ContractTestSettings(
     val contractPaths: String?,
     val filter: String,
     val configFile: String,
-    val specmaticConfig: SpecmaticConfig?,
+    val generative: Boolean?,
 ) {
+    fun adjust(specmaticConfig: SpecmaticConfig?): SpecmaticConfig = (specmaticConfig ?: SpecmaticConfig()).enableResiliencyTests()
+
     internal constructor(contractTestSettings: ThreadLocal<ContractTestSettings?>) : this(
         testBaseURL = contractTestSettings.get()?.testBaseURL ?: System.getProperty(SpecmaticJUnitSupport.TEST_BASE_URL),
         contractPaths = contractTestSettings.get()?.contractPaths ?: System.getProperty(SpecmaticJUnitSupport.CONTRACT_PATHS),
-        filter = contractTestSettings.get()?.filter ?: readEnvVarOrProperty(
-            SpecmaticJUnitSupport.FILTER,
-            SpecmaticJUnitSupport.FILTER
-        ).orEmpty(),
+        filter =
+            contractTestSettings.get()?.filter ?: readEnvVarOrProperty(
+                SpecmaticJUnitSupport.FILTER,
+                SpecmaticJUnitSupport.FILTER,
+            ).orEmpty(),
         configFile = contractTestSettings.get()?.configFile ?: getConfigFilePath(),
-        specmaticConfig =
-            contractTestSettings.get()?.specmaticConfig
-                ?: contractTestSettings.get()?.configFile?.let {
-                    loadSpecmaticConfigOrDefault(it)
-                } ?: loadSpecmaticConfigOrDefault(getConfigFilePath()),
+        generative = contractTestSettings.get()?.generative,
     )
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -1,0 +1,29 @@
+package io.specmatic.test
+
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.getConfigFilePath
+import io.specmatic.core.loadSpecmaticConfigOrDefault
+import io.specmatic.core.utilities.readEnvVarOrProperty
+
+data class ContractTestSettings(
+    val testBaseURL: String?,
+    val contractPaths: String?,
+    val filter: String,
+    val configFile: String,
+    val specmaticConfig: SpecmaticConfig?,
+) {
+    internal constructor(contractTestSettings: ThreadLocal<ContractTestSettings?>) : this(
+        testBaseURL = contractTestSettings.get()?.testBaseURL ?: System.getProperty(SpecmaticJUnitSupport.TEST_BASE_URL),
+        contractPaths = contractTestSettings.get()?.contractPaths ?: System.getProperty(SpecmaticJUnitSupport.CONTRACT_PATHS),
+        filter = contractTestSettings.get()?.filter ?: readEnvVarOrProperty(
+            SpecmaticJUnitSupport.FILTER,
+            SpecmaticJUnitSupport.FILTER
+        ).orEmpty(),
+        configFile = contractTestSettings.get()?.configFile ?: getConfigFilePath(),
+        specmaticConfig =
+            contractTestSettings.get()?.specmaticConfig
+                ?: contractTestSettings.get()?.configFile?.let {
+                    loadSpecmaticConfigOrDefault(it)
+                } ?: loadSpecmaticConfigOrDefault(getConfigFilePath()),
+    )
+}

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTest.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTest.kt
@@ -8,18 +8,33 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import java.util.stream.Stream
 import kotlin.jvm.optionals.getOrNull
 
+@Volatile
+private var contractTestHarnessInstance: SpecmaticJUnitSupport? = null
+
 @ExtendWith(AfterSpecmaticContractTestExecutionCallback::class)
 interface SpecmaticContractTest {
     @TestFactory
     fun contractTest(): Stream<DynamicTest> {
-        return SpecmaticJUnitSupport().contractTest()
+        val instance = SpecmaticJUnitSupport()
+
+        synchronized(SpecmaticJUnitSupport::class.java) {
+            contractTestHarnessInstance = instance
+        }
+        return instance.contractTest()
     }
 }
 
 
 class AfterSpecmaticContractTestExecutionCallback : AfterTestExecutionCallback {
     override fun afterTestExecution(context: ExtensionContext?) {
-        val testInstance = context?.testInstance?.getOrNull() as? SpecmaticJUnitSupport ?: return
-        testInstance.report()
+        val testInstance = context?.testInstance?.getOrNull() as? SpecmaticJUnitSupport
+
+        if(testInstance != null) {
+            testInstance.report()
+        } else {
+            synchronized(SpecmaticJUnitSupport::class.java) {
+                contractTestHarnessInstance?.report()
+            }
+        }
     }
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTest.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticContractTest.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import java.util.stream.Stream
+import kotlin.jvm.optionals.getOrNull
 
 @ExtendWith(AfterSpecmaticContractTestExecutionCallback::class)
 interface SpecmaticContractTest {
-
     @TestFactory
     fun contractTest(): Stream<DynamicTest> {
         return SpecmaticJUnitSupport().contractTest()
@@ -19,6 +19,7 @@ interface SpecmaticContractTest {
 
 class AfterSpecmaticContractTestExecutionCallback : AfterTestExecutionCallback {
     override fun afterTestExecution(context: ExtensionContext?) {
-        SpecmaticJUnitSupport.report()
+        val testInstance = context?.testInstance?.getOrNull() as? SpecmaticJUnitSupport ?: return
+        testInstance.report()
     }
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -51,7 +51,9 @@ data class API(
 open class SpecmaticJUnitSupport {
     private val settings = ContractTestSettings(settingsStaging)
 
-    private val specmaticConfig: SpecmaticConfig? = loadSpecmaticConfigOrDefault(getConfigFilePath())
+    private val specmaticConfig: SpecmaticConfig? =
+        settings.adjust(loadSpecmaticConfigOrDefault(getConfigFilePath()))
+
     private val testFilter = ScenarioMetadataFilter.from(settings.filter)
 
     companion object {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -39,6 +39,7 @@ import org.opentest4j.TestAbortedException
 import java.io.File
 import java.net.URI
 import java.util.*
+import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.stream.Stream
 import kotlin.streams.asStream
 
@@ -73,7 +74,7 @@ data class ContractTestSettings(
 open class SpecmaticJUnitSupport {
     private val settings = ContractTestSettings(settingsStaging)
 
-    private val specmaticConfig: SpecmaticConfig = loadSpecmaticConfigOrDefault(getConfigFilePath())
+    private val specmaticConfig: SpecmaticConfig? = loadSpecmaticConfigOrDefault(getConfigFilePath())
     private val testFilter = ScenarioMetadataFilter.from(settings.filter)
 
     companion object {
@@ -99,7 +100,7 @@ open class SpecmaticJUnitSupport {
         private const val ENDPOINTS_API = "endpointsAPI"
         private const val SWAGGER_UI_BASEURL = "swaggerUIBaseURL"
 
-        val partialSuccesses: MutableList<Result.Success> = mutableListOf()
+        val partialSuccesses: ConcurrentLinkedDeque<Result.Success> = ConcurrentLinkedDeque()
     }
 
     internal var openApiCoverageReportInput: OpenApiCoverageReportInput = OpenApiCoverageReportInput(getConfigFileWithAbsolutePath())
@@ -231,6 +232,8 @@ open class SpecmaticJUnitSupport {
 
     @TestFactory
     fun contractTest(): Stream<DynamicTest> {
+        partialSuccesses.clear()
+
         val givenWorkingDirectory = System.getProperty(WORKING_DIRECTORY)
         val filterName: String? = System.getProperty(FILTER_NAME_PROPERTY) ?: System.getenv(FILTER_NAME_ENVIRONMENT_VARIABLE)
         val filterNotName: String? = System.getProperty(FILTER_NOT_NAME_PROPERTY) ?: System.getenv(FILTER_NOT_NAME_ENVIRONMENT_VARIABLE)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -21,9 +21,6 @@ import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.Value
 import io.specmatic.stub.hasOpenApiFileExtension
 import io.specmatic.stub.isOpenAPI
-import io.specmatic.test.SpecmaticJUnitSupport.Companion.CONTRACT_PATHS
-import io.specmatic.test.SpecmaticJUnitSupport.Companion.FILTER
-import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.reports.OpenApiCoverageReportProcessor
 import io.specmatic.test.reports.TestReportHooks
 import io.specmatic.test.reports.coverage.Endpoint
@@ -48,26 +45,6 @@ data class API(
     val method: String,
     val path: String,
 )
-
-data class ContractTestSettings(
-    val testBaseURL: String?,
-    val contractPaths: String?,
-    val filter: String,
-    val configFile: String,
-    val specmaticConfig: SpecmaticConfig?,
-) {
-    internal constructor(contractTestSettings: ThreadLocal<ContractTestSettings?>) : this(
-        testBaseURL = contractTestSettings.get()?.testBaseURL ?: System.getProperty(TEST_BASE_URL),
-        contractPaths = contractTestSettings.get()?.contractPaths ?: System.getProperty(CONTRACT_PATHS),
-        filter = contractTestSettings.get()?.filter ?: readEnvVarOrProperty(FILTER, FILTER).orEmpty(),
-        configFile = contractTestSettings.get()?.configFile ?: getConfigFilePath(),
-        specmaticConfig =
-            contractTestSettings.get()?.specmaticConfig
-                ?: contractTestSettings.get()?.configFile?.let {
-                    loadSpecmaticConfigOrDefault(it)
-                } ?: loadSpecmaticConfigOrDefault(getConfigFilePath()),
-    )
-}
 
 @Execution(ExecutionMode.CONCURRENT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -43,7 +43,7 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
         return reportConfiguration.mapRenderers { formatterType: ReportFormatterType ->
             when (formatterType) {
                 ReportFormatterType.TEXT -> CoverageReportTextRenderer()
-                ReportFormatterType.HTML -> CoverageReportHtmlRenderer()
+                ReportFormatterType.HTML -> CoverageReportHtmlRenderer(openApiCoverageReportInput)
                 else -> throw Exception("Report formatter type: $formatterType is not supported")
             }
         }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import java.io.File
 
-class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: OpenApiCoverageReportInput ): ReportProcessor<OpenAPICoverageConsoleReport> {
+class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: OpenApiCoverageReportInput, private val reportBaseDirectory: String): ReportProcessor<OpenAPICoverageConsoleReport> {
     companion object {
         const val JSON_REPORT_PATH = "./build/reports/specmatic"
         const val JSON_REPORT_FILE_NAME = "coverage_report.json"
@@ -59,7 +59,7 @@ class OpenApiCoverageReportProcessor (private val openApiCoverageReportInput: Op
             encodeDefaults = false
         }
         val reportJson = json.encodeToString(openApiCoverageJsonReport)
-        val directory = File(JSON_REPORT_PATH)
+        val directory = File(reportBaseDirectory).resolve(JSON_REPORT_PATH)
         directory.mkdirs()
         val file = File(directory, JSON_REPORT_FILE_NAME)
         file.writeText(reportJson)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/OpenApiCoverageReportProcessor.kt
@@ -43,7 +43,7 @@ class OpenApiCoverageReportProcessor(private val openApiCoverageReportInput: Ope
         return reportConfiguration.mapRenderers { formatterType: ReportFormatterType ->
             when (formatterType) {
                 ReportFormatterType.TEXT -> CoverageReportTextRenderer()
-                ReportFormatterType.HTML -> CoverageReportHtmlRenderer(openApiCoverageReportInput)
+                ReportFormatterType.HTML -> CoverageReportHtmlRenderer(openApiCoverageReportInput, reportBaseDirectory)
                 else -> throw Exception("Report formatter type: $formatterType is not supported")
             }
         }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/html/HtmlReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/html/HtmlReport.kt
@@ -15,8 +15,9 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 
-class HtmlReport(private val htmlReportInformation: HtmlReportInformation) {
-    private val outputDirectory = htmlReportInformation.reportFormat.getOutputDirectoryOrDefault()
+class HtmlReport(private val htmlReportInformation: HtmlReportInformation, private val baseDir: String? = null) {
+    private val configuredOutputDirectory = htmlReportInformation.reportFormat.getOutputDirectoryOrDefault()
+    private val outputDirectory = baseDir?.let { File(it).resolve(configuredOutputDirectory).path } ?: configuredOutputDirectory
     private val apiSuccessCriteria = htmlReportInformation.successCriteria
     private val reportFormat = htmlReportInformation.reportFormat
     private val reportData = htmlReportInformation.reportData

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
@@ -20,7 +20,7 @@ import io.specmatic.test.reports.coverage.html.*
 
 typealias GroupedScenarioData = Map<String, Map<String, Map<String, Map<String, List<ScenarioData>>>>>
 
-class CoverageReportHtmlRenderer(openApiCoverageReportInput: OpenApiCoverageReportInput) : ReportRenderer<OpenAPICoverageConsoleReport> {
+class CoverageReportHtmlRenderer(openApiCoverageReportInput: OpenApiCoverageReportInput, val baseDir: String) : ReportRenderer<OpenAPICoverageConsoleReport> {
     val actuatorEnabled = openApiCoverageReportInput.endpointsAPISet
 
     override fun render(report: OpenAPICoverageConsoleReport, specmaticConfig: SpecmaticConfig): String {
@@ -42,7 +42,7 @@ class CoverageReportHtmlRenderer(openApiCoverageReportInput: OpenApiCoverageRepo
             isGherkinReport = report.isGherkinReport
         )
 
-        HtmlReport(htmlReportInformation).generate()
+        HtmlReport(htmlReportInformation, baseDir).generate()
         return "Successfully generated HTML report in ${htmlReportConfiguration.getOutputDirectoryOrDefault()}"
     }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportHtmlRenderer.kt
@@ -13,17 +13,15 @@ import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.TestInteractionsLog.displayName
 import io.specmatic.test.TestInteractionsLog.duration
 import io.specmatic.test.TestResultRecord
+import io.specmatic.test.reports.coverage.OpenApiCoverageReportInput
 import io.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport
 import io.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
 import io.specmatic.test.reports.coverage.html.*
 
 typealias GroupedScenarioData = Map<String, Map<String, Map<String, Map<String, List<ScenarioData>>>>>
 
-class CoverageReportHtmlRenderer : ReportRenderer<OpenAPICoverageConsoleReport> {
-
-    companion object {
-        val actuatorEnabled = SpecmaticJUnitSupport.openApiCoverageReportInput.endpointsAPISet
-    }
+class CoverageReportHtmlRenderer(openApiCoverageReportInput: OpenApiCoverageReportInput) : ReportRenderer<OpenAPICoverageConsoleReport> {
+    val actuatorEnabled = openApiCoverageReportInput.endpointsAPISet
 
     override fun render(report: OpenAPICoverageConsoleReport, specmaticConfig: SpecmaticConfig): String {
         logger.log("Generating HTML report...")

--- a/junit5-support/src/test/kotlin/io/specmatic/test/FilterIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/FilterIntegrationTest.kt
@@ -26,7 +26,9 @@ class FilterIntegrationTest {
     fun contractTestWithDifferentFilters(filter: String, expectedSuccessfulTestCount: Int) {
         System.setProperty("filter", filter)
 
-        SpecmaticJUnitSupport().contractTest().forEach {
+        val contractTestHarness = SpecmaticJUnitSupport()
+
+        contractTestHarness.contractTest().forEach {
             try {
                 it.executable.execute()
             } catch(e: Throwable) {
@@ -34,7 +36,7 @@ class FilterIntegrationTest {
             }
         }
 
-        val count = SpecmaticJUnitSupport.openApiCoverageReportInput.generate().testResultRecords.count {
+        val count = contractTestHarness.openApiCoverageReportInput.generate().testResultRecords.count {
             it.result == TestResult.Success
         }
         assertEquals(expectedSuccessfulTestCount, count)

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -155,7 +155,9 @@ class SpecmaticJunitSupportTest {
 
     @Test
     fun `should be able to get actuator endpoints from swaggerUI`() {
-        SpecmaticJUnitSupport.actuatorFromSwagger("", object: TestExecutor {
+        val contractTestHarness = SpecmaticJUnitSupport()
+
+        contractTestHarness.actuatorFromSwagger("", object: TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
                 return HttpResponse(
                     200,
@@ -199,8 +201,8 @@ class SpecmaticJunitSupportTest {
             }
         })
 
-        assertThat(SpecmaticJUnitSupport.openApiCoverageReportInput.endpointsAPISet).isTrue()
-        assertThat(SpecmaticJUnitSupport.openApiCoverageReportInput.getApplicationAPIs()).isEqualTo(listOf(
+        assertThat(contractTestHarness.openApiCoverageReportInput.endpointsAPISet).isTrue()
+        assertThat(contractTestHarness.openApiCoverageReportInput.getApplicationAPIs()).isEqualTo(listOf(
             API("POST", "/orders"),
             API("POST", "/products"),
             API("GET", "/findAvailableProducts/{date_time}")


### PR DESCRIPTION
**What**:

Added infra for configuring each test instance independently, and for storing reports in specific directories

**Why**:

Useful for when we want to run multiple instances of test and stub in parallel.

