### PR TITLE
Fix NPE caused when setting expectation with a partial example

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -1,5 +1,6 @@
 package io.specmatic.conversions
 
+import io.ktor.http.decodeURLPart
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.NoBodyValue
@@ -136,7 +137,7 @@ class ExampleFromFile(val json: JSONObjectValue, val file: File) {
         }
 
     private val rawPath: String? =
-        json.findByPath("http-request.path")?.toStringLiteral()
+        json.findByPath("http-request.path")?.toStringLiteral()?.decodeURLPart()
 
     val requestPath: String? = attempt("Error reading path in file ${file.canonicalPath}") {
         rawPath?.let { pathOnly(it) }

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -848,7 +848,7 @@ data class Feature(
         }
 
         val results = scenarios.asSequence().map { scenario ->
-            scenario.matchesPartial(scenarioStub.partial) to scenario
+            scenario.matchesPartial(scenarioStub.partial).updateScenario(scenario).updatePath(path) to scenario
         }
 
         val matchingScenario = results.filter { it.first is Result.Success }.map { it.second }.firstOrNull()

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -91,7 +91,7 @@ data class HttpRequest(
 
     fun updatePath(path: String): HttpRequest {
         return try {
-            val urlParam = URI(path)
+            val urlParam = URI(path.decodeURLPart())
             updateWith(urlParam)
         } catch (e: URISyntaxException) {
             val pieces = path.split("?", limit = 2)

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -624,7 +624,7 @@ class HttpStub(
                 }.flatten().toList()
 
                 val failureResults = Results(failures).withoutFluff()
-                throw NoMatchingScenario(failureResults, cachedMessage = failureResults.report(stub.request))
+                throw NoMatchingScenario(failureResults, cachedMessage = failureResults.report(stub.requestElsePartialRequest()))
             }
 
             else -> {

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -598,10 +598,14 @@ class PartialExampleTest {
 
         val (output, _) = captureStandardOutput { createStubFromContracts(listOf(apiSpecification), listOf(examplesDir)).also { it.close() } }
         val exampleFile = osAgnosticPath("src/test/resources/openapi/partial_example_tests/bad_request_invalid_example/pets_post.json")
+        val apiSpecFile = osAgnosticPath(apiSpecification)
 
         print(output)
         assertThat(output).containsIgnoringWhitespaces("""
         Could not load partial example $exampleFile
+        Error from contract $apiSpecFile
+        In scenario "PATCH /creators/(creatorId:number)/pets/(petId:number). Response: bad request"
+        API: PATCH /creators/(creatorId:number)/pets/(petId:number) -> 400
         >> RESPONSE.BODY.code
         Expected number, actual was "400"
         >> RESPONSE.BODY.message


### PR DESCRIPTION
**What**: Fix NPE caused when setting expectation with a partial example

**How**: Utilize `requestElsePartialRequest` in place of `request` on `ScenarioStub` for reporting, which can handle partials

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)