### PR TITLE
Ensure schema with allOf is included in the final pattern

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1791,7 +1791,14 @@ class OpenApiSpecification(
             logger.boundary()
         }
 
-        if (resolvedSchema != referredSchema) return overrideToPattern(resolvedSchema, typeStack, patternName)
+        if (resolvedSchema != referredSchema) {
+            if (patternName.isNotBlank() && typeStack.contains(patternName)) return DeferredPattern("($patternName)")
+            val finalPattern = overrideToPattern(resolvedSchema, typeStack, patternName)
+            if (patternName.isBlank() || patternName.contains(".")) return finalPattern
+            cacheComponentPattern(patternName, finalPattern)
+            return DeferredPattern("($patternName)")
+        }
+
         if (typeStack.contains(componentName)) return DeferredPattern("($componentName)")
         val componentPattern = overrideToPattern(resolvedSchema, typeStack.plus(componentName), componentName)
         cacheComponentPattern(componentName, componentPattern)

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1504,9 +1504,6 @@ class OpenApiSpecification(
     }
 
     private fun resolveDeepAllOfs(schema: Schema<*>, discriminatorDetails: DiscriminatorDetails, typeStack: Set<String>, topLevel: Boolean): Pair<List<Schema<*>>, DiscriminatorDetails> {
-        if (schema.allOf == null)
-            return listOf(schema) to discriminatorDetails
-
         // Pair<String [property name], Map<String [possible value], Pair<String [Schema name derived from the ref], Schema<Any> [reffed schema]>>>
         val newDiscriminatorDetailsDetails: Triple<String, Map<String, Pair<String, List<Schema<*>>>>, DiscriminatorDetails>? = if (!topLevel) null else schema.discriminator?.let { rawDiscriminator ->
             rawDiscriminator.propertyName?.let { propertyName ->
@@ -1545,7 +1542,8 @@ class OpenApiSpecification(
             }
         }
 
-        val allOfs = schema.allOf.mapNotNull { constituentSchema ->
+        val schemasToProcess = schema.allOf.orEmpty().plus(schema)
+        val allOfs = schemasToProcess.mapNotNull { constituentSchema ->
             if (constituentSchema.`$ref` != null) {
                 val (_, referredSchema) = resolveReferenceToSchema(constituentSchema.`$ref`)
 

--- a/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
+++ b/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
@@ -160,19 +160,32 @@ class OpenApi31Test {
         assertThat(oneOfObjectComponent.pattern).containsKey("id?")
         assertThat(oneOfObjectComponent.pattern["id?"]).isInstanceOf(NumberPattern::class.java)
 
-        // AllOf Schema (Merged properties: baseId + details)
+        // AllOf Schema (Merged properties: baseId? + details)
         val allOfScenario = feature.scenarios.elementAt(18)
         val allOfRequestBody = resolvedHop(allOfScenario.httpRequestPattern.body, allOfScenario.resolver)
         val allOfResponseBody = resolvedHop(allOfScenario.httpResponsePattern.body, allOfScenario.resolver)
 
         assertThat(allOfRequestBody).isEqualTo(allOfResponseBody)
         assertThat(allOfRequestBody).isInstanceOf(JSONObjectPattern::class.java); allOfRequestBody as JSONObjectPattern
-        assertThat(allOfRequestBody.pattern.keys).containsExactlyInAnyOrder("baseId?", "details?")
+        assertThat(allOfRequestBody.pattern.keys).containsExactlyInAnyOrder("baseId?", "details")
         assertThat(allOfRequestBody.pattern["baseId?"]).isInstanceOf(UUIDPattern::class.java)
-        assertThat(allOfRequestBody.pattern["details?"]).isInstanceOf(StringPattern::class.java)
+        assertThat(allOfRequestBody.pattern["details"]).isInstanceOf(StringPattern::class.java)
+
+        // AllOf Schema with top level properties [topLevelMandatory(UUID) + topLevelOptional? + AllOf(baseId(UUID) + details?(String))]
+        val allOfWithTopLevelPropertiesScenario = feature.scenarios.elementAt(20)
+        val allOfWithTopLevelPropertiesRequestBody = resolvedHop(allOfWithTopLevelPropertiesScenario.httpRequestPattern.body, allOfWithTopLevelPropertiesScenario.resolver)
+        val allOfWithTopLevelPropertiesResponseBody = resolvedHop(allOfWithTopLevelPropertiesScenario.httpResponsePattern.body, allOfWithTopLevelPropertiesScenario.resolver)
+
+        assertThat(allOfWithTopLevelPropertiesRequestBody).isEqualTo(allOfWithTopLevelPropertiesResponseBody)
+        assertThat(allOfWithTopLevelPropertiesRequestBody).isInstanceOf(JSONObjectPattern::class.java); allOfWithTopLevelPropertiesRequestBody as JSONObjectPattern
+        assertThat(allOfWithTopLevelPropertiesRequestBody.pattern.keys).containsExactlyInAnyOrder("baseId?", "details", "topLevelMandatory", "topLevelOptional?")
+        assertThat(allOfWithTopLevelPropertiesRequestBody.pattern["baseId?"]).isInstanceOf(UUIDPattern::class.java)
+        assertThat(allOfWithTopLevelPropertiesRequestBody.pattern["details"]).isInstanceOf(StringPattern::class.java)
+        assertThat(allOfWithTopLevelPropertiesRequestBody.pattern["topLevelMandatory"]).isInstanceOf(UUIDPattern::class.java)
+        assertThat(allOfWithTopLevelPropertiesRequestBody.pattern["topLevelOptional?"]).isInstanceOf(StringPattern::class.java)
 
         // AnyOf Schema [String, Integer, Boolean]
-        val anyOfScenario = feature.scenarios.elementAt(20)
+        val anyOfScenario = feature.scenarios.elementAt(22)
         val anyOfRequestBody = resolvedHop(anyOfScenario.httpRequestPattern.body, anyOfScenario.resolver)
         val anyOfResponseBody = resolvedHop(anyOfScenario.httpResponsePattern.body, anyOfScenario.resolver)
 
@@ -197,7 +210,7 @@ class OpenApi31Test {
             feature.executeTests(stub.client)
         }.results
 
-        assertThat(results.size).isEqualTo(61)
+        assertThat(results.size).isEqualTo(87)
         assertThat(Result.fromResults(results))
             .withFailMessage { Result.fromResults(results).reportString() }
             .isInstanceOf(Result.Success::class.java)
@@ -215,7 +228,7 @@ class OpenApi31Test {
             openApi30Specification.toFeature().copy(specmaticConfig = specmaticConfig).executeTests(stub.client)
         }.results
 
-        assertThat(results.size).isEqualTo(61 + 2) // +2 Due to multiTypEnum representation
+        assertThat(results.size).isEqualTo(87 + 2) // +2 Due to multiTypEnum representation
         assertThat(Result.fromResults(results))
             .withFailMessage { Result.fromResults(results).reportString() }
             .isInstanceOf(Result.Success::class.java)
@@ -233,7 +246,7 @@ class OpenApi31Test {
             openApi31Specification.toFeature().copy(specmaticConfig = specmaticConfig).executeTests(stub.client)
         }.results
 
-        assertThat(results.size).isEqualTo(61)
+        assertThat(results.size).isEqualTo(87)
         assertThat(Result.fromResults(results))
             .withFailMessage { Result.fromResults(results).reportString() }
             .isInstanceOf(Result.Success::class.java)
@@ -249,13 +262,13 @@ class OpenApi31Test {
         val openApi31Feature = ScenarioFilter(filterClauses = backwardCompatibilityFilter).filter(openApi31Specification.toFeature())
 
         val openApi30To31 = testBackwardCompatibility(openApi30Feature, openApi31Feature)
-        assertThat(openApi30To31.results).hasSize(40)
+        assertThat(openApi30To31.results).hasSize(44)
         assertThat(Result.fromResults(openApi30To31.results))
             .withFailMessage { Result.fromResults(openApi30To31.results).reportString() }
             .isInstanceOf(Result.Success::class.java)
 
         val openApi31To30 = testBackwardCompatibility(openApi31Feature, openApi30Feature)
-        assertThat(openApi31To30.results).hasSize(40)
+        assertThat(openApi31To30.results).hasSize(44)
         assertThat(Result.fromResults(openApi31To30.results))
             .withFailMessage { Result.fromResults(openApi31To30.results).reportString() }
             .isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/integration_tests/YamlToPatternTests.kt
+++ b/core/src/test/kotlin/integration_tests/YamlToPatternTests.kt
@@ -907,7 +907,27 @@ class YamlToPatternTests {
                         assertFailure(pattern.match(mapOf("id" to 1)))
                         assertFailure(pattern.match(mapOf("name" to "Alice")))
                     }
-                }
+                },
+                multiVersionCase("allOf with additional top-level object", OpenApiVersion.OAS30, OpenApiVersion.OAS31) {
+                    schema {
+                        put("type", "object")
+                        put("allOf", listOf(
+                            mapOf(
+                                "type" to "object",
+                                "properties" to mapOf("id" to mapOf("type" to "integer")),
+                                "required" to listOf("id")
+                            ),
+                        ))
+                        put("properties", mapOf("name" to mapOf("type" to "string")))
+                        put("required", listOf("name"))
+                    }
+                    validate { pattern ->
+                        assertThat(pattern).isInstanceOf(JSONObjectPattern::class.java)
+                        assertSuccess(pattern.match(mapOf("id" to 1, "name" to "Alice")))
+                        assertFailure(pattern.match(mapOf("id" to 1)))
+                        assertFailure(pattern.match(mapOf("name" to "Alice")))
+                    }
+                },
             ).flatten().stream()
         }
 

--- a/core/src/test/resources/openapi/3_1/mixed/openapi30.yaml
+++ b/core/src/test/resources/openapi/3_1/mixed/openapi30.yaml
@@ -195,6 +195,25 @@ paths:
         '400':
           description: Bad Request
 
+  /allOfWithTopLevelPropertiesSchema:
+    post:
+      summary: Handle allOf schema with top level properties
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AllOfWithTopLevelPropertiesSchema'
+      responses:
+        '201':
+          description: Successfully created allOf with top level properties
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllOfWithTopLevelPropertiesSchema'
+        '400':
+          description: Bad Request
+
   /anyOfSchema:
     post:
       summary: Handle anyOf schema
@@ -322,6 +341,21 @@ components:
           properties:
             details:
               type: string
+          required:
+            - details
+
+    AllOfWithTopLevelPropertiesSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AllOfSchema'
+      properties:
+        topLevelMandatory:
+          type: string
+          format: uuid
+        topLevelOptional:
+          type: string
+      required:
+        - topLevelMandatory
 
     AnyOfSchema:
       anyOf:

--- a/core/src/test/resources/openapi/3_1/mixed/openapi31.yaml
+++ b/core/src/test/resources/openapi/3_1/mixed/openapi31.yaml
@@ -195,6 +195,25 @@ paths:
         '400':
           description: Bad Request
 
+  /allOfWithTopLevelPropertiesSchema:
+    post:
+      summary: Handle allOf schema with top level properties
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AllOfWithTopLevelPropertiesSchema'
+      responses:
+        '201':
+          description: Successfully created allOf with top level properties
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllOfWithTopLevelPropertiesSchema'
+        '400':
+          description: Bad Request
+
   /anyOfSchema:
     post:
       summary: Handle anyOf schema
@@ -321,6 +340,21 @@ components:
           properties:
             details:
               type: string
+          required:
+            - details
+
+    AllOfWithTopLevelPropertiesSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AllOfSchema'
+      properties:
+        topLevelMandatory:
+          type: string
+          format: uuid
+        topLevelOptional:
+          type: string
+      required:
+        - topLevelMandatory
 
     AnyOfSchema:
       anyOf:


### PR DESCRIPTION
**What**: Ensure schema with allOf is included in the final pattern

**Why**:
```schema
{
  "type": "object",
  "properties": { "type": { "type": "string", "enum": ["user", "admin"] } },
  "required": ["type"],
  "allOf": [{ "$ref": "#/components/schemas/TimestampMixin" }]
}
```
Becomes: allOf: `[TimestampMixin, {type: "object", properties: {type: {...}}, required: ["type"]}]​`

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
