### PR TITLE
Fix the config parse issue on jackson libs version mismatch

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/ContractConfig.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.config.v2
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -16,6 +17,7 @@ data class ContractConfig(
     val provides: List<SpecExecutionConfig>? = null,
     val consumes: List<SpecExecutionConfig>? = null
 ) {
+    @JsonCreator
     @Suppress("unused")
     constructor(
         @JsonProperty("git") git: GitContractSource? = null,


### PR DESCRIPTION
fix: add JsonCreator annotation over the secondary constructor of ContractConfig to fix the config parse issue being faced by projects using specmatic and having a different jackson lib version