### PR TITLE
Coverage Report Fixes

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -276,35 +276,50 @@ class OpenApiCoverageReportInput(
     }
 
     private fun identifyFailedTestsDueToUnimplementedEndpointsAddMissingTests(testResults: List<TestResultRecord>): List<TestResultRecord> {
-        val notImplementedAndMissingTests = mutableListOf<TestResultRecord>()
-        val failedTestResults = testResults.filter { it.result == TestResult.Failed }
-
-        for (failedTestResult in failedTestResults) {
-            val endpointExistsInSpecification = allEndpoints.any {
-                it.path == failedTestResult.path && it.method == failedTestResult.method && it.responseStatus == failedTestResult.actualResponseStatus
+        return testResults.map { testResult ->
+            when {
+                testResult.hasFailedAndEndpointIsNotImplemented() -> testResult.copy(result = TestResult.NotImplemented)
+                else -> testResult
             }
-
-            if (!failedTestResult.isConnectionRefused() && !endpointExistsInSpecification) {
-                notImplementedAndMissingTests.add(
-                    failedTestResult.copy(
-                        responseStatus = failedTestResult.actualResponseStatus,
-                        result = TestResult.MissingInSpec,
-                        actualResponseStatus = failedTestResult.actualResponseStatus
-                    )
-                )
-                continue
+        }.flatMap { testResult ->
+            when {
+                testResult.testedEndpointIsMissingInSpec() -> {
+                    createMissingInSpecRecordAndIncludeOriginalRecordIfApplicable(testResult)
+                }
+                else -> listOf(testResult)
             }
-
-            if (!endpointsAPISet) {
-                notImplementedAndMissingTests.add(failedTestResult)
-                continue
-            }
-
-            val isInApplicationAPI = applicationAPIs.any { api -> api.path == failedTestResult.path && api.method == failedTestResult.method }
-            notImplementedAndMissingTests.add(failedTestResult.copy(result = if (isInApplicationAPI) TestResult.Failed else TestResult.NotImplemented))
         }
+    }
 
-        return testResults.minus(failedTestResults.toSet()).plus(notImplementedAndMissingTests)
+    private fun createMissingInSpecRecordAndIncludeOriginalRecordIfApplicable(testResult: TestResultRecord): List<TestResultRecord> = listOfNotNull(
+        testResult.copy(
+            responseStatus = testResult.actualResponseStatus,
+            result = TestResult.MissingInSpec,
+            actualResponseStatus = testResult.actualResponseStatus
+        ),
+        testResult.takeIf {
+            it.sourceEndpointIsPresentInSpec()
+        }
+    )
+
+    private fun TestResultRecord.hasFailedAndEndpointIsNotImplemented(): Boolean {
+        return this.result == TestResult.Failed && endpointsAPISet &&
+                applicationAPIs.none {
+                    it.path == this.path && it.method == this.method
+                }
+    }
+
+    private fun TestResultRecord.testedEndpointIsMissingInSpec(): Boolean {
+        val endpointExistsInSpecification = allEndpoints.any {
+            it.path == this.path && it.method == this.method && it.responseStatus == this.actualResponseStatus
+        }
+        return (!this.isConnectionRefused() && !endpointExistsInSpecification)
+    }
+
+    private fun TestResultRecord.sourceEndpointIsPresentInSpec(): Boolean {
+        return allEndpoints.any {
+            it.path == this.path && it.method == this.method && it.responseStatus == this.responseStatus
+        }
     }
 
     private fun List<TestResultRecord>.checkForInvalidTestsAndUpdateResult(): List<TestResultRecord> {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -280,11 +280,11 @@ class OpenApiCoverageReportInput(
         val failedTestResults = testResults.filter { it.result == TestResult.Failed }
 
         for (failedTestResult in failedTestResults) {
-            val pathHasErrorResponse = allEndpoints.any {
+            val endpointExistsInSpecification = allEndpoints.any {
                 it.path == failedTestResult.path && it.method == failedTestResult.method && it.responseStatus == failedTestResult.actualResponseStatus
             }
 
-            if (!failedTestResult.isConnectionRefused() && !pathHasErrorResponse) {
+            if (!failedTestResult.isConnectionRefused() && !endpointExistsInSpecification) {
                 notImplementedAndMissingTests.add(
                     failedTestResult.copy(
                         responseStatus = failedTestResult.actualResponseStatus,
@@ -292,6 +292,7 @@ class OpenApiCoverageReportInput(
                         actualResponseStatus = failedTestResult.actualResponseStatus
                     )
                 )
+                continue
             }
 
             if (!endpointsAPISet) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.reporter.generated.dto.coverage.CoverageEntry
 import io.specmatic.reporter.generated.dto.coverage.OpenAPICoverageOperation
 import io.specmatic.reporter.generated.dto.coverage.SpecmaticCoverageReport
+import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
 import io.specmatic.test.HttpInteractionsLog
@@ -293,6 +294,7 @@ class OpenApiCoverageReportInput(
 
     private fun createMissingInSpecRecordAndIncludeOriginalRecordIfApplicable(testResult: TestResultRecord): List<TestResultRecord> = listOfNotNull(
         testResult.copy(
+            operation = OpenAPIOperation(testResult.path, testResult.method, testResult.requestContentType.orEmpty(), testResult.actualResponseStatus),
             responseStatus = testResult.actualResponseStatus,
             result = TestResult.MissingInSpec,
             actualResponseStatus = testResult.actualResponseStatus

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
@@ -37,7 +37,7 @@ data class OpenAPICoverageConsoleReport(
 
         val countOfEndpointsHitThatArePresentInSpec = coverageRows.count { it.count.toInt() > 0 && it.remarks != CoverageStatus.MISSING_IN_SPEC }
 
-        return ((countOfEndpointsHitThatArePresentInSpec * 100) / countOfEndpointsPresentInSpec).toDouble().roundToInt()
+        return ((countOfEndpointsHitThatArePresentInSpec * 100) / countOfEndpointsPresentInSpec.toDouble()).roundToInt()
     }
 
     fun getGroupedTestResultRecords(testResultRecords: List<TestResultRecord>): GroupedTestResultRecords {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenAPICoverageConsoleReport.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test.reports.coverage.console
 
+import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.onEachListener
@@ -29,10 +30,14 @@ data class OpenAPICoverageConsoleReport(
     private fun calculateTotalCoveragePercentage(): Int {
         if (totalEndpointsCount == 0) return 0
 
-        val totalCountOfEndpointsWithResponseStatuses = coverageRows.count()
-        val totalCountOfCoveredEndpointsWithResponseStatuses = coverageRows.count { it.count.toInt() > 0 }
+        val countOfEndpointsPresentInSpec =
+            coverageRows.count { it.remarks != CoverageStatus.MISSING_IN_SPEC }
 
-        return ((totalCountOfCoveredEndpointsWithResponseStatuses * 100) / totalCountOfEndpointsWithResponseStatuses).toDouble().roundToInt()
+        if(countOfEndpointsPresentInSpec == 0 ) return 0
+
+        val countOfEndpointsHitThatArePresentInSpec = coverageRows.count { it.count.toInt() > 0 && it.remarks != CoverageStatus.MISSING_IN_SPEC }
+
+        return ((countOfEndpointsHitThatArePresentInSpec * 100) / countOfEndpointsPresentInSpec).toDouble().roundToInt()
     }
 
     fun getGroupedTestResultRecords(testResultRecords: List<TestResultRecord>): GroupedTestResultRecords {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
@@ -12,7 +12,7 @@ class OpenApiCoverageConsoleReportTest {
     fun `test calculates total percentage based on number of exercised endpoints`() {
         val rows = listOf(
             OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 50, CoverageStatus.COVERED),
-            OpenApiCoverageConsoleRow("POST", "/route1", 200, 0, 0, CoverageStatus.MISSING_IN_SPEC),
+            OpenApiCoverageConsoleRow("POST", "/route1", 200, 0, 0, CoverageStatus.NOT_COVERED),
             OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 25, CoverageStatus.COVERED),
             OpenApiCoverageConsoleRow("POST", "/route2", 200, 0, 0, CoverageStatus.NOT_COVERED),
             OpenApiCoverageConsoleRow("POST", "/route2", 400, 0, 0, CoverageStatus.NOT_COVERED),
@@ -44,5 +44,20 @@ class OpenApiCoverageConsoleReportTest {
         val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0)
 
         assertThat(coverageReport.totalCoveragePercentage).isEqualTo(81)
+    }
+
+    @Test
+    fun `test does not include endpoints missing in spec when calculating coverage percentage`() {
+        val rows = listOf(
+            OpenApiCoverageConsoleRow("GET", "/route1", 200, 1, 100, CoverageStatus.COVERED),
+            OpenApiCoverageConsoleRow("POST", "/route1", 200, 1, 100, CoverageStatus.COVERED),
+            OpenApiCoverageConsoleRow("GET", "/route2", 200, 1, 100, CoverageStatus.COVERED),
+            OpenApiCoverageConsoleRow("POST", "/route2", 200, 1, 100, CoverageStatus.COVERED),
+            OpenApiCoverageConsoleRow("GET", "/route3", 200, 1, 0, CoverageStatus.MISSING_IN_SPEC),
+        )
+
+        val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0)
+
+        assertThat(coverageReport.totalCoveragePercentage).isEqualTo(100)
     }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleReportTest.kt
@@ -22,7 +22,7 @@ class OpenApiCoverageConsoleReportTest {
 
         val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 1, partiallyNotImplementedAPICount = 0)
 
-        assertThat(coverageReport.totalCoveragePercentage).isEqualTo(28)
+        assertThat(coverageReport.totalCoveragePercentage).isEqualTo(29)
     }
 
     @Test
@@ -43,7 +43,7 @@ class OpenApiCoverageConsoleReportTest {
 
         val coverageReport = OpenAPICoverageConsoleReport(rows, emptyList(), totalEndpointsCount = 3, missedEndpointsCount = 0, notImplementedAPICount = 0, partiallyMissedEndpointsCount = 0, partiallyNotImplementedAPICount = 0)
 
-        assertThat(coverageReport.totalCoveragePercentage).isEqualTo(81)
+        assertThat(coverageReport.totalCoveragePercentage).isEqualTo(82)
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.test.reports.coverage
 
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
+import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
 import io.specmatic.test.TestResultRecord
@@ -316,6 +317,10 @@ class OpenApiCoverageReportInputTest {
         assertThat(missingInSpecRow.path).isEqualTo("/current")
         assertThat(missingInSpecRow.method).isEqualTo("GET")
         assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
+
+        // Assert that the responseStatus of testResultRecord's operation is updated
+        val missingInSpecTestResult = report.testResultRecords.single { it.result == TestResult.MissingInSpec }
+        assertThat(missingInSpecTestResult.operation).isEqualTo(OpenAPIOperation("/current", "GET", "", 400))
     }
 
     @Test
@@ -364,4 +369,5 @@ class OpenApiCoverageReportInputTest {
         assertThat(missingInSpecRow.method).isEqualTo("GET")
         assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
     }
+
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -270,4 +270,98 @@ class OpenApiCoverageReportInputTest {
         assertThat(report.coverageRows).noneMatch { it.path == "/filtered" }
         assertThat(report.totalCoveragePercentage).isEqualTo(100)
     }
+
+    @Test
+    fun `should report coverage status as 'missing in spec' for failed tests whose operations do not exit in the spec and actualResponseStatus`(){
+        val allEndpoints = mutableListOf(Endpoint(path = "/current", method = "GET", responseStatus = 200))
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord(
+                "/current",
+                "GET",
+                200,
+                request = null,
+                response = null,
+                result = TestResult.Success,
+                actualResponseStatus = 200
+            ),
+            TestResultRecord(
+                "/current",
+                "GET",
+                400,
+                request = null,
+                response = null,
+                result = TestResult.Failed,
+                actualResponseStatus = 400
+            ),
+        )
+
+        val reportInput = OpenApiCoverageReportInput(
+            testResultRecords = testResultRecords, configFilePath = "", endpointsAPISet = true,
+            allEndpoints = allEndpoints
+        )
+        val report = reportInput.generate()
+
+        assertThat(report.coverageRows).size().isEqualTo(2)
+        val coveredRows = report.coverageRows.filter { it.remarks == CoverageStatus.COVERED }
+        assertThat(coveredRows).size().isEqualTo(1)
+        val coveredRow = coveredRows.first()
+        assertThat(coveredRow.path).isEqualTo("/current")
+        assertThat(coveredRow.method).isEqualTo("GET")
+        assertThat(coveredRow.responseStatus).isEqualTo("200")
+
+        val missingInSpecRows = report.coverageRows.filter { it.remarks == CoverageStatus.MISSING_IN_SPEC }
+        assertThat(missingInSpecRows).size().isEqualTo(1)
+        val missingInSpecRow = missingInSpecRows.first()
+        assertThat(missingInSpecRow.path).isEqualTo("/current")
+        assertThat(missingInSpecRow.method).isEqualTo("GET")
+        assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
+    }
+
+//    @Test
+//    fun `should report coverage status as 'missing in spec' for successful tests whose operations do not exit in the spec and actualResponseStatus`(){
+//        val allEndpoints = mutableListOf(Endpoint(path = "/current", method = "GET", responseStatus = 200))
+//
+//        val testResultRecords = mutableListOf(
+//            TestResultRecord(
+//                "/current",
+//                "GET",
+//                200,
+//                request = null,
+//                response = null,
+//                result = TestResult.Success,
+//                actualResponseStatus = 200
+//            ),
+//            TestResultRecord(
+//                "/current",
+//                "GET",
+//                400,
+//                request = null,
+//                response = null,
+//                result = TestResult.Success,
+//                actualResponseStatus = 400
+//            ),
+//        )
+//
+//        val reportInput = OpenApiCoverageReportInput(
+//            testResultRecords = testResultRecords, configFilePath = "", endpointsAPISet = true,
+//            allEndpoints = allEndpoints
+//        )
+//        val report = reportInput.generate()
+//
+//        assertThat(report.coverageRows).size().isEqualTo(2)
+//        val coveredRows = report.coverageRows.filter { it.remarks == CoverageStatus.COVERED }
+//        assertThat(coveredRows).size().isEqualTo(1)
+//        val coveredRow = coveredRows.first()
+//        assertThat(coveredRow.path).isEqualTo("/current")
+//        assertThat(coveredRow.method).isEqualTo("GET")
+//        assertThat(coveredRow.responseStatus).isEqualTo("200")
+//
+//        val missingInSpecRows = report.coverageRows.filter { it.remarks == CoverageStatus.MISSING_IN_SPEC }
+//        assertThat(missingInSpecRows).size().isEqualTo(1)
+//        val missingInSpecRow = missingInSpecRows.first()
+//        assertThat(missingInSpecRow.path).isEqualTo("/current")
+//        assertThat(missingInSpecRow.method).isEqualTo("GET")
+//        assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
+//    }
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -126,7 +126,7 @@ class OpenApiCoverageReportInputTest {
         )
 
         val report = input.generate()
-        assertThat(report.totalCoveragePercentage).isEqualTo(66)
+        assertThat(report.totalCoveragePercentage).isEqualTo(67)
         assertThat(report.coverageRows).anyMatch { it.path == "/current" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
         assertThat(report.coverageRows).anyMatch { it.path == "/previous" && it.remarks.toString() == "covered" && it.coveragePercentage == 100 }
         assertThat(report.coverageRows).anyMatch { it.path == "/uncovered" && it.remarks.toString() == "invalid" && it.coveragePercentage == 0 }
@@ -203,7 +203,7 @@ class OpenApiCoverageReportInputTest {
         )
 
         val report = input.generate()
-        assertThat(report.totalCoveragePercentage).isEqualTo(66)
+        assertThat(report.totalCoveragePercentage).isEqualTo(67)
         assertThat(report.coverageRows).anyMatch {
             it.path == "/resource" && it.method == "GET" &&  it.remarks.toString() == "covered" &&  it.coveragePercentage == 67
         }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -318,50 +318,50 @@ class OpenApiCoverageReportInputTest {
         assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
     }
 
-//    @Test
-//    fun `should report coverage status as 'missing in spec' for successful tests whose operations do not exit in the spec and actualResponseStatus`(){
-//        val allEndpoints = mutableListOf(Endpoint(path = "/current", method = "GET", responseStatus = 200))
-//
-//        val testResultRecords = mutableListOf(
-//            TestResultRecord(
-//                "/current",
-//                "GET",
-//                200,
-//                request = null,
-//                response = null,
-//                result = TestResult.Success,
-//                actualResponseStatus = 200
-//            ),
-//            TestResultRecord(
-//                "/current",
-//                "GET",
-//                400,
-//                request = null,
-//                response = null,
-//                result = TestResult.Success,
-//                actualResponseStatus = 400
-//            ),
-//        )
-//
-//        val reportInput = OpenApiCoverageReportInput(
-//            testResultRecords = testResultRecords, configFilePath = "", endpointsAPISet = true,
-//            allEndpoints = allEndpoints
-//        )
-//        val report = reportInput.generate()
-//
-//        assertThat(report.coverageRows).size().isEqualTo(2)
-//        val coveredRows = report.coverageRows.filter { it.remarks == CoverageStatus.COVERED }
-//        assertThat(coveredRows).size().isEqualTo(1)
-//        val coveredRow = coveredRows.first()
-//        assertThat(coveredRow.path).isEqualTo("/current")
-//        assertThat(coveredRow.method).isEqualTo("GET")
-//        assertThat(coveredRow.responseStatus).isEqualTo("200")
-//
-//        val missingInSpecRows = report.coverageRows.filter { it.remarks == CoverageStatus.MISSING_IN_SPEC }
-//        assertThat(missingInSpecRows).size().isEqualTo(1)
-//        val missingInSpecRow = missingInSpecRows.first()
-//        assertThat(missingInSpecRow.path).isEqualTo("/current")
-//        assertThat(missingInSpecRow.method).isEqualTo("GET")
-//        assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
-//    }
+    @Test
+    fun `should report coverage status as 'missing in spec' for successful tests whose operations do not exit in the spec and actualResponseStatus`(){
+        val allEndpoints = mutableListOf(Endpoint(path = "/current", method = "GET", responseStatus = 200))
+
+        val testResultRecords = mutableListOf(
+            TestResultRecord(
+                "/current",
+                "GET",
+                200,
+                request = null,
+                response = null,
+                result = TestResult.Success,
+                actualResponseStatus = 200
+            ),
+            TestResultRecord(
+                "/current",
+                "GET",
+                400,
+                request = null,
+                response = null,
+                result = TestResult.Success,
+                actualResponseStatus = 400
+            ),
+        )
+
+        val reportInput = OpenApiCoverageReportInput(
+            testResultRecords = testResultRecords, configFilePath = "", endpointsAPISet = true,
+            allEndpoints = allEndpoints
+        )
+        val report = reportInput.generate()
+
+        assertThat(report.coverageRows).size().isEqualTo(2)
+        val coveredRows = report.coverageRows.filter { it.remarks == CoverageStatus.COVERED }
+        assertThat(coveredRows).size().isEqualTo(1)
+        val coveredRow = coveredRows.first()
+        assertThat(coveredRow.path).isEqualTo("/current")
+        assertThat(coveredRow.method).isEqualTo("GET")
+        assertThat(coveredRow.responseStatus).isEqualTo("200")
+
+        val missingInSpecRows = report.coverageRows.filter { it.remarks == CoverageStatus.MISSING_IN_SPEC }
+        assertThat(missingInSpecRows).size().isEqualTo(1)
+        val missingInSpecRow = missingInSpecRows.first()
+        assertThat(missingInSpecRow.path).isEqualTo("/current")
+        assertThat(missingInSpecRow.method).isEqualTo("GET")
+        assertThat(missingInSpecRow.responseStatus).isEqualTo("400")
+    }
 }


### PR DESCRIPTION
This PR fixes the following issues in the generation of the coverage report:
1. The report was not indicating "missing in spec" operations correctly. This was  due to duplicate test records being added for "missing in spec" tests. This is now fixed
2. When calculating coverage percentage, the current logic includes "missing in spec" operations (which causes discrepancies in Insights). Hence, "missing in spec" operations will not be considered while calculating coverage percentage.