### PR TITLE
Ensure testData is escaped when writing to HTML report

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/html/HtmlReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/html/HtmlReport.kt
@@ -45,6 +45,7 @@ class HtmlReport(private val htmlReportInformation: HtmlReportInformation, priva
         // NOTE: Scenarios should be updated before updating TableRows
         val updatedScenarios = updateScenarioData(reportData.scenarioData)
         val updatedTableRows = updateTableRows(reportData.tableRows)
+        dumpTestData(updatedScenarios)
 
         val templateVariables = mapOf(
             "lite" to reportFormat.getLiteOrDefault(),
@@ -70,12 +71,12 @@ class HtmlReport(private val htmlReportInformation: HtmlReportInformation, priva
             "specmaticVersion" to htmlReportInformation.specmaticVersion,
             "generatedOn" to generatedOnTimestamp(),
             "isGherkinReport" to htmlReportInformation.isGherkinReport,
-            "jsonTestData" to dumpTestData(updatedScenarios)
+            "testData" to updatedScenarios,
         )
 
         return configureTemplateEngine().process(
             "report",
-            Context().apply { setVariables(templateVariables) }
+            Context().apply { setVariables(templateVariables) },
         )
     }
 
@@ -186,12 +187,10 @@ class HtmlReport(private val htmlReportInformation: HtmlReportInformation, priva
         }
     }
 
-    private fun dumpTestData(testData: GroupedScenarioData): String {
+    private fun dumpTestData(testData: GroupedScenarioData) {
         val mapper = ObjectMapper()
-        val json = mapper.writeValueAsString(testData)
         mapper.enable(SerializationFeature.INDENT_OUTPUT)
         writeToFileToAssets(outputDirectory, "test_data.json", mapper.writeValueAsString(testData))
-        return json
     }
 }
 

--- a/junit5-support/src/main/resources/templates/report.html
+++ b/junit5-support/src/main/resources/templates/report.html
@@ -142,8 +142,8 @@
             <p>All Rights Reserved</p>
         </div>
     </footer>
-    <script id="json-data"  type="application/json">
-        [(${jsonTestData})]
+    <script id="json-data" type="application/json" th:inline="javascript">
+        [[${testData}]]
     </script>
     <script defer type="text/javascript" src="assets/utils.js"></script>
     <script defer type="text/javascript" src="assets/summaryUpdater.js"></script>

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/html/HtmlReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/html/HtmlReportTest.kt
@@ -1,0 +1,80 @@
+package io.specmatic.test.reports.coverage.html
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
+import org.thymeleaf.templatemode.TemplateMode
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
+
+class HtmlReportTest {
+    private val objectMapper = ObjectMapper()
+    private val startTag = """<script id="json-data" type="application/json">"""
+    private val endTag = "</script>"
+    private val templateEngine = TemplateEngine().apply {
+        setTemplateResolver(ClassLoaderTemplateResolver().apply {
+            suffix = ".html"
+            templateMode = TemplateMode.HTML
+            characterEncoding = "UTF-8"
+        })
+    }
+
+    private fun renderTemplateWithTestData(testData: Any): String {
+        val context = Context().apply { setVariable("testData", testData) }
+        return templateEngine.process("test-template", context)
+    }
+
+    private fun extractScriptContent(html: String): String {
+        val startIndex = html.indexOf(startTag)
+        val endIndex = html.indexOf(endTag, startIndex + startTag.length)
+        assertThat(startIndex).isGreaterThanOrEqualTo(0)
+        assertThat(endIndex).isGreaterThan(startIndex)
+        return html.substring(startIndex + startTag.length, endIndex).trim()
+    }
+
+    private fun assertJsonContent(scriptContent: String, expectedPairs: Map<String, Any?>) {
+        val jsonNode = objectMapper.readTree(scriptContent)
+        for ((key, value) in expectedPairs) {
+            val node = jsonNode.get(key)
+            assertThat(node).isNotNull
+            when (value) {
+                is String -> assertThat(node.asText()).isEqualTo(value)
+                is Int -> assertThat(node.asInt()).isEqualTo(value)
+                is Boolean -> assertThat(node.asBoolean()).isEqualTo(value)
+                else -> assertThat(node.toString()).isEqualTo(value.toString())
+            }
+        }
+    }
+
+    @Test
+    fun `test simple key value pairs map serialization`() {
+        val testData = mapOf("key" to "value", "number" to 42)
+        val html = renderTemplateWithTestData(testData)
+        val scriptContent = extractScriptContent(html)
+        assertJsonContent(scriptContent, mapOf("key" to "value", "number" to 42))
+    }
+
+    @Test
+    fun `test simple list serialization`() {
+        val testData = mapOf("list" to listOf("one", "two", "three"))
+        val html = renderTemplateWithTestData(testData)
+        val scriptContent = extractScriptContent(html)
+
+        val jsonNode = objectMapper.readTree(scriptContent)
+        val listNode = jsonNode.get("list")
+        assertThat(listNode).isNotNull
+        assertThat(listNode.isArray).isTrue
+        assertThat(listNode[0].asText()).isEqualTo("one")
+    }
+
+    @Test
+    fun `test HTML special characters in strings are escaped properly`() {
+        val testData = mapOf("html" to "<div>Hello & 'world' \"test\"</div>")
+        val html = renderTemplateWithTestData(testData)
+        val scriptContent = extractScriptContent(html)
+
+        assertThat(scriptContent).isEqualTo("""{"html":"<div>Hello \u0026 'world' \"test\"<\/div>"}""")
+        assertJsonContent(scriptContent, mapOf("html" to "<div>Hello & 'world' \"test\"</div>"))
+    }
+}

--- a/junit5-support/src/test/resources/test-template.html
+++ b/junit5-support/src/test/resources/test-template.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Test Inline JavaScript</title>
+</head>
+<body>
+<h1>Thymeleaf Inline JavaScript Test</h1>
+
+<script id="json-data" type="application/json" th:inline="javascript">
+    [[${testData}]]
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
**What**: Ensure testData is escaped when writing to HTML report

**Why**: To ensure that the browser does not misinterpret embedded JSON as DOM elements

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
