### PR TITLE
Stub-side strict mode in config

### DIFF
--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -12,7 +12,7 @@ import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_PARALLELISM
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_TEST_TIMEOUT
 import io.specmatic.core.utilities.Flags.Companion.MATCH_BRANCH
-import io.specmatic.core.utilities.Flags.Companion.STRICT_MODE
+import io.specmatic.core.utilities.Flags.Companion.TEST_STRICT_MODE
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import io.specmatic.core.utilities.exitWithMessage
 import io.specmatic.core.loadSpecmaticConfigOrNull
@@ -49,7 +49,6 @@ import java.io.File
 import java.io.PrintWriter
 import java.io.StringReader
 import java.nio.file.Paths
-import java.util.*
 import java.util.concurrent.Callable
 
 private const val SYSTEM_OUT_TESTCASE_TAG = "system-out"
@@ -183,7 +182,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty("protocol", protocol)
         System.setProperty(FILTER, filter)
         System.setProperty(OVERLAY_FILE_PATH, overlayFilePath.orEmpty())
-        System.setProperty(STRICT_MODE, strictMode.toString())
+        System.setProperty(TEST_STRICT_MODE, strictMode.toString())
 
         val configMatchBranch = loadSpecmaticConfigOrNull(Configuration.configFilePath)?.getMatchBranch() ?: false
         val matchBranchEnabled = useCurrentBranchForCentralRepo || Flags.getBooleanValue(MATCH_BRANCH, false) || configMatchBranch

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -138,7 +138,7 @@ data class StubConfiguration(
     }
 
     fun getStrictMode(): Boolean? {
-        return strictMode ?: getBooleanValue(Flags.STUB_STRICT_MODE)
+        return strictMode ?: getBooleanValue(Flags.STUB_STRICT_MODE, false)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -110,7 +110,8 @@ data class StubConfiguration(
     private val dictionary: String? = null,
     private val includeMandatoryAndRequestedKeysInResponse: Boolean? = null,
     private val startTimeoutInMilliseconds: Long? = null,
-    private val hotReload: Switch? = null
+    private val hotReload: Switch? = null,
+    private val strictMode: Boolean? = null
 ) {
     fun getGenerative(): Boolean? {
         return generative
@@ -134,6 +135,10 @@ data class StubConfiguration(
 
     fun getHotReload(): Switch? {
         return hotReload
+    }
+
+    fun getStrictMode(): Boolean? {
+        return strictMode ?: getBooleanValue(Flags.STUB_STRICT_MODE)
     }
 }
 
@@ -511,6 +516,11 @@ data class SpecmaticConfig(
     @JsonIgnore
     fun getStubDictionary(): String? {
         return stub.getDictionary()
+    }
+
+    @JsonIgnore
+    fun getStubStrictMode(): Boolean? {
+        return stub.getStrictMode()
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -28,8 +28,8 @@ class Flags {
 
         const val MAX_TEST_COUNT = "MAX_TEST_COUNT"
         const val MATCH_BRANCH = "MATCH_BRANCH"
-        const val STRICT_MODE = "STRICT_MODE"
-        const val STUB_STRICT_MODE = "STUB_STRICT_MODE"
+        const val TEST_STRICT_MODE = "SPECMATIC_TEST_STRICT_MODE"
+        const val STUB_STRICT_MODE = "SPECMATIC_STUB_STRICT_MODE"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Flags.kt
@@ -29,6 +29,7 @@ class Flags {
         const val MAX_TEST_COUNT = "MAX_TEST_COUNT"
         const val MATCH_BRANCH = "MATCH_BRANCH"
         const val STRICT_MODE = "STRICT_MODE"
+        const val STUB_STRICT_MODE = "STUB_STRICT_MODE"
 
         fun getStringValue(flagName: String): String? = System.getenv(flagName) ?: System.getProperty(flagName)
 

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -232,7 +232,8 @@ internal fun createStubFromContracts(
     specmaticConfig: SpecmaticConfig,
 ): HttpStub {
     val contractPathData = contractPaths.map { ContractPathData("", it) }
-    val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths, specmaticConfig)
+    val strictMode = specmaticConfig.getStubStrictMode() ?: false
+    val contractInfo = loadContractStubsFromFiles(contractPathData, dataDirPaths, specmaticConfig, strictMode)
     val features = contractInfo.map { it.first }
     val httpExpectations = contractInfoToHttpExpectations(contractInfo)
 
@@ -245,6 +246,7 @@ internal fun createStubFromContracts(
         specmaticConfigSource = SpecmaticConfigSource.fromPath(File(getConfigFilePath()).canonicalPath),
         timeoutMillis = timeoutMillis,
         specToStubBaseUrlMap = contractPathData.specToBaseUrlMap(),
+        strictMode = strictMode,
     )
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -157,6 +157,7 @@ fun createStub(
     val specmaticConfig = loadSpecmaticConfigOrDefault(configFileName)
     val useCurrentBranchForCentralRepo =
         specmaticConfig.getMatchBranch() == true || Flags.getBooleanValue(Flags.MATCH_BRANCH)
+    val effectiveStrictMode = if (strict) true else (specmaticConfig.getStubStrictMode() ?: false)
 
     val timeoutMessage =
         "FATAL: Specmatic stub failed to start within ${specmaticConfig.getStubStartTimeoutInMilliseconds()} milliseconds. You can configure the stub start timeout from Specmatic configuration. The default timeout is 20 seconds."
@@ -176,7 +177,7 @@ fun createStub(
                         contractStubPaths,
                         dataDirPaths,
                         specmaticConfig,
-                        strict,
+                        effectiveStrictMode,
                         withImplicitStubs = true,
                     )
                 }
@@ -200,7 +201,7 @@ fun createStub(
         workingDirectory = stubValues.workingDirectory,
         specmaticConfigSource = SpecmaticConfigSource.fromPath(File(configFileName).canonicalPath),
         timeoutMillis = timeoutMillis,
-        strictMode = strict,
+        strictMode = effectiveStrictMode,
         specToStubBaseUrlMap = stubValues.contractStubPaths.specToBaseUrlMap(),
     )
 }

--- a/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
@@ -109,7 +109,7 @@ internal class StubStrictModeTest {
 
         @Test
         fun `createStubFromContracts should succeed with valid stub in strict mode`() {
-            val resourcesDir = File(javaClass.getResource("/stub_strict_mode")!!.toURI())
+            val resourcesDir = File(javaClass.getResource("${File.separator}stub_strict_mode")!!.toURI())
             val apiFile = File(resourcesDir, "api.yaml")
             val validStubDir = File(resourcesDir, "api_data")
             val configFile = File(resourcesDir, "specmatic_strict_true.yaml")

--- a/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
@@ -120,18 +120,28 @@ internal class StubStrictModeTest {
             tempDir.mkdir()
 
             try {
+                // Copy the API spec file to temp directory (needed for Windows cross-drive support)
+                val tempApiFile = File(tempDir, "api.yaml")
+                tempApiFile.writeText(apiFile.readText())
+
+                // Copy the config file to temp directory
+                val tempConfigFile = File(tempDir, "specmatic_strict_true.yaml")
+                tempConfigFile.writeText(configFile.readText())
+
                 // Copy only the valid stub
                 val validStub = File(validStubDir, "valid_stub.json")
-                val targetFile = File(tempDir, "valid_stub.json")
+                val stubsDir = File(tempDir, "stubs")
+                stubsDir.mkdir()
+                val targetFile = File(stubsDir, "valid_stub.json")
                 targetFile.writeText(validStub.readText())
 
                 val stub = createStubFromContracts(
-                    contractPaths = listOf(apiFile.path),
-                    dataDirPaths = listOf(tempDir.path),
+                    contractPaths = listOf(tempApiFile.path),
+                    dataDirPaths = listOf(stubsDir.path),
                     host = "localhost",
                     port = 9003,
                     timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT,
-                    specmaticConfigPath = configFile.path
+                    specmaticConfigPath = tempConfigFile.path
                 )
 
                 try {

--- a/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
@@ -1,0 +1,147 @@
+package io.specmatic.stub
+
+import io.specmatic.core.loadSpecmaticConfig
+import io.specmatic.core.utilities.Flags
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class StubStrictModeTest {
+
+    @Nested
+    inner class StubConfigurationTests {
+        @Test
+        fun `getStrictMode should return strictMode from config when set to true`() {
+            val configFile = File(javaClass.getResource("/stub_strict_mode/specmatic_strict_true.yaml")!!.toURI())
+            val config = loadSpecmaticConfig(configFile.path)
+
+            assertThat(config.getStubStrictMode()).isTrue()
+        }
+
+        @Test
+        fun `getStrictMode should return strictMode from config when set to false`() {
+            val configFile = File(javaClass.getResource("/stub_strict_mode/specmatic_strict_false.yaml")!!.toURI())
+            val config = loadSpecmaticConfig(configFile.path)
+
+            assertThat(config.getStubStrictMode()).isFalse()
+        }
+
+        @Test
+        fun `getStrictMode should return null when not set in config and no system property`() {
+            val configFile = File(javaClass.getResource("/stub_strict_mode/specmatic_no_strict.yaml")!!.toURI())
+            val config = loadSpecmaticConfig(configFile.path)
+
+            assertThat(config.getStubStrictMode()).isFalse()
+        }
+
+        @Test
+        fun `getStrictMode should fall back to system property when not set in config`() {
+            val configFile = File(javaClass.getResource("/stub_strict_mode/specmatic_no_strict.yaml")!!.toURI())
+
+            Flags.using(Flags.STUB_STRICT_MODE to "true") {
+                val config = loadSpecmaticConfig(configFile.path)
+                assertThat(config.getStubStrictMode()).isTrue()
+            }
+        }
+
+        @Test
+        fun `getStrictMode should prefer config over system property`() {
+            val configFile = File(javaClass.getResource("/stub_strict_mode/specmatic_strict_false.yaml")!!.toURI())
+
+            Flags.using(Flags.STUB_STRICT_MODE to "true") {
+                val config = loadSpecmaticConfig(configFile.path)
+                // Config has false, system property has true - config should win
+                assertThat(config.getStubStrictMode()).isFalse()
+            }
+        }
+    }
+
+    @Nested
+    inner class CreateStubIntegrationTests {
+        @Test
+        fun `createStubFromContracts with config strictMode true should fail with invalid stub`() {
+            val resourcesDir = File(javaClass.getResource("/stub_strict_mode")!!.toURI())
+            val apiFile = File(resourcesDir, "api.yaml")
+            val invalidStubDir = File(resourcesDir, "api_data")
+            val configFile = File(resourcesDir, "specmatic_strict_true.yaml")
+
+            val exception = assertThrows(Exception::class.java) {
+                createStubFromContracts(
+                    contractPaths = listOf(apiFile.path),
+                    dataDirPaths = listOf(invalidStubDir.path),
+                    host = "localhost",
+                    port = 9001,
+                    timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT,
+                    specmaticConfigPath = configFile.path
+                ).use { }
+            }
+
+            // In strict mode, invalid stubs should cause an error
+            assertThat(exception.message).contains("didn't match")
+        }
+
+        @Test
+        fun `createStubFromContracts with config strictMode false should succeed with invalid stub`() {
+            val resourcesDir = File(javaClass.getResource("/stub_strict_mode")!!.toURI())
+            val apiFile = File(resourcesDir, "api.yaml")
+            val invalidStubDir = File(resourcesDir, "api_data")
+            val configFile = File(resourcesDir, "specmatic_strict_false.yaml")
+
+            // Using strict=false in config should allow invalid stubs
+            val stub = createStubFromContracts(
+                contractPaths = listOf(apiFile.path),
+                dataDirPaths = listOf(invalidStubDir.path),
+                host = "localhost",
+                port = 9002,
+                timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT,
+                specmaticConfigPath = configFile.path
+            )
+
+            try {
+                // In non-strict mode, invalid stubs are logged but don't cause failure
+                assertThat(stub).isNotNull()
+            } finally {
+                stub.close()
+            }
+        }
+
+        @Test
+        fun `createStubFromContracts should succeed with valid stub in strict mode`() {
+            val resourcesDir = File(javaClass.getResource("/stub_strict_mode")!!.toURI())
+            val apiFile = File(resourcesDir, "api.yaml")
+            val validStubDir = File(resourcesDir, "api_data")
+            val configFile = File(resourcesDir, "specmatic_strict_true.yaml")
+
+            // Create a directory with only valid stub
+            val tempDir = File.createTempFile("specmatic_test", "")
+            tempDir.delete()
+            tempDir.mkdir()
+
+            try {
+                // Copy only the valid stub
+                val validStub = File(validStubDir, "valid_stub.json")
+                validStub.copyTo(File(tempDir, "valid_stub.json"))
+
+                val stub = createStubFromContracts(
+                    contractPaths = listOf(apiFile.path),
+                    dataDirPaths = listOf(tempDir.path),
+                    host = "localhost",
+                    port = 9003,
+                    timeoutMillis = HTTP_STUB_SHUTDOWN_TIMEOUT,
+                    specmaticConfigPath = configFile.path
+                )
+
+                try {
+                    // Valid stub should work in strict mode
+                    assertThat(stub).isNotNull()
+                } finally {
+                    stub.close()
+                }
+            } finally {
+                tempDir.deleteRecursively()
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/StubStrictModeTest.kt
@@ -109,7 +109,7 @@ internal class StubStrictModeTest {
 
         @Test
         fun `createStubFromContracts should succeed with valid stub in strict mode`() {
-            val resourcesDir = File(javaClass.getResource("${File.separator}stub_strict_mode")!!.toURI())
+            val resourcesDir = File(javaClass.getResource("/stub_strict_mode")!!.toURI())
             val apiFile = File(resourcesDir, "api.yaml")
             val validStubDir = File(resourcesDir, "api_data")
             val configFile = File(resourcesDir, "specmatic_strict_true.yaml")
@@ -122,7 +122,8 @@ internal class StubStrictModeTest {
             try {
                 // Copy only the valid stub
                 val validStub = File(validStubDir, "valid_stub.json")
-                validStub.copyTo(File(tempDir, "valid_stub.json"))
+                val targetFile = File(tempDir, "valid_stub.json")
+                targetFile.writeText(validStub.readText())
 
                 val stub = createStubFromContracts(
                     contractPaths = listOf(apiFile.path),

--- a/core/src/test/resources/stub_strict_mode/api.yaml
+++ b/core/src/test/resources/stub_strict_mode/api.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{id}:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: User found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string

--- a/core/src/test/resources/stub_strict_mode/api_data/invalid_stub.json
+++ b/core/src/test/resources/stub_strict_mode/api_data/invalid_stub.json
@@ -1,0 +1,10 @@
+{
+  "http-request": {
+    "method": "POST",
+    "path": "/invalid"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {}
+  }
+}

--- a/core/src/test/resources/stub_strict_mode/api_data/valid_stub.json
+++ b/core/src/test/resources/stub_strict_mode/api_data/valid_stub.json
@@ -1,0 +1,13 @@
+{
+  "http-request": {
+    "method": "GET",
+    "path": "/users/123"
+  },
+  "http-response": {
+    "status": 200,
+    "body": {
+      "id": 123,
+      "name": "John Doe"
+    }
+  }
+}

--- a/core/src/test/resources/stub_strict_mode/specmatic_no_strict.yaml
+++ b/core/src/test/resources/stub_strict_mode/specmatic_no_strict.yaml
@@ -1,0 +1,3 @@
+version: 2
+stub:
+  startTimeoutInMilliseconds: 20000

--- a/core/src/test/resources/stub_strict_mode/specmatic_strict_false.yaml
+++ b/core/src/test/resources/stub_strict_mode/specmatic_strict_false.yaml
@@ -1,0 +1,3 @@
+version: 2
+stub:
+  strictMode: false

--- a/core/src/test/resources/stub_strict_mode/specmatic_strict_true.yaml
+++ b/core/src/test/resources/stub_strict_mode/specmatic_strict_true.yaml
@@ -1,0 +1,3 @@
+version: 2
+stub:
+  strictMode: true

--- a/core/src/test/resources/stub_strict_mode/specmatic_strict_true_with_spec.yaml
+++ b/core/src/test/resources/stub_strict_mode/specmatic_strict_true_with_spec.yaml
@@ -1,0 +1,6 @@
+version: 2
+contracts:
+  - consumes:
+      - src/test/resources/specmatic_strict_mode/api.yaml
+stub:
+  strictMode: true

--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -47,6 +47,6 @@ data class ContractTestSettings(
         generative = contractTestSettings.get()?.generative,
         reportBaseDirectory = contractTestSettings.get()?.reportBaseDirectory,
         coverageHooks = contractTestSettings.get()?.coverageHooks ?: emptyList(),
-        strictMode = contractTestSettings.get()?.strictMode ?: Flags.getStringValue(Flags.STRICT_MODE)?.toBoolean(),
+        strictMode = contractTestSettings.get()?.strictMode ?: Flags.getStringValue(Flags.TEST_STRICT_MODE)?.toBoolean(),
     )
 }


### PR DESCRIPTION
**What**:

Added the following support to config:

```yaml
stub:
  strictMode: true
```

**Why**:

Added it for consistency with test-side strict mode which is also available in config.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
