### PR TITLE
Per-spec resiliency test config improvements

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -763,12 +763,12 @@ data class Source(
         }?.toMap() ?: test.orEmpty().associateWith { null }
     }
 
-    fun specToTestGenerativeMap(): Map<String, io.specmatic.core.config.v3.Generative?> {
+    fun specToTestGenerativeMap(): Map<String, ResiliencyTestSuite?> {
         return testConsumes?.flatMap {
             when (it) {
                 is SpecExecutionConfig.StringValue -> listOf(it.value to null)
                 is SpecExecutionConfig.ObjectValue -> it.specs.map { specPath ->
-                    specPath to it.generative
+                    specPath to it.resiliencyTests?.enable
                 }
             }
         }?.toMap() ?: emptyMap()

--- a/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/ContractSource.kt
@@ -1,6 +1,6 @@
 package io.specmatic.core.utilities
 
-import io.specmatic.core.config.v3.Generative
+import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.git.NonZeroExitError
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.git.exitErrorMessageContains
@@ -9,7 +9,7 @@ import java.io.File
 data class ContractSourceEntry(
     val path: String,
     val baseUrl: String? = null,
-    val generative: Generative? = null
+    val generative: ResiliencyTestSuite? = null
 )
 
 sealed interface ContractSource {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -12,8 +12,8 @@ import io.specmatic.core.KeyData
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.azure.AzureAuthCredentials
-import io.specmatic.core.config.v3.Generative
 import io.specmatic.core.git.GitCommand
+import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.log.consoleDebug
@@ -298,7 +298,7 @@ data class ContractPathData(
     val branch: String? = null,
     val specificationPath: String? = null,
     val baseUrl: String? = null,
-    val generative: Generative? = null,
+    val generative: ResiliencyTestSuite? = null,
     val port: Int? = null
 ) {
     companion object {


### PR DESCRIPTION
**What**:

Update the support for `resiliencyTests` config per spec in `provides` to mirror what it is in the top-level `test` config.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
