### PR TITLE
Replace Int with Long for effectiveMin and max in Number Pattern

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/NumberPattern.kt
@@ -27,8 +27,8 @@ data class NumberPattern(
     private fun minValueIsSet() = minimum != null
     private fun maxValueIsSet() = maximum != null
     private fun minAndMaxValuesNotSet() = minimum == null && maximum == null
-    private val lowerBound = if (isDoubleFormat) BigDecimal(-Double.MAX_VALUE) else BigDecimal(Int.MIN_VALUE)
-    private val upperBound = if (isDoubleFormat) BigDecimal(Double.MAX_VALUE) else BigDecimal(Int.MAX_VALUE)
+    private val lowerBound = if (isDoubleFormat) BigDecimal(-Double.MAX_VALUE) else BigDecimal(Long.MIN_VALUE)
+    private val upperBound = if (isDoubleFormat) BigDecimal(Double.MAX_VALUE) else BigDecimal(Long.MAX_VALUE)
     private val smallInc = BigDecimal("1")
 
     private val effectiveMax =
@@ -97,7 +97,7 @@ data class NumberPattern(
         val number = if (isDoubleFormat)
             SecureRandom().nextDouble(effectiveMin.toDouble(), effectiveMax.toDouble())
         else
-            SecureRandom().nextInt(effectiveMin.toInt(), effectiveMax.toInt())
+            SecureRandom().nextLong(effectiveMin.toLong(), effectiveMax.toLong())
         return NumberValue(number)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/pattern/NumberPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/NumberPatternTest.kt
@@ -194,7 +194,7 @@ internal class NumberPatternTest {
 
     @Test
     fun `should match number of any length when min and max are not specified`() {
-        val randomNumber = RandomStringUtils.randomNumeric((1..9).random()).toInt()
+        val randomNumber = RandomStringUtils.randomNumeric((1..9).random()).toLong()
         assertThat(NumberPattern().matches(NumberValue(randomNumber), Resolver()).isSuccess()).isTrue
     }
 
@@ -204,7 +204,7 @@ internal class NumberPatternTest {
         val generatedValues = (0..5).map { NumberPattern(minimum = minimum).generate(Resolver()) }
         assertThat(generatedValues).allSatisfy {
             it as NumberValue
-            assertThat(it.number as Int).isGreaterThanOrEqualTo(minimum.toInt())
+            assertThat(it.number as Long).isGreaterThanOrEqualTo(minimum.toLong())
         }
     }
 
@@ -214,7 +214,7 @@ internal class NumberPatternTest {
         val generatedValues = (0..5).map { NumberPattern(maximum = maximum).generate(Resolver()) }
         assertThat(generatedValues).allSatisfy {
             it as NumberValue
-            assertThat(it.number as Int).isLessThanOrEqualTo(maximum.toInt())
+            assertThat(it.number as Long).isLessThanOrEqualTo(maximum.toLong())
         }
     }
 
@@ -225,7 +225,7 @@ internal class NumberPatternTest {
         val generatedValues = (0..5).map { NumberPattern(minimum = minimum, maximum = maximum).generate(Resolver()) }
         assertThat(generatedValues).allSatisfy {
             it as NumberValue
-            assertThat(it.number as Int).isGreaterThanOrEqualTo(minimum.toInt()).isLessThanOrEqualTo(maximum.toInt())
+            assertThat(it.number as Long).isGreaterThanOrEqualTo(minimum.toLong()).isLessThanOrEqualTo(maximum.toLong())
         }
     }
 
@@ -254,7 +254,7 @@ internal class NumberPatternTest {
         val generatedValues = (0..5).map { NumberPattern(maximum = maximum).generate(Resolver()) }
         assertThat(generatedValues).allSatisfy {
             it as NumberValue
-            assertThat(it.number as Int).isLessThanOrEqualTo(maximum.toInt())
+            assertThat(it.number as Long).isLessThanOrEqualTo(maximum.toLong())
         }
     }
 
@@ -265,7 +265,7 @@ internal class NumberPatternTest {
         val generatedValues = (0..5).map { NumberPattern(minimum = minimum, maximum = maximum).generate(Resolver()) }
         assertThat(generatedValues).allSatisfy {
             it as NumberValue
-            assertThat(it.number as Int).isGreaterThanOrEqualTo(minimum.toInt()).isLessThanOrEqualTo(maximum.toInt())
+            assertThat(it.number as Long).isGreaterThanOrEqualTo(minimum.toLong()).isLessThanOrEqualTo(maximum.toLong())
         }
     }
 
@@ -282,7 +282,7 @@ internal class NumberPatternTest {
         }
         assertThat(generatedValues).allSatisfy {
             it as NumberValue
-            assertThat(it.number as Int).isGreaterThanOrEqualTo(minimum.toInt()).isLessThanOrEqualTo(maximum.toInt())
+            assertThat(it.number as Long).isGreaterThanOrEqualTo(minimum.toLong()).isLessThanOrEqualTo(maximum.toLong())
         }
     }
 
@@ -390,12 +390,12 @@ internal class NumberPatternTest {
     @ParameterizedTest
     @CsvSource(
         "givenMin, givenMax, givenType, expectedTestMin, expectedTestMax, exclusive",
-        "none, 10, int, INT_MIN, 10, non-exclusive",
-        "-10, none, int, -10, INT_MAX, non-exclusive",
+        "none, 10, int, LONG_MIN, 10, non-exclusive",
+        "-10, none, int, -10, LONG_MAX, non-exclusive",
         "none, 10.0, double, DOUBLE_MIN, 10.0, non-exclusive",
         "-10.0, none, double, -10.0, DOUBLE_MAX, non-exclusive",
-        "none, 10, int, INT_MIN+1, 10, exclusive",
-        "-10, none, int, -10, INT_MAX-1, exclusive",
+        "none, 10, int, LONG_MIN+1, 10, exclusive",
+        "-10, none, int, -10, LONG_MAX-1, exclusive",
         "none, 10.0, double, DOUBLE_MIN+1, 10.0, exclusive",
         "-10.0, none, double, -10.0, DOUBLE_MAX-1, exclusive",
         useHeadersInDisplayName = true,
@@ -408,18 +408,15 @@ internal class NumberPatternTest {
         expectedTestMax: String,
         exclusivity: String,
     ) {
-        val parseNumber =
-            if (givenType == "int") {
-                { s: String -> BigDecimal(s.toInt()) }
-            } else {
-                { s: String -> BigDecimal(s.toDouble()) }
-            }
+        val parseNumber = when (givenType) {
+            "long" -> { s: String -> BigDecimal(s.toLong()) }
+            else -> { s: String -> BigDecimal(s.toDouble()) }
+        }
 
         val minimum = if (givenMin == "none") null else parseNumber(givenMin)
         val maximum = if (givenMax == "none") null else parseNumber(givenMax)
-
         val exclusive = exclusivity == "exclusive"
-        val isDoubleFormat = givenType != "int"
+        val isDoubleFormat = givenType == "double"
 
         val testValues =
             NumberPattern(
@@ -432,14 +429,14 @@ internal class NumberPatternTest {
 
         val expectedMinTestNumber =
             when (expectedTestMin) {
-                "INT_MIN" -> {
-                    Int.MIN_VALUE
+                "LONG_MIN" -> {
+                    Long.MIN_VALUE
                 }
                 "DOUBLE_MIN" -> {
                     -Double.MAX_VALUE
                 }
-                "INT_MIN+1" -> {
-                    Int.MIN_VALUE + 1
+                "LONG_MIN+1" -> {
+                    Long.MIN_VALUE + 1L
                 }
                 "DOUBLE_MIN+1" -> {
                     -Double.MAX_VALUE + 1
@@ -451,14 +448,14 @@ internal class NumberPatternTest {
 
         val expectedMaxTestNumber =
             when (expectedTestMax) {
-                "INT_MAX" -> {
-                    Int.MAX_VALUE
+                "LONG_MAX" -> {
+                    Long.MAX_VALUE
                 }
                 "DOUBLE_MAX" -> {
                     Double.MAX_VALUE
                 }
-                "INT_MAX-1" -> {
-                    Int.MAX_VALUE - 1
+                "LONG_MAX-1" -> {
+                    Long.MAX_VALUE - 1L
                 }
                 "DOUBLE_MAX-1" -> {
                     Double.MAX_VALUE - 1
@@ -478,12 +475,10 @@ internal class NumberPatternTest {
             it is ExactValuePattern && it.pattern.let { it is NumberValue && it.nativeValue == expectedMaxTestNumber }
         }
 
-        val cast =
-            if (isDoubleFormat) {
-                { number: Number -> BigDecimal(number.toDouble()) }
-            } else {
-                { number: Number -> BigDecimal(number.toInt()) }
-            }
+        val cast = when (givenType) {
+            "long" -> { number: Number -> BigDecimal(number.toLong()) }
+            else -> { number: Number -> BigDecimal(number.toDouble()) }
+        }
 
         assertThat(testValues).anySatisfy {
             it is ExactValuePattern &&
@@ -602,8 +597,8 @@ internal class NumberPatternTest {
 
     @Test
     fun `newBasedOn should include boundary values when enabled boundary testing is enabled`() {
-        val intMinimum = BigDecimal(Int.MIN_VALUE)
-        val intMaximum = BigDecimal(Int.MAX_VALUE)
+        val longMinimum = BigDecimal(Long.MIN_VALUE)
+        val longMaximum = BigDecimal(Long.MAX_VALUE)
 
         val generated =
             NumberPattern(boundaryTestingEnabled = true)
@@ -613,6 +608,25 @@ internal class NumberPatternTest {
 
         val boundaryExactValues = generated.filterIsInstance<ExactValuePattern>().map { (it.pattern as NumberValue).nativeValue as BigDecimal }
 
-        assertThat(boundaryExactValues).contains(intMinimum, intMaximum)
+        assertThat(boundaryExactValues).contains(longMinimum, longMaximum)
+    }
+
+    @Test
+    fun `should match numbers beyond Int range`() {
+        val pattern = NumberPattern(isDoubleFormat = false)
+        val smallerThanIntMin = NumberValue(Int.MIN_VALUE.toLong() - 1L)
+        val largerThanIntMax = NumberValue(Int.MAX_VALUE.toLong() + 1L)
+
+        val resolver = Resolver()
+        val smallerResult = pattern.matches(smallerThanIntMin, resolver)
+        val largerResult = pattern.matches(largerThanIntMax, resolver)
+
+        assertThat(smallerResult.isSuccess())
+            .withFailMessage("Expected value smaller than Int.MIN_VALUE to match, but it failed with: ${smallerResult.reportString()}")
+            .isTrue()
+
+        assertThat(largerResult.isSuccess())
+            .withFailMessage("Expected value larger than Int.MAX_VALUE to match, but it failed with: ${largerResult.reportString()}")
+            .isTrue()
     }
 }


### PR DESCRIPTION
**What**: Replace Int with Long for effectiveMin and effectiveMax in Number Pattern

**Why**: To accommodate larger numeric ranges when matching incoming high-value data

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)