### PR TITLE
Fix for the logical path shadowing issue

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpPathPattern.kt
@@ -98,12 +98,6 @@ data class HttpPathPattern(
         val structureMatches = structureMatches(path, resolver)
         if (!structureMatches) return finalMatchResult.withFailureReason(FailureReason.URLPathMisMatch)
 
-        // If there are basic pattern matching failures but structure matches, return URLPathParamMismatchButSameStructure
-        if (failures.isNotEmpty()) {
-            return finalMatchResult.withFailureReason(FailureReason.URLPathParamMismatchButSameStructure)
-        }
-
-        // Check for conflicts with other path patterns based on specificity
         val matchingOtherPatterns = otherPathPatterns.filter { otherPattern ->
             otherPattern.path != this.path && otherPattern.matches(path, resolver).isSuccess()
         }
@@ -121,6 +115,10 @@ data class HttpPathPattern(
                     failureReason = FailureReason.URLPathParamMatchButConflict
                 )
             }
+        }
+
+        if (failures.isNotEmpty()) {
+            return finalMatchResult.withFailureReason(FailureReason.URLPathParamMismatchButSameStructure)
         }
 
         return Success()

--- a/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/URLPathSegmentPattern.kt
@@ -7,17 +7,9 @@ import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.Value
 
-data class URLPathSegmentPattern(override val pattern: Pattern, override val key: String? = null, override val typeAlias: String? = null, val conflicts: Set<String> = emptySet()) : Pattern, Keyed {
+data class URLPathSegmentPattern(override val pattern: Pattern, override val key: String? = null, override val typeAlias: String? = null) : Pattern, Keyed {
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
-        val result = resolver.matchesPattern(key, pattern, sampleData ?: NullValue)
-        if (result.isSuccess() && sampleData?.toStringLiteral() in conflicts) {
-            return Result.Failure(
-                "Value ${sampleData?.displayableValue()} conflicts with an existing path using the same prefix",
-                failureReason = FailureReason.URLPathParamMatchButConflict
-            )
-        }
-
-        return result
+        return resolver.matchesPattern(key, pattern, sampleData ?: NullValue)
     }
 
     override fun generate(resolver: Resolver): Value {

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -100,6 +100,20 @@ internal class HttpPathPatternTest {
         assertThat((result as Result.Failure).reportString()).contains("matches a more specific pattern")
     }
 
+    @Test
+    fun `should not conflict when otherPathPatterns is empty representing different HTTP methods`() {
+        val postPattern = HttpPathPattern(listOf(
+            URLPathSegmentPattern(StringPattern(), "section"),
+            URLPathSegmentPattern(StringPattern(), "version"),
+            URLPathSegmentPattern(ExactValuePattern(StringValue("users")))
+        ), path = "/(section:String)/(version:String)/users", otherPathPatterns = emptyList())
+        
+        // This should succeed because there are no conflicting patterns in the same HTTP method
+        val result = postPattern.matches("api/v1/users", Resolver())
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
     @ParameterizedTest
     @CsvSource(
         "/pets/(id:number), /pets/abc",

--- a/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpPathPatternTest.kt
@@ -32,9 +32,9 @@ internal class HttpPathPatternTest {
     )
     fun `should match path when structure matches and not all segments conflict`(path: String) {
         val pattern = HttpPathPattern(listOf(
-            URLPathSegmentPattern(StringPattern(), "first", conflicts = setOf("a")),
-            URLPathSegmentPattern(StringPattern(), "second", conflicts = setOf("b")),
-            URLPathSegmentPattern(StringPattern(), "third", conflicts = setOf("c"))
+            URLPathSegmentPattern(StringPattern(), "first"),
+            URLPathSegmentPattern(StringPattern(), "second"),
+            URLPathSegmentPattern(StringPattern(), "third")
         ), path = "/(first:String)/(second:String)/(third:String)")
         val result = pattern.matches(path, Resolver())
 
@@ -44,9 +44,9 @@ internal class HttpPathPatternTest {
     @Test
     fun `should match not path when structure does matches and there are some segment conflicts`() {
         val pattern = HttpPathPattern(listOf(
-            URLPathSegmentPattern(NumberPattern(), "first", conflicts = setOf("a")),
-            URLPathSegmentPattern(StringPattern(), "second", conflicts = setOf("b")),
-            URLPathSegmentPattern(StringPattern(), "third", conflicts = setOf("c"))
+            URLPathSegmentPattern(NumberPattern(), "first"),
+            URLPathSegmentPattern(StringPattern(), "second"),
+            URLPathSegmentPattern(StringPattern(), "third")
         ), path = "/(first:number)/(second:String)/(third:String)")
         val result = pattern.matches("/a/b/1", Resolver())
 
@@ -54,26 +54,50 @@ internal class HttpPathPatternTest {
     }
 
     @Test
-    fun `should return failure when path conflicts with an existing path even if structure and data type matches`() {
-        val pattern = HttpPathPattern(listOf(
-            URLPathSegmentPattern(StringPattern(), "first", conflicts = setOf("a")),
-            URLPathSegmentPattern(StringPattern(), "second", conflicts = setOf("b")),
-            URLPathSegmentPattern(StringPattern(), "third", conflicts = setOf("c"))
+    fun `should return success when path matches and no other patterns conflict based on specificity`() {
+        // Create a pattern with other less specific patterns that should not conflict
+        val lessSpecificPattern1 = HttpPathPattern(listOf(
+            URLPathSegmentPattern(StringPattern(), "first"),
+            URLPathSegmentPattern(StringPattern(), "second"),
+            URLPathSegmentPattern(StringPattern(), "third")
         ), path = "/(first:String)/(second:String)/(third:String)")
+        
+        val lessSpecificPattern2 = HttpPathPattern(listOf(
+            URLPathSegmentPattern(StringPattern(), "param"),
+            URLPathSegmentPattern(StringPattern(), "second")
+        ), path = "/(param:String)/(second:String)")
+
+        val pattern = HttpPathPattern(listOf(
+            URLPathSegmentPattern(ExactValuePattern(StringValue("a"))),
+            URLPathSegmentPattern(ExactValuePattern(StringValue("b"))),
+            URLPathSegmentPattern(ExactValuePattern(StringValue("c")))
+        ), path = "/a/b/c", otherPathPatterns = listOf(lessSpecificPattern1, lessSpecificPattern2))
+        
         val result = pattern.matches("a/b/c", Resolver())
 
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `should return failure when path matches a more specific pattern based on specificity`() {
+        // Create a more specific pattern (with more ExactValuePattern segments)
+        val moreSpecificPattern = HttpPathPattern(listOf(
+            URLPathSegmentPattern(ExactValuePattern(StringValue("api"))),
+            URLPathSegmentPattern(ExactValuePattern(StringValue("v1"))),
+            URLPathSegmentPattern(ExactValuePattern(StringValue("users")))
+        ), path = "/api/v1/users")
+
+        // Create a less specific pattern (with fewer ExactValuePattern segments)
+        val lessSpecificPattern = HttpPathPattern(listOf(
+            URLPathSegmentPattern(StringPattern(), "section"),
+            URLPathSegmentPattern(StringPattern(), "version"),
+            URLPathSegmentPattern(ExactValuePattern(StringValue("users")))
+        ), path = "/(section:String)/(version:String)/users", otherPathPatterns = listOf(moreSpecificPattern))
+        
+        val result = lessSpecificPattern.matches("api/v1/users", Resolver())
+
         assertThat(result).isInstanceOf(Result.Failure::class.java)
-        assertThat((result as Result.Failure).hasReason(FailureReason.URLPathParamMatchButConflict)).isTrue()
-        assertThat(result.reportString()).isEqualToNormalizingWhitespace("""
-        >> PATH
-        Path segments of URL a/b/c overlap with another URL that has the same structure
-        >> PARAMETERS.PATH.first
-        Value "a" conflicts with an existing path using the same prefix
-        >> PARAMETERS.PATH.second
-        Value "b" conflicts with an existing path using the same prefix
-        >> PARAMETERS.PATH.third
-        Value "c" conflicts with an existing path using the same prefix
-        """.trimIndent())
+        assertThat((result as Result.Failure).reportString()).contains("matches a more specific pattern")
     }
 
     @ParameterizedTest


### PR DESCRIPTION
**What**:

If the following paths exist in the spec:
- /a/b/{path-param}
- /a/b/c

The path /a/b/c matches both. But because one is more specific than the other, it should be considered to match /a/b/c.

The previous implementation of this worked for simpler cases, but it was more confusing when there were multiple params, such as below:

- /{path-param}/b/{path-param}
- /{path-param}/b/c

The path matcher would get confused in the above case and might match /a/b/c to the first instead of the second.

**How**:

The logic looking for a more specific match has been cleaned up / simplified.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
