### PR TITLE
Add strict mode for contract testing to enforce example-based test execution

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_PARALLELISM
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.MATCH_BRANCH
+import io.specmatic.core.utilities.Flags.Companion.STRICT_MODE
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.loadSpecmaticConfigOrNull
@@ -28,7 +29,6 @@ import io.specmatic.test.SpecmaticJUnitSupport.Companion.HOST
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.INLINE_SUGGESTIONS
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.OVERLAY_FILE_PATH
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.PORT
-import io.specmatic.test.SpecmaticJUnitSupport.Companion.STRICT_MODE
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.SUGGESTIONS_PATH
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.SpecmaticJUnitSupport.Companion.VARIABLES_FILE_NAME

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -769,6 +769,8 @@ data class Feature(
     private fun positiveTestScenarios(suggestions: List<Scenario>, fn: (Scenario, Row) -> Scenario = { s, _ -> s }): Sequence<Pair<Scenario, ReturnValue<Scenario>>> =
         scenarios.asSequence().filter {
             it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario
+        }.filter {
+            !strictMode || it.hasExampleRows()
         }.map {
             it.newBasedOn(suggestions)
         }.flatMap { originalScenario ->
@@ -792,6 +794,8 @@ data class Feature(
     fun negativeTestScenarios(): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
         return scenarios.asSequence().filter {
             it.isA2xxScenario()
+        }.filter {
+            !strictMode || it.hasExampleRows()
         }.flatMap { originalScenario ->
             val negativeScenario = originalScenario.negativeBasedOn(getBadRequestsOrDefault(originalScenario))
 

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -790,6 +790,8 @@ data class Scenario(
 
     fun isA4xxScenario(): Boolean = this.httpResponsePattern.status in 400..499
 
+    fun hasExampleRows(): Boolean = examples.any { it.rows.isNotEmpty() }
+
     fun calculatePath(httpRequest: HttpRequest): Set<String> {
         val bodyPattern = resolvedHop(this.httpRequestPattern.body, this.resolver)
         val paths = when (bodyPattern) {

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -478,6 +478,11 @@ data class SpecmaticConfig(
     }
 
     @JsonIgnore
+    fun getTestStrictMode(): Boolean? {
+        return test?.strictMode
+    }
+
+    @JsonIgnore
     fun copyResiliencyTestsConfig(onlyPositive: Boolean): SpecmaticConfig {
         return this.copy(
             test = test?.copy(
@@ -655,7 +660,8 @@ data class TestConfiguration(
     val resiliencyTests: ResiliencyTestsConfig? = null,
     val validateResponseValues: Boolean? = null,
     val allowExtensibleSchema: Boolean? = null,
-    val timeoutInMilliseconds: Long? = null
+    val timeoutInMilliseconds: Long? = null,
+    val strictMode: Boolean? = null
 )
 
 enum class ResiliencyTestSuite {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -28,6 +28,7 @@ class Flags {
 
         const val MAX_TEST_COUNT = "MAX_TEST_COUNT"
         const val MATCH_BRANCH = "MATCH_BRANCH"
+        const val STRICT_MODE = "STRICT_MODE"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -14,7 +14,7 @@ data class ContractTestSettings(
     val generative: Boolean?,
     val reportBaseDirectory: String?,
     val coverageHooks: List<TestReportListener>,
-    val strictMode: Boolean,
+    val strictMode: Boolean?,
 ) {
     fun adjust(specmaticConfig: SpecmaticConfig?): SpecmaticConfig? =
         if (generative == true) {
@@ -35,6 +35,6 @@ data class ContractTestSettings(
         generative = contractTestSettings.get()?.generative,
         reportBaseDirectory = contractTestSettings.get()?.reportBaseDirectory,
         coverageHooks = contractTestSettings.get()?.coverageHooks ?: emptyList(),
-        strictMode = contractTestSettings.get()?.strictMode ?: Flags.getBooleanValue(Flags.STRICT_MODE, false),
+        strictMode = contractTestSettings.get()?.strictMode ?: Flags.getStringValue(Flags.STRICT_MODE)?.toBoolean(),
     )
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -2,6 +2,7 @@ package io.specmatic.test
 
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.getConfigFilePath
+import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.readEnvVarOrProperty
 import io.specmatic.test.reports.TestReportListener
@@ -22,6 +23,12 @@ data class ContractTestSettings(
         } else {
             specmaticConfig
         }
+
+    fun getAdjustedConfig(): SpecmaticConfig? {
+        if (configFile.isBlank()) return null
+
+        return adjust(loadSpecmaticConfig(configFile))
+    }
 
     internal constructor(contractTestSettings: ThreadLocal<ContractTestSettings?>) : this(
         testBaseURL = contractTestSettings.get()?.testBaseURL ?: System.getProperty(SpecmaticJUnitSupport.TEST_BASE_URL),

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -2,6 +2,7 @@ package io.specmatic.test
 
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.getConfigFilePath
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.readEnvVarOrProperty
 import io.specmatic.test.reports.TestReportListener
 
@@ -13,6 +14,7 @@ data class ContractTestSettings(
     val generative: Boolean?,
     val reportBaseDirectory: String?,
     val coverageHooks: List<TestReportListener>,
+    val strictMode: Boolean,
 ) {
     fun adjust(specmaticConfig: SpecmaticConfig?): SpecmaticConfig? =
         if (generative == true) {
@@ -33,5 +35,6 @@ data class ContractTestSettings(
         generative = contractTestSettings.get()?.generative,
         reportBaseDirectory = contractTestSettings.get()?.reportBaseDirectory,
         coverageHooks = contractTestSettings.get()?.coverageHooks ?: emptyList(),
+        strictMode = contractTestSettings.get()?.strictMode ?: Flags.getBooleanValue(Flags.STRICT_MODE, false),
     )
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.loadSpecmaticConfig
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.readEnvVarOrProperty
 import io.specmatic.test.reports.TestReportListener
+import java.io.File
 
 data class ContractTestSettings(
     val testBaseURL: String?,
@@ -26,6 +27,10 @@ data class ContractTestSettings(
 
     fun getAdjustedConfig(): SpecmaticConfig? {
         if (configFile.isBlank()) return null
+
+        if (File(configFile).exists().not()) {
+            return null
+        }
 
         return adjust(loadSpecmaticConfig(configFile))
     }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -80,7 +80,6 @@ open class SpecmaticJUnitSupport {
         const val FILTER_NAME_ENVIRONMENT_VARIABLE = "FILTER_NAME"
         const val FILTER_NOT_NAME_ENVIRONMENT_VARIABLE = "FILTER_NOT_NAME"
         const val OVERLAY_FILE_PATH = "overlayFilePath"
-        const val STRICT_MODE = "strictMode"
         private const val ENDPOINTS_API = "endpointsAPI"
         private const val SWAGGER_UI_BASEURL = "swaggerUIBaseURL"
 
@@ -532,7 +531,7 @@ open class SpecmaticJUnitSupport {
         }
 
         val contractFile = File(path)
-        val strictMode = (System.getProperty(STRICT_MODE) ?: System.getenv(STRICT_MODE)) == "true"
+        val strictMode = settings.strictMode
         val rawSpecmaticConfig = specmaticConfig ?: SpecmaticConfig()
         val effectiveSpecmaticConfig =
             when (generative) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -56,7 +56,8 @@ open class SpecmaticJUnitSupport {
     private var startTime: Instant? = null
 
     private val specmaticConfig: SpecmaticConfig? =
-        settings.adjust(loadSpecmaticConfigOrNull(getConfigFilePath()))
+        settings.getAdjustedConfig()
+            ?: settings.adjust(loadSpecmaticConfigOrNull(getConfigFilePath()))
 
     private val testFilter = ScenarioMetadataFilter.from(settings.filter)
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 import org.opentest4j.TestAbortedException
 import java.io.File
 import java.net.URI
-import java.time.Duration
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedDeque
@@ -532,6 +531,8 @@ open class SpecmaticJUnitSupport {
 
         val contractFile = File(path)
         val strictMode = settings.strictMode
+            ?: specmaticConfig?.getTestStrictMode()
+            ?: false
         val rawSpecmaticConfig = specmaticConfig ?: SpecmaticConfig()
         val effectiveSpecmaticConfig =
             when (generative) {


### PR DESCRIPTION
**What**:

This PR introduces a strict mode feature for contract testing in Specmatic. When enabled, strict mode ensures that tests are only generated and executed for API scenarios that have external examples defined. This provides better control over which endpoints are tested and prevents auto-generated tests from running on endpoints without explicit examples.

**Why**:

In certain testing scenarios, teams may want to ensure that only APIs with explicitly defined examples are tested, rather than relying on auto-generated test data. This is particularly useful when:
- Teams want explicit control over test coverage
- Generated tests may produce false positives or negatives
- There's a need to gradually adopt contract testing by starting with specific, example-backed endpoints

**How**:

The implementation adds a `strictMode` configuration option that can be set via environment variable (`STRICT_MODE=true`), system property, SpecmaticConfig JSON (`test.strictMode: true`), or ContractTestSettings in JUnit support. The feature filters out scenarios without example rows during test generation for both positive and negative test scenarios. Comprehensive unit and integration tests have been added to verify the behavior.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A