### PR TITLE
refactor: enhance API specification loading functions to support only valid formats

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -1067,7 +1067,9 @@ fun isInvalidOpenAPISpecification(specPath: String): Boolean = hasOpenApiFileExt
 
 fun isOpenAPI(path: String): Boolean =
     try {
-        Yaml().load<MutableMap<String, Any?>>(File(path).reader()).contains("openapi")
+        File(path).reader().use { reader ->
+            Yaml().load<MutableMap<String, Any?>>(reader).contains("openapi")
+        }
     } catch (e: Throwable) {
         logger.log(e, "Could not parse $path")
         false

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -592,7 +592,7 @@ Feature: Math API
         }
 
         val contractPathData = ContractPathData("", file.path)
-        val (output, result) = captureStandardOutput {  loadIfSupportedAPISpecification(contractPathData, SpecmaticConfig()) }
+        val (output, result) = captureStandardOutput { loadIfSupportedAPISpecification(contractPathData, SpecmaticConfig()) }
         assertThat(result).isNull()
         assertThat(output).contains("Skipping the file")
         assertThat(output).endsWith(expectedOutput)

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -15,9 +15,6 @@ import org.junit.jupiter.params.provider.CsvSource
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlin.io.path.createFile
 
 internal class ApiKtTest {
     @Test
@@ -595,7 +592,7 @@ Feature: Math API
         }
 
         val contractPathData = ContractPathData("", file.path)
-        val (output, result) = captureStandardOutput {  loadIfOpenAPISpecification(contractPathData, SpecmaticConfig()) }
+        val (output, result) = captureStandardOutput {  loadIfSupportedAPISpecification(contractPathData, SpecmaticConfig()) }
         assertThat(result).isNull()
         assertThat(output).contains(expectedOutput)
     }

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -618,7 +618,6 @@ Feature: Math API
 
         val contractPathData = ContractPathData("", validSpecFile.path)
         val (_, result) = captureStandardOutput { loadIfSupportedAPISpecification(contractPathData, SpecmaticConfig()) }
-        validSpecFile.deleteOnExit()
 
         assertThat(result).isNotNull()
         assertThat(result?.second).isInstanceOf(Feature::class.java)
@@ -644,7 +643,6 @@ Feature: Math API
 
         val contractPathData = ContractPathData("", validAsyncAPISpecFile.path)
         val (output, result) = captureStandardOutput { loadIfSupportedAPISpecification(contractPathData, SpecmaticConfig()) }
-        validAsyncAPISpecFile.deleteOnExit()
 
         assertThat(result).isNull()
         assertThat(output).contains("Skipping the file")

--- a/specmatic-mcp/build.gradle.kts
+++ b/specmatic-mcp/build.gradle.kts
@@ -24,6 +24,4 @@ dependencies {
 
     implementation("info.picocli:picocli:4.7.7")
     implementation("org.fusesource.jansi:jansi:2.4.2")
-
-    testImplementation(kotlin("test"))
 }


### PR DESCRIPTION
**What**:

Filter out unsupported API Spec formats.

**Why**:

To avoid seeing errors when we try to parse non-supported API specs


**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
