### PR TITLE
chore: add categories to the help output

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    shadow("io.specmatic.build-reporter:specmatic-reporter:0.0.22")
+    implementation("io.specmatic.build-reporter:specmatic-reporter:0.0.22")
 
     implementation("io.netty:netty-codec-http:4.2.5.Final")
     implementation("joda-time:joda-time:2.14.0")

--- a/application/src/main/kotlin/application/CentralContractRepoReportCommand.kt
+++ b/application/src/main/kotlin/application/CentralContractRepoReportCommand.kt
@@ -2,6 +2,7 @@ package application
 
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.saveJsonFile
+import io.specmatic.license.core.cli.Category
 import io.specmatic.reports.CentralContractRepoReport
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -13,6 +14,7 @@ import java.util.concurrent.Callable
     mixinStandardHelpOptions = true,
     description = ["Generate the Central Contract Repo Report"]
 )
+@Category("Specmatic core")
 class CentralContractRepoReportCommand : Callable<Unit> {
 
     companion object {

--- a/application/src/main/kotlin/application/CompareCommand.kt
+++ b/application/src/main/kotlin/application/CompareCommand.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.*
 import io.specmatic.core.log.logger
 import io.specmatic.core.log.logException
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.license.core.cli.Category
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
@@ -18,6 +19,7 @@ Checks if two contracts are equivalent.
 DEPRECATED: This command will be removed in the next major release. Use 'backward-compatibility-check' command instead.
 """
         ])
+@Category("Specmatic core")
 class CompareCommand : Callable<Unit> {
     @Parameters(index = "0", description = ["Older contract file path"])
     lateinit var olderContractFilePath: String
@@ -76,4 +78,3 @@ fun backwardCompatible(olderContract: Feature, newerContract: Feature): Compatib
         } catch(e: Throwable) {
             ExceptionReport(e)
         }
-

--- a/application/src/main/kotlin/application/ConfigCommand.kt
+++ b/application/src/main/kotlin/application/ConfigCommand.kt
@@ -13,6 +13,7 @@ import io.specmatic.core.config.toSpecmaticConfig
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exitWithMessage
+import io.specmatic.license.core.cli.Category
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.File
@@ -34,6 +35,7 @@ private const val SPECMATIC_CONFIGURATION = "Specmatic Configuration"
         ConfigCommand.Upgrade::class
     ]
 )
+@Category("Specmatic core")
 class ConfigCommand : Callable<Int> {
     override fun call(): Int {
         println("Use a subcommand. Use --help for more details.")

--- a/application/src/main/kotlin/application/ExamplesCommand.kt
+++ b/application/src/main/kotlin/application/ExamplesCommand.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.log.NonVerbose
 import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.capitalizeFirstChar
+import io.specmatic.license.core.cli.Category
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.*
@@ -26,6 +27,7 @@ private const val FAILURE_EXIT_CODE = 1
     description = ["Validate inline and externalised examples"],
     subcommands = [ExamplesCommand.Validate::class]
 )
+@Category("Specmatic core")
 class ExamplesCommand : Callable<Int> {
 
     override fun call(): Int {

--- a/application/src/main/kotlin/application/ImportCommand.kt
+++ b/application/src/main/kotlin/application/ImportCommand.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.utilities.jsonStringToValueMap
 import io.specmatic.core.utilities.parseXML
 import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.WSDL
+import io.specmatic.license.core.cli.Category
 import io.specmatic.mock.mockFromJSON
 import io.swagger.v3.core.util.Yaml
 import java.io.File
@@ -20,6 +21,7 @@ import java.util.concurrent.Callable
 @Command(name = "import",
         mixinStandardHelpOptions = true,
         description = ["Converts a $APPLICATION_NAME stub, Postman or WSDL file into a $APPLICATION_NAME spec file"])
+@Category("Contract conversion")
 class ImportCommand : Callable<Int> {
     @Parameters(description = ["File to convert"], index = "0")
     lateinit var path: String

--- a/application/src/main/kotlin/application/ProxyCommand.kt
+++ b/application/src/main/kotlin/application/ProxyCommand.kt
@@ -9,6 +9,7 @@ import io.specmatic.core.log.*
 import io.specmatic.core.utilities.consolePrintableURL
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.utilities.exitWithMessage
+import io.specmatic.license.core.cli.Category
 import io.specmatic.proxy.Proxy
 import java.io.File
 import java.lang.Thread.sleep
@@ -17,6 +18,7 @@ import java.util.concurrent.Callable
 @Command(name = "proxy",
         mixinStandardHelpOptions = true,
         description = ["Proxies requests to the specified target and converts the result into contracts and stubs"])
+@Category("Specmatic core")
 class ProxyCommand : Callable<Unit> {
     @Option(names = ["--target"], description = ["Base URL of the target to proxy"], required = true)
     var targetBaseURL: String = ""

--- a/application/src/main/kotlin/application/SpecmaticApplication.kt
+++ b/application/src/main/kotlin/application/SpecmaticApplication.kt
@@ -20,6 +20,7 @@ open class SpecmaticApplication {
             }
 
             val commandLine = CommandLine(SpecmaticCommand())
+            SpecmaticCoreSubcommands.configure(commandLine)
             if (args.none { it == "-V" || it == "--version" }) {
                 print("Specmatic Version: ")
                 commandLine.printVersionHelp(System.out)

--- a/application/src/main/kotlin/application/SpecmaticCommand.kt
+++ b/application/src/main/kotlin/application/SpecmaticCommand.kt
@@ -2,36 +2,39 @@ package application
 
 import application.backwardCompatibility.BackwardCompatibilityCheckCommandV2
 import application.mcp.McpBaseCommand
-import io.specmatic.license.core.cli.FetchLicenseCommand
-import io.specmatic.reporter.commands.SendReportCommand
-import picocli.AutoComplete.GenerateCompletion
+import io.specmatic.license.core.cli.CliConfigurer
+import io.specmatic.reporter.commands.ReporterSubcommands
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import java.util.concurrent.Callable
 
 @Command(
-        name = "specmatic",
-        mixinStandardHelpOptions = true,
-        versionProvider = VersionProvider::class,
-        scope = CommandLine.ScopeType.INHERIT,
-        subcommands = [
-            BackwardCompatibilityCheckCommandV2::class,
-            CompareCommand::class,
-            GenerateCompletion::class,
-            ImportCommand::class,
-            ProxyCommand::class,
-            ExamplesCommand::class,
-            StubCommand::class,
-            TestCommand::class,
-            CentralContractRepoReportCommand::class,
-            ConfigCommand::class,
-            McpBaseCommand::class,
-            FetchLicenseCommand::class,
-            SendReportCommand::class
-        ]
+    name = "specmatic",
+    mixinStandardHelpOptions = true,
+    versionProvider = VersionProvider::class,
+    scope = CommandLine.ScopeType.INHERIT,
+    subcommands = [
+    ]
 )
 class SpecmaticCommand : Callable<Int> {
     override fun call(): Int {
         return 0
     }
+}
+
+
+object SpecmaticCoreSubcommands : CliConfigurer {
+    override fun subcommands() = arrayOf(
+        BackwardCompatibilityCheckCommandV2(),
+        CompareCommand(),
+        ImportCommand(),
+        ProxyCommand(),
+        ExamplesCommand(),
+        StubCommand(),
+        TestCommand(),
+        CentralContractRepoReportCommand(),
+        ConfigCommand(),
+        McpBaseCommand(),
+        *ReporterSubcommands.subcommands(),
+    )
 }

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -14,6 +14,7 @@ import io.specmatic.core.loadSpecmaticConfigOrNull
 import io.specmatic.core.utilities.Flags.Companion.MATCH_BRANCH
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_BASE_URL
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
+import io.specmatic.license.core.cli.Category
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
@@ -29,6 +30,7 @@ import java.util.concurrent.Callable
     mixinStandardHelpOptions = true,
     description = ["Start a stub server with contract"]
 )
+@Category("Specmatic core")
 class StubCommand(
     private val httpStubEngine: HTTPStubEngine = HTTPStubEngine(),
     private val stubLoaderEngine: StubLoaderEngine = StubLoaderEngine(),

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -17,6 +17,7 @@ import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.loadSpecmaticConfigOrNull
 import io.specmatic.core.utilities.newXMLBuilder
 import io.specmatic.core.utilities.xmlToString
+import io.specmatic.license.core.cli.Category
 import io.specmatic.test.SpecmaticJUnitSupport
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.CONTRACT_PATHS
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.ENV_NAME
@@ -58,6 +59,7 @@ private const val DISPLAY_NAME_PREFIX_IN_SYSTEM_OUT_TAG_TEXT = "display-name: "
 @Command(name = "test",
         mixinStandardHelpOptions = true,
         description = ["Run contract tests"])
+@Category("Specmatic core")
 class TestCommand(private val junitLauncher: Launcher = LauncherFactory.create()) : Callable<Unit> {
 
     @CommandLine.Parameters(arity = "0..*", description = ["Contract file paths"])

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -6,6 +6,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
+import io.specmatic.license.core.cli.Category
 import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.Command
 import java.io.File
@@ -20,7 +21,8 @@ import kotlin.io.path.pathString
     mixinStandardHelpOptions = true,
     description = ["Checks backward compatibility of OpenAPI specifications"]
 )
-class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand() {
+@Category("Specmatic core")
+class BackwardCompatibilityCheckCommandV2 : BackwardCompatibilityCheckBaseCommand() {
 
     override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): Results {
         return testBackwardCompatibility(oldFeature as Feature, newFeature as Feature)
@@ -30,7 +32,7 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
         return try {
             ObjectMapper(YAMLFactory()).readValue(string, Map::class.java)
             true
-        } catch(e: Throwable) {
+        } catch (e: Throwable) {
             false
         }
     }
@@ -39,7 +41,7 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
         return try {
             ObjectMapper().readValue(string, Map::class.java)
             true
-        } catch(e: Throwable) {
+        } catch (e: Throwable) {
             false
         }
     }
@@ -49,7 +51,7 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
 
         val content = this.readText()
 
-        return when(this.extension.lowercase()) {
+        return when (this.extension.lowercase()) {
             "yaml", "yml" -> isYAML(content)
             "json" -> isJSON(content)
             "spec" -> isGherkin(content)
@@ -65,7 +67,7 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
         return try {
             parseGherkinStringToFeature(content)
             true
-        } catch(e: Throwable) {
+        } catch (e: Throwable) {
             false
         }
     }
@@ -152,7 +154,12 @@ class BackwardCompatibilityCheckCommandV2: BackwardCompatibilityCheckBaseCommand
     private fun findSpecFiles(path: Path): List<Path> {
         val extensions = CONTRACT_EXTENSIONS
         return extensions.map { path.resolveSibling(path.fileName.toString() + it) }
-            .filter { Files.exists(it) && (isOpenAPI(it.pathString) || it.extension in listOf(WSDL, CONTRACT_EXTENSION)) }
+            .filter {
+                Files.exists(it) && (isOpenAPI(it.pathString) || it.extension in listOf(
+                    WSDL,
+                    CONTRACT_EXTENSION
+                ))
+            }
     }
 }
 

--- a/application/src/main/kotlin/application/mcp/McpBaseCommand.kt
+++ b/application/src/main/kotlin/application/mcp/McpBaseCommand.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.log.ConsolePrinter
 import io.specmatic.core.log.NonVerbose
 import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
+import io.specmatic.license.core.cli.Category
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
@@ -15,6 +16,7 @@ import java.util.concurrent.Callable
     subcommands = [McpTestCommand::class],
     description = ["Execute Specmatic MCP capabilities"]
 )
+@Category("MCP capabilities")
 class McpBaseCommand : Callable<Int> {
     override fun call(): Int = 0
 

--- a/application/src/main/kotlin/application/mcp/McpTestCommand.kt
+++ b/application/src/main/kotlin/application/mcp/McpTestCommand.kt
@@ -1,6 +1,7 @@
 package application.mcp
 
 import io.specmatic.core.examples.module.FAILURE_EXIT_CODE
+import io.specmatic.license.core.cli.Category
 import io.specmatic.mcp.constants.BASE_URL
 import io.specmatic.mcp.constants.TRANSPORT_KIND
 import io.specmatic.mcp.test.McpAutoTest
@@ -16,6 +17,7 @@ import picocli.CommandLine.Option
     mixinStandardHelpOptions = true,
     description = ["Runs auto tests against a mcp server"]
 )
+@Category("AI Assisted Contract Programming")
 class McpTestCommand : Callable<Int> {
     @Option(
         names = ["--url"],


### PR DESCRIPTION
Updated subcommands so specmatic now categorizes commands:

```
Usage: specmatic [-hV] [COMMAND]
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.

Specmatic core commands:
  backward-compatibility-check  Checks backward compatibility of OpenAPI
                                  specifications
  compare
                                Checks if two contracts are equivalent.
                                DEPRECATED: This command will be removed in the
                                  next major release. Use
                                  'backward-compatibility-check' command
                                  instead.

  proxy                         Proxies requests to the specified target and
                                  converts the result into contracts and stubs
  examples                      Validate inline and externalised examples
  stub, virtualize              Start a stub server with contract
  test                          Run contract tests
  central-contract-repo-report  Generate the Central Contract Repo Report
  config                        Manage and configure Specmatic Configuration.

Contract conversion commands:
  import  Converts a Specmatic stub, Postman or WSDL file into a Specmatic spec
            file

MCP capabilities commands:
  mcp  Execute Specmatic MCP capabilities

Build Reporting commands:
  send-report  Send Specmatic build report to Specmatic Insights Server

License management commands:
  get-license   Fetch a license from a Specmatic Insights Server
  show-license  Display the current Specmatic license
```