### PR TITLE
Modify the Dictionary implementation to be lenient by default

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/BasicAuthSecurityScheme.kt
@@ -92,7 +92,7 @@ data class BasicAuthSecurityScheme(private val token: String? = null) : OpenAPIS
     private fun getTokenFromDictionary(resolver: Resolver): ReturnValue<String>? {
         val updatedResolver = resolver.updateLookupForParam(BreadCrumb.HEADER.value)
         val dictionaryValue = updatedResolver.dictionary.getValueFor(AUTHORIZATION, StringPattern(), updatedResolver)
-        val authHeader = dictionaryValue?.unwrapOrContractException() ?: return null
+        val authHeader = dictionaryValue ?: return null
 
         if (authHeader !is StringValue) return HasFailure(Result.Failure(
             breadCrumb = BreadCrumb.HEADER.with(AUTHORIZATION),

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -88,8 +88,8 @@ class OpenApiSpecification(
     private val specificationPath: String? = null,
     private val securityConfiguration: SecurityConfiguration? = null,
     private val specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
-    private val dictionary: Dictionary = loadDictionary(openApiFilePath, specmaticConfig.getStubDictionary()),
-    private val strictMode: Boolean = false
+    private val strictMode: Boolean = false,
+    private val dictionary: Dictionary = loadDictionary(openApiFilePath, specmaticConfig.getStubDictionary(), strictMode),
 ) : IncludedSpecification, ApiSpecification {
     init {
         StringProviders // Trigger early initialization of StringProviders to ensure all providers are loaded at startup

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -268,9 +268,9 @@ class OpenApiSpecification(
             )
         }
 
-        fun loadDictionary(openApiFilePath: String, dictionaryPathFromConfig: String?): Dictionary {
+        fun loadDictionary(openApiFilePath: String, dictionaryPathFromConfig: String?, strictMode: Boolean = false): Dictionary {
             val dictionaryFile = getDictionaryFile(File(openApiFilePath), dictionaryPathFromConfig)
-            return if (dictionaryFile != null) Dictionary.from(dictionaryFile) else Dictionary.empty()
+            return if (dictionaryFile != null) Dictionary.from(dictionaryFile, strictMode) else Dictionary.empty(strictMode)
         }
 
         private fun getDictionaryFile(openApiFile: File, dictionaryPathFromConfig: String?): File? {

--- a/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
@@ -133,15 +133,21 @@ data class Dictionary(
     private fun resetFocus(): Dictionary = copy(focusedData = emptyMap())
 
     private fun selectValue(pattern: Pattern, values: List<Value>, resolver: Resolver): Value? {
-        if (!strictMode) return selectValueLenient(pattern, values, resolver)
-        return selectValueLenient(pattern, values, resolver) ?: throw ContractException(
-            errorMessage = """
-            None of the dictionary values matched the schema.
-            This could happen due to conflicts in the dictionary at the same json path, due to conflicting dataTypes at the same json path between multiple payloads
-            strictMode enforces the presence of matching values in the dictionary if the json-path is present
-            Either ensure that a matching value exists in the dictionary or disable strictMode
-            """.trimIndent()
-        )
+        val lenientlySelectedValue = selectValueLenient(pattern, values, resolver)
+
+        if (strictMode && lenientlySelectedValue == null) {
+            throw ContractException(
+                errorMessage =
+                    """
+                    None of the dictionary values matched the schema.
+                    This could happen due to conflicts in the dictionary at the same json path, due to conflicting dataTypes at the same json path between multiple payloads
+                    strictMode enforces the presence of matching values in the dictionary if the json-path is present
+                    Either ensure that a matching value exists in the dictionary or disable strictMode
+                    """.trimIndent(),
+            )
+        }
+
+        return lenientlySelectedValue
     }
 
     private fun selectValueLenient(pattern: Pattern, values: List<Value>, resolver: Resolver): Value? {

--- a/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Dictionary.kt
@@ -136,7 +136,7 @@ data class Dictionary(
         if (strictMode) return values.randomOrNull()
         return values.shuffled().firstOrNull { value ->
             runCatching {
-                val result = pattern.matches(value, resolver)
+                val result = pattern.matches(value, resolver.copy(findKeyErrorCheck = noPatternKeyCheckDictionary))
                 if (result is Result.Failure) {
                     logger.debug("Invalid value $value from dictionary for ${pattern.typeName}")
                     logger.debug(result.reportString())
@@ -151,6 +151,7 @@ data class Dictionary(
 
     companion object {
         private const val SPECMATIC_CONSTANTS = "SPECMATIC_CONSTANTS"
+        private val noPatternKeyCheckDictionary = KeyCheck(noPatternKeyCheck, IgnoreUnexpectedKeys)
 
         fun from(file: File, strictMode: Boolean = false): Dictionary {
             if (!file.exists()) throw ContractException(

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -264,11 +264,17 @@ data class Resolver(
             focusIntoProperty(keyPattern, focusKey, this@Resolver)
         }
 
-        return this.copy(
+        val patternUpdatedResolver = this.copy(
             dictionaryLookupPath = lookupPath,
             lookupPathsSeenSoFar = lookupPathsSeenSoFar.plus(lookupPath),
             dictionary = keyFocused
         )
+
+        return if (keyWithPattern?.pattern?.typeAlias == null || builtInPatterns.contains(keyWithPattern.pattern.typeAlias)) {
+            patternUpdatedResolver
+        } else {
+            patternUpdatedResolver.updateLookupPath(keyWithPattern.pattern.typeAlias)
+        }
     }
 
     fun <T> updateLookupPath(pattern: T, childPattern: Pattern): Resolver where T: Pattern, T: SequenceType {

--- a/core/src/main/kotlin/io/specmatic/core/Resolver.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Resolver.kt
@@ -218,7 +218,7 @@ data class Resolver(
     fun generate(pattern: Pattern): Value {
         val valueFromDict = dictionary.getValueFor(dictionaryLookupPath, pattern, this)
         if (valueFromDict != null) {
-            return valueFromDict.unwrapOrContractException()
+            return valueFromDict
         }
 
         val defaultValueFromDict = dictionary.getDefaultValueFor(pattern, this)
@@ -322,11 +322,7 @@ data class Resolver(
     fun generateList(pattern: ListPattern): Value {
         val patternFocused = updateLookupPath(pattern.typeAlias)
         val valueFromDict = patternFocused.dictionary.getValueFor(patternFocused.dictionaryLookupPath, pattern, this)
-        if (valueFromDict != null) {
-            return valueFromDict.unwrapOrContractException()
-        }
-
-        return this.updateLookupPath(pattern, pattern.pattern).generateRandomList(pattern.pattern)
+        return valueFromDict ?: this.updateLookupPath(pattern, pattern.pattern).generateRandomList(pattern.pattern)
     }
 
     private fun generateRandomList(pattern: Pattern): Value {

--- a/core/src/main/kotlin/io/specmatic/stub/api.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/api.kt
@@ -1063,6 +1063,7 @@ fun loadIfSupportedAPISpecification(
                 contractPathData.repository,
                 contractPathData.branch,
                 contractPathData.specificationPath,
+                strictMode = specmaticConfig.getStubStrictMode() ?: false
             ).copy(specmaticConfig = specmaticConfig),
         )
     } catch (e: Throwable) {

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -1046,7 +1046,10 @@ class DictionaryTest {
 
             assertThat(exception.report()).containsIgnoringWhitespaces("""
             >> commonKey
-            Invalid Dictionary value at ".commonKey"
+            None of the dictionary values matched the schema.
+            This could happen due to conflicts in the dictionary at the same json path, due to conflicting dataTypes at the same json path between multiple payloads
+            strictMode enforces the presence of matching values in the dictionary if the json-path is present
+            Either ensure that a matching value exists in the dictionary or disable strictMode
             """.trimIndent())
         }
     }

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -1024,16 +1024,16 @@ class DictionaryTest {
             val commonKeyValue = value.jsonObject.getValue("commonKey")
             assertThat(commonKeyValue).isInstanceOf(BooleanValue::class.java)
             assertThat(stdout).containsIgnoringWhitespaces("""
-            Invalid value Twenty from dictionary for boolean
-            Expected boolean, actual was "Twenty"
+            >> DICTIONARY..commonKey
+            Expected boolean but got "Twenty" in the dictionary
             """.trimIndent())
             assertThat(stdout).containsIgnoringWhitespaces("""
-            Invalid value specmatic@test.io from dictionary for boolean
-            Expected boolean, actual was "specmatic@test.io"
+            >> DICTIONARY..commonKey
+            Expected boolean but got 10 (number) in the dictionary
             """.trimIndent())
             assertThat(stdout).containsIgnoringWhitespaces("""
-            Invalid value 10 from dictionary for boolean
-            Expected boolean, actual was 10 (number)
+            >> DICTIONARY..commonKey
+            Expected boolean but got "specmatic@test.io" in the dictionary
             """.trimIndent())
         }
 

--- a/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
+++ b/core/src/test/kotlin/integration_tests/PartialExampleTest.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.log.DebugLogger
 import io.specmatic.core.log.withLogger
 import io.specmatic.core.pattern.parsedJSONObject
+import io.specmatic.core.utilities.Flags.Companion.STUB_STRICT_MODE
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
@@ -448,6 +449,7 @@ class PartialExampleTest {
     fun `partial example using invalid dictionary should throw an error at runtime`() {
         try {
             System.setProperty(SPECMATIC_STUB_DICTIONARY, "src/test/resources/openapi/substitutions/dictionary.json")
+            System.setProperty(STUB_STRICT_MODE, "true")
 
             createStubFromContracts(
                 listOf("src/test/resources/openapi/substitutions/partial_with_invalid_dictionary_value.yaml"),
@@ -466,6 +468,7 @@ class PartialExampleTest {
             }
         } finally {
             System.clearProperty(SPECMATIC_STUB_DICTIONARY)
+            System.clearProperty(STUB_STRICT_MODE)
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/EnumPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/EnumPatternTest.kt
@@ -185,7 +185,7 @@ class EnumPatternTest {
         val enumPattern = EnumPattern(enumValues, typeAlias = "(AnimalType)")
         val jsonPattern = JSONObjectPattern(mapOf("type" to enumPattern), typeAlias = "(Test)")
 
-        val dictionary = "Test: { type: Dog }".let(Dictionary::fromYaml)
+        val dictionary = "AnimalType: Dog".let(Dictionary::fromYaml)
         val resolver = Resolver(newPatterns = mapOf("(AnimalType)" to enumPattern), dictionary = dictionary)
         val value = JSONObjectValue(mapOf("type" to StringValue("(AnimalType)")))
         val filledInValue = jsonPattern.fillInTheBlanks(value, resolver).value

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -916,9 +916,11 @@ internal class JSONObjectPatternTest {
         }
 
         assertThat(exception.report()).isEqualToNormalizingWhitespace("""
-        >> addresses[0]
-        Invalid Dictionary value at "Person.addresses"
-        Expected string, actual was 10 (number)
+        >> addresses
+        None of the dictionary values matched the schema.
+        This could happen due to conflicts in the dictionary at the same json path, due to conflicting dataTypes at the same json path between multiple payloads
+        strictMode enforces the presence of matching values in the dictionary if the json-path is present
+        Either ensure that a matching value exists in the dictionary or disable strictMode
         """.trimIndent())
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/JSONObjectPatternTest.kt
@@ -893,7 +893,7 @@ internal class JSONObjectPatternTest {
     }
 
     @Test
-    fun `should throw an exception when dictionary values in an array do not match`() {
+    fun `should throw an exception when dictionary values in an array do not match with strict mode`() {
         val personTypeAlias = "(Person)"
 
         val personPattern = JSONObjectPattern(
@@ -908,7 +908,7 @@ internal class JSONObjectPatternTest {
 
         val resolver = Resolver(
             newPatterns = mapOf(personTypeAlias to personPattern),
-            dictionary = dictionary
+            dictionary = dictionary.copy(strictMode = true)
         )
 
         val exception = assertThrows<ContractException> {
@@ -1080,7 +1080,7 @@ internal class JSONObjectPatternTest {
     }
 
     @Test
-    fun `throw exception when example is found but invalid `() {
+    fun `throw exception when example is found but invalid with strict mode`() {
         val personTypeAlias = "(Person)"
 
         val personPattern = JSONObjectPattern(
@@ -1095,7 +1095,7 @@ internal class JSONObjectPatternTest {
         val dictionary = "Person: { id: $id }".let(Dictionary::fromYaml)
         val resolver = Resolver(
             newPatterns = mapOf(personTypeAlias to personPattern),
-            dictionary = dictionary
+            dictionary = dictionary.copy(strictMode = true)
         )
 
         assertThatThrownBy {


### PR DESCRIPTION
**What**: Modify the Dictionary implementation to be lenient by default

**How**:
The dictionary attempts to select the best value from the provided options without causing a complete failure in the generation process, It can be configured by activating strict mode, which will restore the original behavior of providing immediate feedback

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)