### PR TITLE
Include previous tests in ContractTest via ContractTestSettings

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -17,6 +17,7 @@ data class ContractTestSettings(
     val reportBaseDirectory: String?,
     val coverageHooks: List<TestReportListener>,
     val strictMode: Boolean?,
+    val previousTestRuns: List<TestResultRecord> = emptyList()
 ) {
     fun adjust(specmaticConfig: SpecmaticConfig?): SpecmaticConfig? =
         if (generative == true) {
@@ -48,5 +49,7 @@ data class ContractTestSettings(
         reportBaseDirectory = contractTestSettings.get()?.reportBaseDirectory,
         coverageHooks = contractTestSettings.get()?.coverageHooks ?: emptyList(),
         strictMode = contractTestSettings.get()?.strictMode ?: Flags.getStringValue(Flags.TEST_STRICT_MODE)?.toBoolean(),
+        previousTestRuns = contractTestSettings.get()?.previousTestRuns.orEmpty()
+
     )
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -86,11 +86,12 @@ open class SpecmaticJUnitSupport {
         val partialSuccesses: ConcurrentLinkedDeque<Result.Success> = ConcurrentLinkedDeque()
     }
 
-    internal var openApiCoverageReportInput: OpenApiCoverageReportInput =
+    internal val openApiCoverageReportInput: OpenApiCoverageReportInput =
         OpenApiCoverageReportInput(
             getConfigFileWithAbsolutePath(),
             coverageHooks = settings.coverageHooks,
             httpInteractionsLog = httpInteractionsLog,
+            previousTestResultRecord = settings.previousTestRuns
         )
 
     private val threads: Vector<String> = Vector<String>()
@@ -242,9 +243,6 @@ open class SpecmaticJUnitSupport {
         val overlayFilePath: String? = System.getProperty(OVERLAY_FILE_PATH) ?: System.getenv(OVERLAY_FILE_PATH)
         val overlayContent = if(overlayFilePath.isNullOrBlank()) "" else readFrom(overlayFilePath, "overlay")
         val useCurrentBranchForCentralRepo = specmaticConfig?.getMatchBranch() ?: Flags.getBooleanValue(Flags.MATCH_BRANCH) ?: false
-
-        openApiCoverageReportInput = OpenApiCoverageReportInput(getConfigFileWithAbsolutePath(), filterExpression = settings.filter, coverageHooks = settings.coverageHooks, httpInteractionsLog = httpInteractionsLog)
-
         val timeoutInMilliseconds = specmaticConfig?.getTestTimeoutInMilliseconds() ?: try {
             getLongValue(SPECMATIC_TEST_TIMEOUT)
         } catch (e: NumberFormatException) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
@@ -19,6 +19,7 @@ data class TestExecutionResult(
     val request: List<HttpRequest>,
     val requestTime: Long,
     val response: List<HttpResponse?>,
+    val actualResponseStatus: Int,
     val responseTime: Long?
 )
 
@@ -57,6 +58,7 @@ internal fun List<TestReportListener>.onTestResult(testResultRecord: TestResultR
         requestTime = firstHttpLogMessage.requestTime.toEpochMillis(),
         response = httpLogMessages.map(HttpLogMessage::response),
         responseTime = lastHttpLogMessage.responseTime?.toEpochMillis(),
+        actualResponseStatus = testResultRecord.actualResponseStatus,
         details = testResultRecord.scenarioResult?.reportString() ?: "No details found for this test",
     )
     onEachListener { onTestResult(testExecutionResult) }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -31,7 +31,8 @@ class OpenApiCoverageReportInput(
     internal var endpointsAPISet: Boolean = false,
     private val filterExpression: String = "",
     private val coverageHooks: List<TestReportListener> = emptyList(),
-    private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog()
+    private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog(),
+    private val previousTestResultRecord: List<TestResultRecord> = emptyList(),
 ) {
     fun totalDuration(): Long {
         return httpInteractionsLog.totalDuration()
@@ -70,7 +71,10 @@ class OpenApiCoverageReportInput(
     }
 
     fun testResultRecords(): List<TestResultRecord> {
-        val testResults = testResultRecords.filter { testResult -> excludedAPIs.none { it == testResult.path } }
+        val testResults = testResultRecords
+            .plus(previousTestResultRecord)
+            .filter { testResult -> excludedAPIs.none { it == testResult.path } }
+
         val testResultsWithNotImplementedEndpoints =
             identifyFailedTestsDueToUnimplementedEndpointsAddMissingTests(testResults)
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -1,0 +1,193 @@
+package io.specmatic.test.reports.coverage
+
+import io.specmatic.reporter.model.TestResult
+import io.specmatic.test.TestResultRecord
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenApiCoverageReportInputTest {
+    @Test
+    fun `should generate report with only current records when no previous results are provided`() {
+        val currentRecord = TestResultRecord(
+            path = "/current",
+            method = "GET",
+            responseStatus = 200,
+            result = TestResult.Success
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(currentRecord),
+            previousTestResultRecord = emptyList()
+        )
+
+        val report = input.generate()
+        assertThat(report.coverageRows).anyMatch { row -> row.path == "/current" && row.method == "GET" && row.responseStatus == "200" }
+        assertThat(report.coverageRows).noneMatch { row -> row.path == "/previous" }
+    }
+
+    @Test
+    fun `should include previous test results in the coverage report generation`() {
+        val currentRecord = TestResultRecord(
+            path = "/current",
+            method = "GET",
+            responseStatus = 200,
+            result = TestResult.Success
+        )
+
+        val previousRecord = TestResultRecord(
+            path = "/previous",
+            method = "POST",
+            responseStatus = 201,
+            result = TestResult.Success
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(currentRecord),
+            previousTestResultRecord = listOf(previousRecord)
+        )
+
+        val report = input.generate()
+        assertThat(report.coverageRows).anyMatch { row -> row.path == "/current" && row.method == "GET" && row.responseStatus == "200" }
+        assertThat(report.coverageRows).anyMatch { row -> row.path == "/previous" && row.method == "POST" && row.responseStatus == "201" }
+    }
+
+    @Test
+    fun `should calculate coverage percentage with only current results`() {
+        val endpoint1 = Endpoint(path = "/current", method = "GET", responseStatus = 200)
+        val endpoint2 = Endpoint(path = "/previous", method = "POST", responseStatus = 201)
+        val endpoint3 = Endpoint(path = "/uncovered", method = "GET", responseStatus = 404)
+
+        val allEndpoints = mutableListOf(endpoint1, endpoint2, endpoint3)
+        val currentRecord = TestResultRecord(
+            path = "/current",
+            method = "GET",
+            responseStatus = 200,
+            result = TestResult.Success
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(currentRecord),
+            previousTestResultRecord = emptyList(),
+            allEndpoints = allEndpoints
+        )
+
+        val report = input.generate()
+        assertThat(report.totalCoveragePercentage).isEqualTo(33)
+        assertThat(report.coverageRows).anyMatch { it.path == "/current" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
+        assertThat(report.coverageRows).anyMatch { it.path == "/previous" && it.remarks.toString() == "not covered" && it.coveragePercentage == 0 }
+        assertThat(report.coverageRows).anyMatch { it.path == "/uncovered" && it.remarks.toString() == "invalid" && it.coveragePercentage == 0 }
+    }
+
+    @Test
+    fun `should calculate coverage percentage including previous test results and uncovered endpoints`() {
+        val endpoint1 = Endpoint(path = "/current", method = "GET", responseStatus = 200)
+        val endpoint2 = Endpoint(path = "/previous", method = "POST", responseStatus = 201)
+        val endpoint3 = Endpoint(path = "/uncovered", method = "GET", responseStatus = 404)
+
+        val allEndpoints = mutableListOf(endpoint1, endpoint2, endpoint3)
+        val currentRecord = TestResultRecord(
+            path = "/current",
+            method = "GET",
+            responseStatus = 200,
+            result = TestResult.Success
+        )
+
+        val previousRecord = TestResultRecord(
+            path = "/previous",
+            method = "POST",
+            responseStatus = 201,
+            result = TestResult.Success
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(currentRecord),
+            previousTestResultRecord = listOf(previousRecord),
+            allEndpoints = allEndpoints
+        )
+
+        val report = input.generate()
+        assertThat(report.totalCoveragePercentage).isEqualTo(66)
+        assertThat(report.coverageRows).anyMatch { it.path == "/current" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
+        assertThat(report.coverageRows).anyMatch { it.path == "/previous" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
+        assertThat(report.coverageRows).anyMatch { it.path == "/uncovered" && it.remarks.toString() == "invalid" && it.coveragePercentage == 0 }
+    }
+
+    @Test
+    fun `should calculate coverage for a single path with mixed results excluding previous runs`() {
+        val endpoint1 = Endpoint(path = "/resource", method = "GET", responseStatus = 200)
+        val endpoint2 = Endpoint(path = "/resource", method = "POST", responseStatus = 201)
+        val endpoint3 = Endpoint(path = "/resource", method = "DELETE", responseStatus = 204)
+
+        val allEndpoints = mutableListOf(endpoint1, endpoint2, endpoint3)
+        val currentRecord = TestResultRecord(
+            path = "/resource",
+            method = "GET",
+            responseStatus = 200,
+            result = TestResult.Success
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(currentRecord),
+            previousTestResultRecord = emptyList(),
+            allEndpoints = allEndpoints
+        )
+
+        val report = input.generate()
+        assertThat(report.totalCoveragePercentage).isEqualTo(33)
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/resource" && it.method == "GET" &&  it.remarks.toString() == "covered" &&  it.coveragePercentage == 33
+        }
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/resource" && it.method == "POST" && it.remarks.toString() == "not covered" && it.coveragePercentage == 33
+        }
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/resource" && it.method == "DELETE" && it.remarks.toString() == "not covered" && it.coveragePercentage == 33
+        }
+    }
+
+    @Test
+    fun `should calculate coverage for a single path with mixed results including previous runs`() {
+        val endpoint1 = Endpoint(path = "/resource", method = "GET", responseStatus = 200)
+        val endpoint2 = Endpoint(path = "/resource", method = "POST", responseStatus = 201)
+        val endpoint3 = Endpoint(path = "/resource", method = "DELETE", responseStatus = 204)
+
+        val allEndpoints = mutableListOf(endpoint1, endpoint2, endpoint3)
+        val currentRecord = TestResultRecord(
+            path = "/resource",
+            method = "GET",
+            responseStatus = 200,
+            result = TestResult.Success
+        )
+
+        val previousRecord = TestResultRecord(
+            path = "/resource",
+            method = "POST",
+            responseStatus = 201,
+            result = TestResult.Success
+        )
+
+        val input = OpenApiCoverageReportInput(
+            configFilePath = "specmatic.yaml",
+            testResultRecords = mutableListOf(currentRecord),
+            previousTestResultRecord = listOf(previousRecord),
+            allEndpoints = allEndpoints
+        )
+
+        val report = input.generate()
+        assertThat(report.totalCoveragePercentage).isEqualTo(66)
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/resource" && it.method == "GET" &&  it.remarks.toString() == "covered" &&  it.coveragePercentage == 67
+        }
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/resource" && it.method == "POST" && it.remarks.toString() == "covered" && it.coveragePercentage == 67
+        }
+        assertThat(report.coverageRows).anyMatch {
+            it.path == "/resource" && it.method == "DELETE" && it.remarks.toString() == "not covered" && it.coveragePercentage == 67
+        }
+    }
+}


### PR DESCRIPTION
**What**: Include previous tests in ContractTest via ContractTestSettings

**How**:
- Consider the previous test in case it is a sub-run provided through ContracTestSettings.
- The previous test currently only affects the path and overall coverage calculations.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)