### PR TITLE
Fix to exit code

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
@@ -23,7 +23,6 @@ private fun colorIsRequested() = System.getenv("SPECMATIC_COLOR") == "1"
 private fun stdOutIsRedirected() = System.console() == null
 
 class ContractExecutionListener : TestExecutionListener {
-
     companion object {
         private var success: Int = 0
         private var failure: Int = 0
@@ -39,15 +38,13 @@ class ContractExecutionListener : TestExecutionListener {
             exitProcess(exitStatus())
         }
 
-        internal fun exitStatus(): Int = if (testSuiteFailed || couldNotStart) 1 else 0
-
+        internal fun exitStatus(): Int = if (testSuiteFailed || couldNotStart || failure > 0) 1 else 0
     }
 
     override fun executionFinished(testIdentifier: TestIdentifier?, testExecutionResult: TestExecutionResult?) {
         if (testIdentifier != null &&
             testIdentifier.type == TestDescriptor.Type.CONTAINER
-            ) {
-
+        ) {
             testExecutionResult?.let {
                 it.throwable?.ifPresent { throwable -> exceptionsThrown.add(throwable) }
                 if (it.status != Status.SUCCESSFUL) {
@@ -62,15 +59,15 @@ class ContractExecutionListener : TestExecutionListener {
         printer.printTestSummary(testIdentifier, testExecutionResult)
 
         when (testExecutionResult?.status) {
-            TestExecutionResult.Status.SUCCESSFUL -> {
+            Status.SUCCESSFUL -> {
                 success++
                 println()
             }
-            TestExecutionResult.Status.ABORTED -> {
+            Status.ABORTED -> {
                 aborted++
                 printAndLogFailure(testExecutionResult, testIdentifier)
             }
-            TestExecutionResult.Status.FAILED -> {
+            Status.FAILED -> {
                 failure++
                 printAndLogFailure(testExecutionResult, testIdentifier)
             }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
@@ -39,6 +39,16 @@ class ContractExecutionListener : TestExecutionListener {
         }
 
         internal fun exitStatus(): Int = if (testSuiteFailed || couldNotStart || failure > 0) 1 else 0
+
+        internal fun reset() {
+            success = 0
+            failure = 0
+            aborted = 0
+            couldNotStart = false
+            testSuiteFailed = false
+            failedLog.clear()
+            exceptionsThrown.clear()
+        }
     }
 
     override fun executionFinished(testIdentifier: TestIdentifier?, testExecutionResult: TestExecutionResult?) {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/listeners/ContractExecutionListenerTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/listeners/ContractExecutionListenerTest.kt
@@ -1,0 +1,103 @@
+package io.specmatic.test.listeners
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import io.specmatic.core.Result
+import io.specmatic.core.ScenarioDetailsForResult
+import io.specmatic.test.SpecmaticJUnitSupport
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor
+import org.junit.platform.launcher.TestIdentifier
+import java.util.UUID
+
+class ContractExecutionListenerTest {
+    @BeforeEach
+    fun resetState() {
+        ContractExecutionListener.reset()
+        SpecmaticJUnitSupport.partialSuccesses.clear()
+    }
+
+    @Test
+    fun `exit status is 0 when all tests pass`() {
+        val listener = ContractExecutionListener()
+
+        listener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.successful())
+        listener.testPlanExecutionFinished(null)
+
+        assertEquals(0, ContractExecutionListener.exitStatus())
+    }
+
+    @Test
+    fun `exit status is 0 when tests are aborted but none fail`() {
+        val listener = ContractExecutionListener()
+
+        listener.executionFinished(
+            testIdentifier(TestDescriptor.Type.TEST),
+            TestExecutionResult.aborted(RuntimeException("skipped"))
+        )
+        listener.testPlanExecutionFinished(null)
+
+        assertEquals(0, ContractExecutionListener.exitStatus())
+    }
+
+    @Test
+    fun `test plan reports partial successes`() {
+        val listener = ContractExecutionListener()
+
+        val partialSuccess = Result.Success(partialSuccessMessage = "partial coverage")
+        partialSuccess.scenario = FakeScenario()
+        SpecmaticJUnitSupport.partialSuccesses.add(partialSuccess)
+
+        listener.testPlanExecutionFinished(null)
+
+        assertEquals(0, ContractExecutionListener.exitStatus())
+    }
+
+    @Test
+    fun `exit status is 1 when the test suite fails`() {
+        val listener = ContractExecutionListener()
+
+        listener.executionFinished(testIdentifier(TestDescriptor.Type.TEST), TestExecutionResult.successful())
+        listener.executionFinished(
+            testIdentifier(TestDescriptor.Type.CONTAINER),
+            TestExecutionResult.failed(RuntimeException("coverage threshold not met"))
+        )
+        listener.testPlanExecutionFinished(null)
+
+        assertEquals(1, ContractExecutionListener.exitStatus())
+    }
+
+    @Test
+    fun `exit status is 1 when any test fails`() {
+        val listener = ContractExecutionListener()
+
+        listener.executionFinished(
+            testIdentifier(TestDescriptor.Type.TEST),
+            TestExecutionResult.failed(AssertionError("boom"))
+        )
+        listener.testPlanExecutionFinished(null)
+
+        assertEquals(1, ContractExecutionListener.exitStatus())
+    }
+}
+
+private fun testIdentifier(type: TestDescriptor.Type): TestIdentifier {
+    val uniqueId = UniqueId.forEngine("specmatic-tests").append("id", UUID.randomUUID().toString())
+    val descriptor = object : AbstractTestDescriptor(uniqueId, "sample") {
+        override fun getType(): TestDescriptor.Type = type
+    }
+    return TestIdentifier.from(descriptor)
+}
+
+private class FakeScenario : ScenarioDetailsForResult {
+    override val status: Int = 200
+    override val ignoreFailure: Boolean = false
+    override val name: String = "Partial success scenario"
+    override val method: String = "GET"
+    override val path: String = "/partial-success"
+
+    override fun testDescription(): String = name
+}


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Exit code should be 1 when tests have failed. This was broken in a recent commit.


**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
