### PR TITLE
Utilize filtered endpoints to calculate report coverage

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -798,7 +798,7 @@ data class Feature(
             !strictMode || it.hasExampleRows()
         }.flatMap { originalScenario ->
             val badRequestOrDefault = getBadRequestsOrDefault(originalScenario)
-            if (badRequestOrDefault == null && getBadRequestsOrDefault(originalScenario, originalScenarios) != null) {
+            if (badRequestOrDefaultWasFilteredOut(badRequestOrDefault, originalScenario, originalScenarios)) {
                 return@flatMap emptySequence()
             }
 
@@ -823,6 +823,12 @@ data class Feature(
             }
         }
     }
+
+    private fun badRequestOrDefaultWasFilteredOut(
+        badRequestOrDefault: BadRequestOrDefault?,
+        originalScenario: Scenario,
+        originalScenarios: List<Scenario>
+    ): Boolean = badRequestOrDefault == null && getBadRequestsOrDefault(originalScenario, originalScenarios) != null
 
     fun negativeScenarioFor(scenario: Scenario): Scenario {
         return scenario.negativeBasedOn(getBadRequestsOrDefault(scenario))

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -709,7 +709,7 @@ paths:
     @Nested
     inner class FeatureToOpenAPI {
         @Test
-        fun `should provide unique names to body schemas under the same endpoint`()     {
+        fun `should provide unique names to body schemas under the same endpoint`() {
             val requestPattern = HttpRequestPattern(
                 httpPathPattern = HttpPathPattern.from("/orders/(id:string)"), method = "POST",
                 headersPattern = HttpHeadersPattern(mapOf("headerKey" to StringPattern())),

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -709,7 +709,7 @@ paths:
     @Nested
     inner class FeatureToOpenAPI {
         @Test
-        fun `should provide unique names to body schemas under the same endpoint`() {
+        fun `should provide unique names to body schemas under the same endpoint`()     {
             val requestPattern = HttpRequestPattern(
                 httpPathPattern = HttpPathPattern.from("/orders/(id:string)"), method = "POST",
                 headersPattern = HttpHeadersPattern(mapOf("headerKey" to StringPattern())),
@@ -1123,5 +1123,61 @@ paths:
         }
 
         assertThat(stdout).doesNotContain("Could not find the Specmatic configuration at path")
+    }
+
+    @Test
+    fun `should filter out scenario when 4xx definitions are missing from Feature but present in originalScenarios`() {
+        val path = "/orders/(id:string)"
+        val orderPostOk = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST", body = DeferredPattern("(RequestBody)")),
+            httpResponsePattern = HttpResponsePattern(status = 201),
+            patterns = mapOf("(RequestBody)" to toJSONObjectPattern("""{"digit": "(number)"}""", "(RequestBody"))
+        ))
+
+        val orderPostBadRequest = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST"),
+            httpResponsePattern = HttpResponsePattern(status = 400)
+        ))
+
+        val allScenarios = listOf(orderPostOk, orderPostBadRequest)
+        val featureSubset = Feature(name = "Orders Subset", scenarios = listOf(orderPostOk))
+
+        val results = featureSubset.negativeTestScenarios(originalScenarios = allScenarios).toList()
+        assertThat(results)
+            .withFailMessage("Expected no negative scenarios because the required 4xx definition was filtered out of the feature")
+            .isEmpty()
+    }
+
+    @Test
+    fun `should NOT filter out scenario when 4xx definitions are present in the Feature`() {
+        val path = "/orders/(id:string)"
+        val orderPostOk = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST", body = DeferredPattern("(RequestBody)")),
+            httpResponsePattern = HttpResponsePattern(status = 201),
+            patterns = mapOf("(RequestBody)" to toJSONObjectPattern("""{"digit": "(number)"}""", "(RequestBody"))
+        ))
+
+        val orderPostBadRequest = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST"),
+            httpResponsePattern = HttpResponsePattern(status = 400)
+        ))
+
+        val featureComplete = Feature(name = "Orders Complete", scenarios = listOf(orderPostOk, orderPostBadRequest))
+        val results = featureComplete.negativeTestScenarios(originalScenarios = featureComplete.scenarios).toList()
+        assertThat(results).hasSize(3)
+    }
+
+    @Test
+    fun `should NOT filter out scenario when 4xx definitions are missing from the Feature as well as originalScenarios`() {
+        val path = "/orders/(id:string)"
+        val orderPostOk = Scenario(ScenarioInfo(
+            httpRequestPattern = HttpRequestPattern(httpPathPattern = HttpPathPattern.from(path), method = "POST", body = DeferredPattern("(RequestBody)")),
+            httpResponsePattern = HttpResponsePattern(status = 201),
+            patterns = mapOf("(RequestBody)" to toJSONObjectPattern("""{"digit": "(number)"}""", "(RequestBody"))
+        ))
+
+        val featureComplete = Feature(name = "Orders Complete", scenarios = listOf(orderPostOk))
+        val results = featureComplete.negativeTestScenarios(originalScenarios = featureComplete.scenarios).toList()
+        assertThat(results).hasSize(3)
     }
 }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -88,10 +88,11 @@ open class SpecmaticJUnitSupport {
 
     internal val openApiCoverageReportInput: OpenApiCoverageReportInput =
         OpenApiCoverageReportInput(
-            getConfigFileWithAbsolutePath(),
+            configFilePath = getConfigFileWithAbsolutePath(),
+            filterExpression = settings.filter,
             coverageHooks = settings.coverageHooks,
             httpInteractionsLog = httpInteractionsLog,
-            previousTestResultRecord = settings.previousTestRuns
+            previousTestResultRecord = settings.previousTestRuns,
         )
 
     private val threads: Vector<String> = Vector<String>()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
@@ -27,6 +27,7 @@ interface TestReportListener {
     fun onActuator(enabled: Boolean)
     fun onActuatorApis(apis: List<API>)
     fun onEndpointApis(apis: List<Endpoint>)
+    fun onFilteredEndpointApis(apis: List<Endpoint>)
     fun onTestResult(result: TestExecutionResult)
     fun onTestsComplete()
     fun onCoverageCalculated(coverage: Int)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
@@ -27,7 +27,6 @@ interface TestReportListener {
     fun onActuator(enabled: Boolean)
     fun onActuatorApis(apis: List<API>)
     fun onEndpointApis(apis: List<Endpoint>)
-    fun onFilteredEndpointApis(apis: List<Endpoint>)
     fun onTestResult(result: TestExecutionResult)
     fun onTestsComplete()
     fun onCoverageCalculated(coverage: Int)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -61,7 +61,6 @@ class OpenApiCoverageReportInput(
         this.allEndpoints.addAll(allEndpoints)
         coverageHooks.onEachListener { onEndpointApis(allEndpoints) }
         this.filteredEndpoints.addAll(filteredEndpoints)
-        coverageHooks.onEachListener { onFilteredEndpointApis(allEndpoints) }
     }
 
     fun setEndpointsAPIFlag(isSet: Boolean) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -33,6 +33,7 @@ class OpenApiCoverageReportInput(
     private val coverageHooks: List<TestReportListener> = emptyList(),
     private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog(),
     private val previousTestResultRecord: List<TestResultRecord> = emptyList(),
+    private val filteredEndpoints: MutableList<Endpoint> = mutableListOf(),
 ) {
     fun totalDuration(): Long {
         return httpInteractionsLog.totalDuration()
@@ -56,9 +57,11 @@ class OpenApiCoverageReportInput(
         excludedAPIs.addAll(apis)
     }
 
-    fun addEndpoints(endpoints: List<Endpoint>) {
-        coverageHooks.onEachListener { onEndpointApis(endpoints) }
-        allEndpoints.addAll(endpoints)
+    fun addEndpoints(allEndpoints: List<Endpoint>, filteredEndpoints: List<Endpoint>) {
+        this.allEndpoints.addAll(allEndpoints)
+        coverageHooks.onEachListener { onEndpointApis(allEndpoints) }
+        this.filteredEndpoints.addAll(filteredEndpoints)
+        coverageHooks.onEachListener { onFilteredEndpointApis(allEndpoints) }
     }
 
     fun setEndpointsAPIFlag(isSet: Boolean) {
@@ -79,7 +82,7 @@ class OpenApiCoverageReportInput(
             identifyFailedTestsDueToUnimplementedEndpointsAddMissingTests(testResults)
 
         return addTestResultsForMissingEndpoints(testResultsWithNotImplementedEndpoints)
-            .addTestResultsForTestsNotGeneratedBySpecmatic(allEndpoints)
+            .addTestResultsForTestsNotGeneratedBySpecmatic(filteredEndpoints)
             .identifyWipTestsAndUpdateResult()
             .checkForInvalidTestsAndUpdateResult()
     }
@@ -150,9 +153,9 @@ class OpenApiCoverageReportInput(
         )
     }
 
-    private fun List<TestResultRecord>.addTestResultsForTestsNotGeneratedBySpecmatic(allEndpoints: List<Endpoint>): List<TestResultRecord> {
+    private fun List<TestResultRecord>.addTestResultsForTestsNotGeneratedBySpecmatic(endpoints: List<Endpoint>): List<TestResultRecord> {
         val endpointsWithoutTests =
-            allEndpoints.filter { endpoint ->
+            endpoints.filter { endpoint ->
                 this.none { it.path == endpoint.path && it.method == endpoint.method && it.responseStatus == endpoint.responseStatus }
                         && excludedAPIs.none { it == endpoint.path }
             }
@@ -258,7 +261,6 @@ class OpenApiCoverageReportInput(
         val testResultsForMissingAPIs = applicationAPIs.filter { api ->
             val noTestResultFoundForThisAPI = allEndpoints.none { it.path == api.path && it.method == api.method }
             val isNotExcluded = api.path !in excludedAPIs
-
             noTestResultFoundForThisAPI && isNotExcluded
         }.map { api ->
             TestResultRecord(
@@ -298,7 +300,6 @@ class OpenApiCoverageReportInput(
         val failedTestResults = testResults.filter { it.result == TestResult.Failed }
 
         for (failedTestResult in failedTestResults) {
-
             val pathHasErrorResponse = allEndpoints.any {
                 it.path == failedTestResult.path && it.method == failedTestResult.method && it.responseStatus == failedTestResult.actualResponseStatus
             }
@@ -318,8 +319,7 @@ class OpenApiCoverageReportInput(
                 continue
             }
 
-            val isInApplicationAPI =
-                applicationAPIs.any { api -> api.path == failedTestResult.path && api.method == failedTestResult.method }
+            val isInApplicationAPI = applicationAPIs.any { api -> api.path == failedTestResult.path && api.method == failedTestResult.method }
             notImplementedAndMissingTests.add(failedTestResult.copy(result = if (isInApplicationAPI) TestResult.Failed else TestResult.NotImplemented))
         }
 

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
@@ -337,7 +337,7 @@ class ApiCoverageReportInputTest {
             Endpoint("/route2", "GET", 400)
         )
 
-        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = allEndpoints, endpointsAPISet = true).generate()
+        val apiCoverageReport = OpenApiCoverageReportInput(CONFIG_FILE_PATH, testReportRecords, applicationAPIs, allEndpoints = allEndpoints, filteredEndpoints = allEndpoints, endpointsAPISet = true).generate()
         println(CoverageReportTextRenderer().render(apiCoverageReport, specmaticConfig))
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportStatusTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportStatusTest.kt
@@ -206,6 +206,7 @@ class ApiCoverageReportStatusTest {
             contractTestResults,
             applicationAPIs,
             allEndpoints = endpointsInSpec,
+            filteredEndpoints = endpointsInSpec,
             endpointsAPISet = true
         ).generate()
         assertThat(apiCoverageReport.coverageRows).isEqualTo(

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportTest.kt
@@ -17,6 +17,7 @@ class ApiCoverageReportTest {
             testResultRecords: MutableList<TestResultRecord>,
             allEndpoints: MutableList<Endpoint>,
             applicationAPIS: MutableList<API>? = null,
+            filteredEndpoints: MutableList<Endpoint> = mutableListOf(),
         ): OpenAPICoverageConsoleReport {
             if (applicationAPIS != null) {
                 return OpenApiCoverageReportInput(
@@ -24,11 +25,12 @@ class ApiCoverageReportTest {
                     testResultRecords,
                     applicationAPIS,
                     allEndpoints = allEndpoints,
+                    filteredEndpoints = filteredEndpoints,
                     endpointsAPISet = true
                 ).generate()
             }
             return OpenApiCoverageReportInput(
-                CONFIG_FILE_PATH, testResultRecords, allEndpoints = allEndpoints
+                CONFIG_FILE_PATH, testResultRecords, allEndpoints = allEndpoints, filteredEndpoints = filteredEndpoints,
             ).generate()
         }
     }
@@ -132,7 +134,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200, TestResult.Failed, actualResponseStatus = 404)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -156,7 +158,7 @@ class ApiCoverageReportTest {
             TestResultRecord("/order/{id}", "POST", 201, TestResult.Failed, actualResponseStatus = 404),
             TestResultRecord("/order/{id}", "POST", 400, TestResult.Failed, actualResponseStatus = 404)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIS)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIS, filteredEndpoints = endpointsInSpec)
 
 
         assertThat(apiCoverageReport).isEqualTo(
@@ -178,7 +180,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200, TestResult.Failed, actualResponseStatus = 404)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -201,7 +203,7 @@ class ApiCoverageReportTest {
             TestResultRecord("/order/{id}", "POST", 201, TestResult.Failed, actualResponseStatus = 404),
             TestResultRecord("/order/{id}", "POST", 400, TestResult.Failed, actualResponseStatus = 404)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -225,7 +227,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200, TestResult.Success, actualResponseStatus = 200)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs, filteredEndpoints = endpointsInSpec)
 
 
         assertThat(apiCoverageReport).isEqualTo(
@@ -252,7 +254,7 @@ class ApiCoverageReportTest {
             TestResultRecord("/order/{id}", "POST", 201, TestResult.Success, actualResponseStatus = 201),
             TestResultRecord("/order/{id}", "POST", 400, TestResult.Success, actualResponseStatus = 400)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -274,7 +276,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200, TestResult.Success, actualResponseStatus = 200)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -297,7 +299,7 @@ class ApiCoverageReportTest {
             TestResultRecord("/order/{id}", "POST", 201, TestResult.Success, actualResponseStatus = 201),
             TestResultRecord("/order/{id}", "POST", 400, TestResult.Success, actualResponseStatus = 400)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -366,7 +368,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200, TestResult.Failed, actualResponseStatus = 404)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -386,7 +388,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/order/{id}", "GET", 200, TestResult.Failed, actualResponseStatus = 404)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, filteredEndpoints = endpointsInSpec)
 
         assertThat(apiCoverageReport).isEqualTo(
             OpenAPICoverageConsoleReport(
@@ -431,7 +433,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/orders", "GET", 200, TestResult.Failed, actualResponseStatus = 404)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, filteredEndpoints = endpointsInSpec)
 
         assertThat(
             apiCoverageReport
@@ -457,7 +459,7 @@ class ApiCoverageReportTest {
         val testResultRecords = mutableListOf(
             TestResultRecord("/orders", "GET", 200, TestResult.Success, actualResponseStatus = 200)
         )
-        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs)
+        val apiCoverageReport = generateCoverageReport(testResultRecords, endpointsInSpec, applicationAPIs, filteredEndpoints = endpointsInSpec)
 
         assertThat(
             apiCoverageReport

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -236,7 +236,7 @@ class OpenApiCoverageReportInputTest {
     }
 
     @Test
-    fun `filtered endpoints should be used to find not-implemented endpoints instead of all endpoints`() {
+    fun `not-implemented endpoints should be identified using filtered endpoints instead of all endpoints`() {
         val allEndpoints = mutableListOf(Endpoint("/test", "POST", 200), Endpoint("/filtered", "POST", 200))
         val filtered = mutableListOf(Endpoint("/test", "POST", 200))
         val testResultRecords = mutableListOf(TestResultRecord("/test", "POST", 200, TestResult.Failed, actualResponseStatus = 0))


### PR DESCRIPTION
**What**:
- Use filtered endpoints to calculate report coverage
- Use all endpoints to identify `Missing In Spec` and `Not Implemented` remarks
- Enable the execution of negative tests even when the 2xx counterparts are filtered out

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
