### PR TITLE
fix: use correct path breadcrumb while parsing the spec

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1574,7 +1574,16 @@ class OpenApiSpecification(
     private fun toSpecmaticPattern(
         schema: Schema<*>, typeStack: List<String>, patternName: String = "", jsonInFormData: Boolean = false, breadCrumb: String = ""
     ): Pattern {
-        if(patternName.isNotBlank()) logger.debug("Processing schema $patternName")
+        val debugMessage =
+            if(patternName.isNotBlank()) {
+                "Processing schema $patternName"
+            } else if (breadCrumb.isNotBlank()) {
+                "Processing schema at $breadCrumb"
+            } else {
+                "Processing inline schema"
+            }
+
+        logger.debug(debugMessage)
 
         val preExistingResult = patterns["($patternName)"]
         if (preExistingResult != null && patternName.isNotBlank()) return preExistingResult
@@ -2287,7 +2296,7 @@ class OpenApiSpecification(
             )
 
             URLPathSegmentPattern(
-                pattern = toSpecmaticPattern(param.schema, emptyList(), "$schemaLocationDescription.$paramName"),
+                pattern = toSpecmaticPattern(param.schema, emptyList(), patternName = "", breadCrumb = "$schemaLocationDescription.$paramName"),
                 key = paramName
             )
         }


### PR DESCRIPTION
During parsing pass the path schema location as breadcrumb instead of patternName

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
