### PR TITLE
fix: Headers and Query Params should be scalars not JSON objects or arrays

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/GherkinClause.kt
+++ b/core/src/main/kotlin/io/specmatic/core/GherkinClause.kt
@@ -42,7 +42,7 @@ fun toGherkinClauses(patterns: Map<String, Pattern>): List<GherkinClause> {
 }
 
 fun headersToGherkin(headers: Map<String, String>, keyword: String, types: Map<String, Pattern>, exampleDeclarationsStore: ExampleDeclarations, section: GherkinSection): Triple<List<GherkinClause>, Map<String, Pattern>, ExampleDeclarations> {
-    val (dictionaryTypeMap, newTypes, newExamples) = dictionaryToDeclarations(stringMapToValueMap(headers), types, exampleDeclarationsStore)
+    val (dictionaryTypeMap, newTypes, newExamples) = dictionaryToDeclarations(stringMapToScalarMap(headers), types, exampleDeclarationsStore)
 
     val headerClauses = dictionaryTypeMap.entries.map {
         "$keyword ${it.key} ${it.value.pattern}"

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -622,8 +622,11 @@ fun toGherkinClauses(request: HttpRequest): Triple<List<GherkinClause>, Map<Stri
 fun stringMapToValueMap(stringStringMap: Map<String, String>) =
     stringStringMap.mapValues { guessType(parsedValue(it.value)) }
 
-fun queryParamsToValueMap(queryParams: QueryParameters) =
-    queryParams.paramPairs.associate { (key, value) -> key to guessType(parsedValue(value)) }
+fun stringMapToScalarMap(stringStringMap: Map<String, String>) =
+    stringStringMap.mapValues { parsedScalarValue(it.value) }
+
+fun queryParamsToScalarMap(queryParams: QueryParameters) =
+    queryParams.paramPairs.associate { (key, value) -> key to parsedScalarValue(value) }
 
 fun bodyToGherkin(
     request: HttpRequest,
@@ -671,7 +674,7 @@ fun firstLineToGherkin(
     val (query, newTypes, newExamples) = when {
         request.queryParams.isNotEmpty() -> {
             val (dictionaryType, newTypes, examples) = dictionaryToDeclarations(
-                queryParamsToValueMap(request.queryParams),
+                queryParamsToScalarMap(request.queryParams),
                 types,
                 exampleDeclarationsStore
             )

--- a/core/src/main/kotlin/io/specmatic/core/Substitution.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Substitution.kt
@@ -136,7 +136,7 @@ class Substitution(
 
                 (patternMap[key] ?: patternMap["$key?"])?.let { pattern ->
                     try {
-                        HasValue(pattern.parse(substituteValue, resolver).toStringLiteral())
+                        HasValue(pattern.parse(substituteValue, resolver).toUnformattedString())
                     } catch (e: Throwable) {
                         HasException(e)
                     }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/JSONSerialisation.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/JSONSerialisation.kt
@@ -25,6 +25,12 @@ fun valueArrayToJsonString(value: List<Value>): String {
     return indentedJson.encodeToString(data)
 }
 
+fun valueArrayToUnformattedJsonString(value: List<Value>): String {
+    val data = valueListToElements(value)
+
+    return unformattedJson.encodeToString(data)
+}
+
 fun toMap(value: Value?) = jsonStringToValueMap(value.toString())
 
 fun stringToPatternMap(stringContent: String): Map<String, Pattern>  {

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONArrayValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONArrayValue.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.valueArrayToJsonString
+import io.specmatic.core.utilities.valueArrayToUnformattedJsonString
 
 typealias TypeDeclarationsCallType = (Value, String, Map<String, Pattern>, ExampleDeclarations) -> Pair<TypeDeclaration, ExampleDeclarations>
 
@@ -101,5 +102,9 @@ data class JSONArrayValue(override val list: List<Value> = emptyList()) : Value,
 
     override fun specificity(): Int {
         return list.sumOf { it.specificity() }
+    }
+
+    override fun toUnformattedString(): String {
+        return valueArrayToUnformattedJsonString(list)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/JSONObjectValue.kt
@@ -128,6 +128,10 @@ data class JSONObjectValue(val jsonObject: Map<String, Value> = emptyMap()) : Va
     override fun specificity(): Int {
         return jsonObject.values.sumOf { it.specificity() }
     }
+
+    override fun toUnformattedString(): String {
+        return valueMapToUnindentedJsonString(jsonObject)
+    }
 }
 
 internal fun dictionaryToDeclarations(jsonObject: Map<String, Value>, types: Map<String, Pattern>, exampleDeclarations: ExampleDeclarations): Triple<Map<String, DeferredPattern>, Map<String, Pattern>, ExampleDeclarations> {

--- a/core/src/main/kotlin/io/specmatic/core/value/Value.kt
+++ b/core/src/main/kotlin/io/specmatic/core/value/Value.kt
@@ -15,6 +15,10 @@ interface Value {
         return StringValue(toStringLiteral())
     }
 
+    fun toUnformattedString(): String {
+        return this.toStringLiteral()
+    }
+
     fun displayableType(): String
     fun exactMatchElseType(): Pattern
     fun type(): Pattern

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -11654,6 +11654,29 @@ paths:
     }
 
     @Test
+    fun `should handle stringified json in response header value`() {
+        val spec = OpenApiSpecification.fromFile("src/test/resources/openapi/specification/proxy_generated.yaml")
+        val feature = spec.toFeature()
+        HttpStub(feature).use { stub ->
+            stub.setExpectation(
+                ScenarioStub(
+                    HttpRequest("GET", "/todos/1"),
+                    HttpResponse(
+                        status = 200,
+                        headers = mapOf(
+                            "Nel" to """{"success_fraction":0.0,"report_to":"default","max_age":604800}"""
+                        ),
+                        body = JSONObjectValue(mapOf(
+                            "id" to NumberValue(1)
+                        ))
+                    )
+            ))
+            val response = stub.client.execute(HttpRequest("GET", "/todos/1"))
+            assertThat(response.headers["Nel"]).isNotNull
+        }
+    }
+
+    @Test
     fun `should generate tests with different combinations of the query params`() {
         val spec = OpenApiSpecification.fromFile("src/test/resources/openapi/spec_with_query_params.yaml")
         val feature = spec.toFeature().enableGenerativeTesting()

--- a/core/src/test/resources/openapi/partial_with_discriminator/openapi.yaml
+++ b/core/src/test/resources/openapi/partial_with_discriminator/openapi.yaml
@@ -6,6 +6,17 @@ paths:
   /pets:
     post:
       summary: Add a new pet
+      parameters:
+        - name: my-req-header
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: my-req-query
+          in: query
+          required: false
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -15,6 +26,10 @@ paths:
       responses:
         '201':
           description: Pet added successfully
+          headers:
+            my-res-header:
+              schema:
+                type: string
           content:
             application/json:
               schema:

--- a/core/src/test/resources/openapi/partial_with_discriminator/openapi_dictionary.json
+++ b/core/src/test/resources/openapi/partial_with_discriminator/openapi_dictionary.json
@@ -6,5 +6,18 @@
   "Dog": {
     "breed": "Golden Retriever",
     "barkVolume": 10
+  },
+  "PARAMETERS": {
+    "HEADER": {
+      "my-req-header": "{\"type\": \"string\", \"example\": \"header-value\"}"
+    },
+    "QUERY": {
+      "my-req-query": "{\"type\": \"string\", \"example\": \"query-value\"}"
+    }
+  },
+  "RESPONSE": {
+    "HEADER": {
+      "my-res-header": "{\"type\": \"string\", \"example\": \"header-value\"}"
+    }
   }
 }

--- a/core/src/test/resources/openapi/specification/proxy_generated.yaml
+++ b/core/src/test/resources/openapi/specification/proxy_generated.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  title: New feature
+  version: "1"
+paths:
+  /todos/1:
+    get:
+      summary: GET /todos/1
+      responses:
+        "200":
+          description: GET /todos/1
+          headers:
+            Nel:
+              required: true
+              schema:
+                type: object
+                properties:
+                  report_to:
+                    type: string
+                  success_fraction:
+                    type: number
+                  max_age:
+                    type: integer
+                required:
+                  - max_age
+                  - report_to
+                  - success_fraction
+          content:
+            application/json:
+              schema:
+                required:
+                  - id
+                type: object
+                properties:
+                  id:
+                    type: integer


### PR DESCRIPTION
**What**:

When Specmatic proxy geneates a spec, if the req or res header contained a json object, we should treat it as scalar (string). This thing applies to query params as well. Similarly, when stub has to send a header, even if the value is a json object it needs to send it as a single line string.

**Why**:

If we don't do this and try to send a multi-line json object as a header, then ktor crashes.


**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
