### PR TITLE
Accept config object or file in constructor

### DIFF
--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.log.consoleLog
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.HttpStub
+import io.specmatic.stub.SpecmaticConfigSource
 import io.specmatic.stub.contractInfoToHttpExpectations
 import io.specmatic.stub.listener.MockEventListener
 
@@ -37,7 +38,7 @@ class HTTPStubEngine {
             passThroughTargetBase = passThroughTargetBase,
             httpClientFactory = httpClientFactory,
             workingDirectory = workingDirectory,
-            specmaticConfigPath = specmaticConfigPath,
+            specmaticConfigSource = SpecmaticConfigSource.fromPath(specmaticConfigPath),
             timeoutMillis = gracefulRestartTimeoutInMs,
             specToStubBaseUrlMap = specToBaseUrlMap,
             listeners = listeners

--- a/core/src/main/kotlin/io/specmatic/core/Configuration.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Configuration.kt
@@ -9,7 +9,7 @@ fun getConfigFileName(): String = getConfigFilePath()
 fun getConfigFilePath(): String {
     return getStringValue(CONFIG_FILE_PATH)?.takeIf { File(it).exists() }
         ?: getConfigFilePathFromClasspath()?.takeIf { File(it).exists() }
-        ?: getConfigFilePath(".${File.separator}")
+        ?: getConfigFilePath(".")
 }
 
 private fun getConfigFilePathFromClasspath(): String? {
@@ -18,8 +18,11 @@ private fun getConfigFilePathFromClasspath(): String? {
     }
 }
 
-private fun getConfigFilePath(filePathPrefix: String): String {
-    val configFileNameWithoutExtension = "$filePathPrefix${CONFIG_FILE_NAME_WITHOUT_EXT}"
+fun getConfigFilePath(filePathPrefix: String): String {
+    val fileSystemPathSeparator = if (filePathPrefix.endsWith(File.separator)) "" else File.separator
+
+    val configFileNameWithoutExtension = listOf(filePathPrefix, CONFIG_FILE_NAME_WITHOUT_EXT).joinToString(fileSystemPathSeparator)
+
     return CONFIG_EXTENSIONS.firstNotNullOfOrNull {
         val filePath = "$configFileNameWithoutExtension.$it"
         filePath.takeIf { File(filePath).exists() }

--- a/core/src/main/kotlin/io/specmatic/stub/SpecmaticConfigSource.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/SpecmaticConfigSource.kt
@@ -1,0 +1,45 @@
+package io.specmatic.stub
+
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.loadSpecmaticConfig
+import java.io.File
+
+interface SpecmaticConfigSource {
+    fun load(): LoadedSpecmaticConfig
+
+    data class LoadedSpecmaticConfig(val config: SpecmaticConfig, val path: String?)
+
+    companion object {
+        val None: SpecmaticConfigSource = object : SpecmaticConfigSource {
+            override fun load(): LoadedSpecmaticConfig = LoadedSpecmaticConfig(SpecmaticConfig(), null)
+        }
+
+        fun fromPath(path: String?): SpecmaticConfigSource = when (path) {
+            null -> None
+            else -> SpecmaticConfigFromPath(path)
+        }
+
+        fun fromConfig(config: SpecmaticConfig): SpecmaticConfigSource = SpecmaticConfigFromObject(config)
+
+        fun from(path: String?, config: SpecmaticConfig?): SpecmaticConfigSource = when {
+            config != null -> fromConfig(config)
+            else -> fromPath(path)
+        }
+    }
+}
+
+private class SpecmaticConfigFromPath(private val path: String) : SpecmaticConfigSource {
+    override fun load(): SpecmaticConfigSource.LoadedSpecmaticConfig {
+        val file = File(path)
+
+        val resolvedPath = if (file.exists()) file.canonicalPath else path
+        val config = if (file.exists()) loadSpecmaticConfig(resolvedPath) else SpecmaticConfig()
+
+        return SpecmaticConfigSource.LoadedSpecmaticConfig(config, resolvedPath)
+    }
+}
+
+private class SpecmaticConfigFromObject(private val config: SpecmaticConfig) : SpecmaticConfigSource {
+    override fun load(): SpecmaticConfigSource.LoadedSpecmaticConfig =
+        SpecmaticConfigSource.LoadedSpecmaticConfig(config, null)
+}

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -198,7 +198,7 @@ fun createStub(
         port,
         log = ::consoleLog,
         workingDirectory = stubValues.workingDirectory,
-        specmaticConfigPath = File(configFileName).canonicalPath,
+        specmaticConfigSource = SpecmaticConfigSource.fromPath(File(configFileName).canonicalPath),
         timeoutMillis = timeoutMillis,
         strictMode = strict,
         specToStubBaseUrlMap = stubValues.contractStubPaths.specToBaseUrlMap(),
@@ -241,7 +241,7 @@ internal fun createStubFromContracts(
         host,
         port,
         ::consoleLog,
-        specmaticConfigPath = File(getConfigFilePath()).canonicalPath,
+        specmaticConfigSource = SpecmaticConfigSource.fromPath(File(getConfigFilePath()).canonicalPath),
         timeoutMillis = timeoutMillis,
         specToStubBaseUrlMap = contractPathData.specToBaseUrlMap(),
     )

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -64,6 +64,27 @@ internal class HttpStubTest {
     }
 
     @Test
+    fun `should use provided specmatic config instance`() {
+        val gherkin = """
+            Feature: Greeting
+              Scenario: Say hello
+                When GET /hello
+                Then status 200
+        """.trimIndent()
+
+        val feature = parseGherkinStringToFeature(gherkin)
+        val specmaticConfig = SpecmaticConfig(stub = StubConfiguration(delayInMilliseconds = 123))
+
+        HttpStub(features = listOf(feature), specmaticConfig = specmaticConfig).use { stub ->
+            val specmaticConfigField = HttpStub::class.java.getDeclaredField("specmaticConfigInstance")
+            specmaticConfigField.isAccessible = true
+            val resolvedSpecmaticConfig = specmaticConfigField.get(stub)
+
+            assertThat(resolvedSpecmaticConfig).isSameAs(specmaticConfig)
+        }
+    }
+
+    @Test
     fun `should serve mocked data before stub`() {
         val gherkin = """
 Feature: Math API

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -18,6 +18,7 @@ import io.specmatic.mock.ScenarioStub
 import io.specmatic.osAgnosticPath
 import io.specmatic.shouldMatch
 import io.specmatic.test.LegacyHttpClient
+import io.specmatic.stub.SpecmaticConfigSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -75,7 +76,10 @@ internal class HttpStubTest {
         val feature = parseGherkinStringToFeature(gherkin)
         val specmaticConfig = SpecmaticConfig(stub = StubConfiguration(delayInMilliseconds = 123))
 
-        HttpStub(features = listOf(feature), specmaticConfig = specmaticConfig).use { stub ->
+        HttpStub(
+            features = listOf(feature),
+            specmaticConfigSource = SpecmaticConfigSource.fromConfig(specmaticConfig)
+        ).use { stub ->
             val specmaticConfigField = HttpStub::class.java.getDeclaredField("specmaticConfigInstance")
             specmaticConfigField.isAccessible = true
             val resolvedSpecmaticConfig = specmaticConfigField.get(stub)
@@ -1450,7 +1454,10 @@ paths:
 
             val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-            HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            HttpStub(
+                listOf(feature),
+                specmaticConfigSource = SpecmaticConfigSource.fromPath("src/test/resources/specmatic_config_wtih_generate_stub.yaml")
+            ).use { stub ->
                 val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
                 val response = stub.client.execute(request)
 
@@ -1512,7 +1519,10 @@ paths:
 
             val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-            HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            HttpStub(
+                listOf(feature),
+                specmaticConfigSource = SpecmaticConfigSource.fromPath("src/test/resources/specmatic_config_wtih_generate_stub.yaml")
+            ).use { stub ->
                 val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
                 val response = stub.client.execute(request)
 
@@ -1579,7 +1589,10 @@ paths:
 
             val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-            HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            HttpStub(
+                listOf(feature),
+                specmaticConfigSource = SpecmaticConfigSource.fromPath("src/test/resources/specmatic_config_wtih_generate_stub.yaml")
+            ).use { stub ->
                 val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
                 val response = stub.client.execute(request)
 
@@ -1641,7 +1654,10 @@ paths:
 
             val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-            HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            HttpStub(
+                listOf(feature),
+                specmaticConfigSource = SpecmaticConfigSource.fromPath("src/test/resources/specmatic_config_wtih_generate_stub.yaml")
+            ).use { stub ->
                 val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
                 val response = stub.client.execute(request)
 
@@ -1703,7 +1719,10 @@ paths:
 
             val feature = OpenApiSpecification.fromYAML(spec, "").toFeature()
 
-            HttpStub(listOf(feature), specmaticConfigPath = "src/test/resources/specmatic_config_wtih_generate_stub.yaml").use { stub ->
+            HttpStub(
+                listOf(feature),
+                specmaticConfigSource = SpecmaticConfigSource.fromPath("src/test/resources/specmatic_config_wtih_generate_stub.yaml")
+            ).use { stub ->
                 val request = HttpRequest("POST", path = "/hello", body = parsedJSONObject("""{"data": 10}"""))
                 val response = stub.client.execute(request)
 
@@ -2633,7 +2652,7 @@ Then status 200
             HttpStub(
                 features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specmaticConfigSource = SpecmaticConfigSource.fromPath(specmaticConfigFile.canonicalPath),
                 specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
             ).use {
                 val productsResponse = LegacyHttpClient(
@@ -2737,7 +2756,7 @@ Then status 200
             HttpStub(
                 features = scenarioStubs.features(),
                 rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                specmaticConfigSource = SpecmaticConfigSource.fromPath(specmaticConfigFile.canonicalPath),
                 specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
             ).use {
                 val postProductResponse = LegacyHttpClient(
@@ -2875,7 +2894,7 @@ Then status 200
                 HttpStub(
                     features = scenarioStubs.features(),
                     rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                    specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                    specmaticConfigSource = SpecmaticConfigSource.fromPath(specmaticConfigFile.canonicalPath),
                     specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
                 ).close()
             }
@@ -2904,7 +2923,7 @@ Then status 200
                     HttpStub(
                         features = scenarioStubs.features(),
                         rawHttpStubs = contractInfoToHttpExpectations(scenarioStubs),
-                        specmaticConfigPath = specmaticConfigFile.canonicalPath,
+                        specmaticConfigSource = SpecmaticConfigSource.fromPath(specmaticConfigFile.canonicalPath),
                         specToStubBaseUrlMap = contractPathData.specToBaseUrlMap()
                     ).close()
                 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubUsageReportTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubUsageReportTest.kt
@@ -110,7 +110,10 @@ paths:
         val stubContract1 = OpenApiSpecification.fromYAML(helloAndDataSpec, "", sourceProvider = "git", sourceRepository = "https://github.com/specmatic/specmatic-order-contracts.git", sourceRepositoryBranch = "main", specificationPath = "in/specmatic/examples/store/helloAndDataSpec.yaml").toFeature()
         val stubContract2 = OpenApiSpecification.fromYAML(hello2AndData2Spec, "", sourceProvider = "git", sourceRepository = "https://github.com/specmatic/specmatic-order-contracts.git", sourceRepositoryBranch = "main", specificationPath = "in/specmatic/examples/store/hello2AndData2Spec.yaml").toFeature()
 
-        HttpStub(listOf(stubContract1, stubContract2), specmaticConfigPath = "./specmatic.json").use { stub ->
+        HttpStub(
+            listOf(stubContract1, stubContract2),
+            specmaticConfigSource = SpecmaticConfigSource.fromPath("./specmatic.json")
+        ).use { stub ->
             stub.client.execute(HttpRequest("GET", "/data"))
             stub.client.execute(HttpRequest("GET", "/unknown"))
             stub.client.execute(HttpRequest("GET", "/hello"))


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: The `HttpStub` constructor now accepts an optional `specmaticConfig` object.

**Why**: To provide a way for `HttpStub` to be initialized with a pre-existing `SpecmaticConfig` object directly, or load it from a file, offering greater flexibility in configuration.

**How**:
- Modified the `HttpStub` constructor to accept an optional `specmaticConfig` parameter.
- Introduced `specmaticConfigInstance` to centralize the resolution of the `SpecmaticConfig`, prioritizing the provided object, then a file path, then a default.
- Updated all internal usages of `specmaticConfig` to `specmaticConfigInstance`.
- Added a new unit test to `HttpStubTest` to verify that the provided `SpecmaticConfig` instance is used directly.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
