### PR TITLE
Trim whitespace from Specmatic type name in XML node generation

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -57,7 +57,7 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
             path,
             operationName,
             soapAction,
-            responseTypeInfo.types,
+            responseTypeInfo.types.mapKeys { it.key.trim() },
             requestTypeInfo.soapPayload,
             responseTypeInfo.soapPayload
         )

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
@@ -32,7 +32,7 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
 
         val qualification = namespaceQualification ?: wsdl.getQualification(element, wsdlTypeReference)
 
-        val inPlaceNode = toXMLNode("<${qualification.nodeName} $TYPE_ATTRIBUTE_NAME=\"$specmaticTypeName\"/>").let {
+        val inPlaceNode = toXMLNode("<${qualification.nodeName} $TYPE_ATTRIBUTE_NAME=\"${specmaticTypeName.trim()}\"/>").let {
             it.copy(attributes = it.attributes.plus(deriveSpecmaticAttributes(element)))
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPTypes.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPTypes.kt
@@ -8,7 +8,7 @@ data class SOAPTypes(val types: Map<String, XMLPattern>) {
             type.toGherkinStatement(typeName)
         }
 
-        return firstLineShouldBeGiven(typeStrings)
+        return firstLineShouldBeGiven(typeStrings).map { it.trimEnd() }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayload.kt
@@ -29,5 +29,5 @@ fun buildXmlDataForComplexElement(
         "${it.nameWithOptionality}=\"${it.type}\""
     }
 
-    return "<${nodeName} $TYPE_ATTRIBUTE_NAME=\"$specmaticTypeName\" $attributeString />"
+    return "<${nodeName} $TYPE_ATTRIBUTE_NAME=\"${specmaticTypeName.trim()}\" $attributeString />"
 }

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPTypesTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPTypesTest.kt
@@ -20,4 +20,16 @@ internal class SOAPTypesTest {
         assertThat(statements).hasSize(2)
         assertThat(statements.first()).startsWith("Given ")
     }
+
+    @Test
+    fun `trims trailing whitespace from generated gherkin statements`() {
+        val types = SOAPTypes(mapOf("Name" to XMLPattern("<name>(string)</name>")))
+        val statements = types.statements()
+        assertThat(statements).hasSize(1)
+        // Verify no trailing whitespace exists
+        statements.forEach { statement ->
+            assertThat(statement).isEqualTo(statement.trimEnd())
+            assertThat(statement).doesNotEndWith(" ")
+        }
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayloadTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayloadTest.kt
@@ -23,4 +23,25 @@ internal class ComplexTypedSOAPPayloadTest {
             </soapenv:Envelope>
             ""${'"'}""".trimIndent().trimmedLinesList())
     }
+
+    @Test
+    fun `trims whitespace from specmatic type name in generated payload`() {
+        // Create payload with type name that has trailing whitespace
+        val type = ComplexTypedSOAPPayload(SOAPMessageType.Input, "person", "Person  ", mapOf("ns0" to "http://ns"))
+        val statement = type.specmaticStatement().first().trim()
+
+        // Verify the generated XML has trimmed type name (no whitespace)
+        assertThat(statement).contains("specmatic_type=\"Person\"")
+        assertThat(statement).doesNotContain("specmatic_type=\"Person  \"")
+        assertThat(statement).doesNotContain("Person \"")
+    }
+
+    @Test
+    fun `buildXmlDataForComplexElement trims whitespace from type name`() {
+        val xml = buildXmlDataForComplexElement("person", "  PersonType  ", emptyList())
+
+        // Verify the type attribute has no leading or trailing whitespace
+        assertThat(xml).contains("specmatic_type=\"PersonType\"")
+        assertThat(xml).doesNotContain("  PersonType  ")
+    }
 }


### PR DESCRIPTION
**What**:

This PR fixes bugs where whitespace in Specmatic type names was causing issues in WSDL parsing and XML generation.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

