### PR TITLE
Fix case-insensitive Host header removal in proxy

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -289,7 +289,7 @@ data class HttpRequest(
             return headers
 
         if (isNotIPAddress(url.host))
-            return headers - "Host"
+            return headers.filterKeys { !it.equals("Host", ignoreCase = true) }
 
         return headers
     }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -255,6 +255,17 @@ internal class HttpRequestTest {
     }
 
     @Test
+    fun `should remove lowercase host header to avoid duplicates`() {
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            this.url.host = "target.com"
+            this.url.port = 80
+        }
+        HttpRequest("GET", "/", headers = mapOf("host" to "original.com"))
+            .buildKTORRequest(httpRequestBuilder, java.net.URL("http://target.com/"))
+        assertThat(httpRequestBuilder.headers["Host"]).isEqualTo("target.com")
+    }
+
+    @Test
     fun `should formulate a loggable error in non-strict mode`() {
         val request = spyk(
             HttpRequest(


### PR DESCRIPTION
**What**:

Fix case-insensitive Host header removal in proxy mode.

**Why**:

The `withoutDuplicateHostHeader` function was using `headers - "Host"` which only removes headers with exact case match. HTTP clients like node-fetch send lowercase `host:` headers, which were not being removed. This caused duplicate Host headers to be forwarded to the target server, resulting in 421 TLS certificate mismatch errors from CDNs like Fastly.

**How**:

Updated the Host header removal logic to use case-insensitive matching.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A