### PR TITLE
Fix requestContentType handling in reports

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -40,7 +40,7 @@ data class TestResultRecord(
     override val operation: APIOperation = OpenAPIOperation(
         path = path,
         method = method,
-        contentType = requestContentType.orEmpty(),
+        contentType = requestContentType,
         responseCode = responseStatus
     )
 ): CtrfTestResultRecord {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -165,6 +165,7 @@ class OpenApiCoverageReportInput(
                 TestResultRecord(
                     path = endpoint.path,
                     method = endpoint.method,
+                    requestContentType = endpoint.requestContentType,
                     responseStatus = endpoint.responseStatus,
                     request = null,
                     response = null,


### PR DESCRIPTION
This PR includes the following fixes:
1. Inclusion of requestContentType for not covered test result records (which was previously being skipped)
2. requestContentType to be sent  as null wherever it is not applicable or available (instead of passing an empty string)
