### PR TITLE
Cleaner match-branch config

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -395,12 +395,14 @@ data class SpecmaticConfig(
             val testGenerativeMap = source.specToTestGenerativeMap()
             val testPaths = testBaseUrlMap.entries.map { ContractSourceEntry(it.key, it.value, testGenerativeMap[it.key]) }
 
-            val effectiveBranch = getEffectiveBranchForSource(source.branch, useCurrentBranchForCentralRepo)
+            val sourceMatchBranch = source.matchBranch ?: false
+            val effectiveUseCurrentBranch = useCurrentBranchForCentralRepo || sourceMatchBranch
+            val effectiveBranch = getEffectiveBranchForSource(source.branch, effectiveUseCurrentBranch)
 
             when (source.provider) {
                 git -> when (source.repository) {
                     null -> GitMonoRepo(testPaths, stubPaths, source.provider.toString())
-                    else -> GitRepo(source.repository, effectiveBranch, testPaths, stubPaths, source.provider.toString(), useCurrentBranchForCentralRepo)
+                    else -> GitRepo(source.repository, effectiveBranch, testPaths, stubPaths, source.provider.toString(), effectiveUseCurrentBranch)
                 }
 
                 filesystem -> LocalFileSystemSource(source.directory ?: ".", testPaths, stubPaths)
@@ -735,6 +737,7 @@ data class Source(
     val stub: List<SpecExecutionConfig>? = null,
     val directory: String? = null,
     @JsonIgnore val testConsumes: List<SpecExecutionConfig>? = null,
+    val matchBranch: Boolean? = null,
 ) {
     constructor(test: List<String>? = null, stub: List<String>? = null) : this(
         test = test,

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
@@ -71,9 +71,10 @@ data class ContractConfig(
 
     data class GitContractSource(
         val url: String? = null,
-        val branch: String? = null
+        val branch: String? = null,
+        val matchBranch: Boolean? = null
     ) : ContractSource {
-        constructor(source: Source) : this(source.repository, source.branch)
+        constructor(source: Source) : this(source.repository, source.branch, source.matchBranch)
 
         override fun transform(provides: List<SpecExecutionConfig>?, consumes: List<SpecExecutionConfig>?): Source {
             val testSpecs = provides?.flatMap { p -> when(p) { is SpecExecutionConfig.StringValue -> listOf(p.value); is SpecExecutionConfig.ObjectValue -> p.specs } }
@@ -87,7 +88,8 @@ data class ContractConfig(
                 branch = this.branch,
                 test = testSpecs,
                 stub = consumes.orEmpty(),
-                testConsumes = testSpecExecutionConfigOrNull
+                testConsumes = testSpecExecutionConfigOrNull,
+                matchBranch = this.matchBranch
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -22,7 +22,6 @@ import org.eclipse.jgit.lib.BranchConfig
 data class SpecmaticConfigV2(
     val version: SpecmaticConfigVersion,
     val contracts: List<ContractConfig> = emptyList(),
-    val matchBranch: Boolean? = null,
     val auth: Auth? = null,
     val pipeline: Pipeline? = null,
     val environments: Map<String, Environment>? = null,
@@ -48,7 +47,6 @@ data class SpecmaticConfigV2(
         return SpecmaticConfig(
             version = currentConfigVersion(),
             sources = this.contracts.map { contract -> contract.transform() },
-            matchBranch = this.matchBranch,
             auth = this.auth,
             pipeline = this.pipeline,
             environments = this.environments,

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -427,6 +427,34 @@ internal class SpecmaticConfigAllTest {
     }
 
     @Test
+    fun `should deserialize ContractConfigV2 successfully when matchBranch is present in git config`() {
+        val contractConfigYaml = """
+            git:
+              url: https://contracts
+              branch: main
+              matchBranch: true
+            provides:
+              - com/petstore/1.yaml
+            consumes:
+              - com/petstore/payment.yaml
+        """.trimIndent()
+
+        val contractConfig = objectMapper.readValue(contractConfigYaml, ContractConfig::class.java)
+
+        assertThat(contractConfig.contractSource).isInstanceOf(GitContractSource::class.java)
+        val gitContractSource = contractConfig.contractSource as GitContractSource
+        assertThat(gitContractSource.url).isEqualTo("https://contracts")
+        assertThat(gitContractSource.branch).isEqualTo("main")
+        assertThat(gitContractSource.matchBranch).isEqualTo(true)
+        assertThat(contractConfig.provides).containsOnly(SpecExecutionConfig.StringValue("com/petstore/1.yaml"))
+        assertThat(contractConfig.consumes).containsOnly(SpecExecutionConfig.StringValue("com/petstore/payment.yaml"))
+        
+        // Test that the matchBranch is properly transformed to Source
+        val source = contractConfig.transform()
+        assertThat(source.matchBranch).isEqualTo(true)
+    }
+
+    @Test
     fun `should deserialize SpecmaticConfig successfully when VirtualService key is present`(@TempDir tempDir: File) {
         val configFile = tempDir.resolve("specmatic.yaml")
         val configYaml = """


### PR DESCRIPTION
**What**:

Add per-source and top-level matchBranch configuration to control when the central repo follows the current git branch.

**Why**:

- matchBranch is only relevant when git is selected for a particular source.

**How**:

- Update config with the relevant property changes. `matchBranch` is now invalid at the top-level.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
