### PR TITLE
Fix host header management in Ktor request conversion

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -234,7 +234,7 @@ data class HttpRequest(
         }.toMap()
     }
 
-    fun buildKTORRequest(httpRequestBuilder: HttpRequestBuilder, url: URL?) {
+    fun buildKTORRequest(httpRequestBuilder: HttpRequestBuilder) {
         httpRequestBuilder.method = HttpMethod.parse(method as String)
 
         val listOfExcludedHeaders: List<String> = listOfExcludedHeaders()

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -238,16 +238,14 @@ data class HttpRequest(
         httpRequestBuilder.method = HttpMethod.parse(method as String)
 
         val listOfExcludedHeaders: List<String> = listOfExcludedHeaders()
-
-        withoutDuplicateHostHeader(headers, url)
-            .map { Triple(it.key.trim(), it.key.trim().lowercase(), it.value.trim()) }
+        headers.map { Triple(it.key.trim(), it.key.trim().lowercase(), it.value.trim()) }
             .filter { (_, loweredKey, _) -> loweredKey !in listOfExcludedHeaders }
             .forEach { (key, _, value) ->
                 httpRequestBuilder.header(key, value)
             }
 
         httpRequestBuilder.url.let {
-            httpRequestBuilder.header("Host", it.authority)
+            httpRequestBuilder.headers.set(name = "Host", value = it.authority)
         }
 
         if(body !is NoBodyValue) {
@@ -278,28 +276,6 @@ data class HttpRequest(
                     }
                 }
             )
-        }
-    }
-
-    private fun withoutDuplicateHostHeader(headers: Map<String, String>, url: URL?): Map<String, String> {
-        if (url === null)
-            return headers
-
-        if (isNotIPAddress(url.host))
-            return headers.filterKeys { !it.equals("Host", ignoreCase = true) }
-
-        return headers
-    }
-
-    private fun isNotIPAddress(host: String): Boolean {
-        return !isIPAddress(host) && host != "localhost"
-    }
-
-    private fun isIPAddress(host: String): Boolean {
-        return try {
-            host.split(".").map { it.toInt() }.isNotEmpty()
-        } catch (e: Throwable) {
-            false
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
+++ b/core/src/main/kotlin/io/specmatic/test/HttpClient.kt
@@ -55,7 +55,7 @@ data class HttpClient(
         return try {
             runBlocking {
                 val ktorResponse: io.ktor.client.statement.HttpResponse = httpClient.value.request(url) {
-                    requestWithFileContent.buildKTORRequest(this, url)
+                    requestWithFileContent.buildKTORRequest(this)
                 }
 
                 val outboundRequest: HttpRequest = ktorHttpRequestToHttpRequestForLogging(ktorResponse.request, requestWithFileContent)

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestKtTest.kt
@@ -15,7 +15,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
-import java.net.URL
 
 internal class HttpRequestKtTest {
     @Test
@@ -264,7 +263,7 @@ internal class HttpRequestKtTest {
         }
 
         val httpRequest = HttpRequest(path = "/test", method = "GET")
-        httpRequest.buildKTORRequest(builder, URL("http://example.com/path"))
+        httpRequest.buildKTORRequest(builder)
         assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly("old.example.com")
         assertThat(builder.url.host).isEqualTo("old.example.com")
     }
@@ -276,7 +275,7 @@ internal class HttpRequestKtTest {
         }
 
         val httpRequest = HttpRequest(path = "/test", method = "GET")
-        httpRequest.buildKTORRequest(builder, URL("http://example.com/path"))
+        httpRequest.buildKTORRequest(builder)
         assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly("old.example.com")
         assertThat(builder.url.host).isEqualTo("old.example.com")
     }
@@ -286,12 +285,12 @@ internal class HttpRequestKtTest {
         val builder = HttpRequestBuilder().apply {
             url("https://old.example.com")
             headers.append("host", "a.example.com")
-            headers.append("HOST", "b.example.com")
-            headers.append("Host", "c.example.com")
+            headers.append("Host", "b.example.com")
+            headers.append("HOST", "c.example.com")
         }
 
         val httpRequest = HttpRequest(path = "/test", method = "GET")
-        httpRequest.buildKTORRequest(builder, URL("http://example.com/path"))
+        httpRequest.buildKTORRequest(builder)
         assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly("old.example.com")
         assertThat(builder.url.host).isEqualTo("old.example.com")
     }
@@ -305,7 +304,7 @@ internal class HttpRequestKtTest {
         }
 
         val httpRequest = HttpRequest(path = "/test", method = "GET")
-        httpRequest.buildKTORRequest(builder, URL("http://irrelevant.example/path"))
+        httpRequest.buildKTORRequest(builder)
         assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly(expectedHost)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestKtTest.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core
 
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.url
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.GherkinSection.When
@@ -9,6 +11,11 @@ import io.specmatic.core.pattern.parsedJSON
 import io.specmatic.core.pattern.parsedValue
 import io.specmatic.core.utilities.jsonStringToValueMap
 import io.specmatic.core.value.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.net.URL
 
 internal class HttpRequestKtTest {
     @Test
@@ -246,6 +253,70 @@ internal class HttpRequestKtTest {
         assertThat(request.multiPartFormData.single().name).isEqualTo("name")
         val filePart = request.multiPartFormData.single() as MultiPartFileValue
         assertThat(filePart.filename).isEqualTo("test.csv")
+    }
+
+    @ParameterizedTest(name = "existing host header ''{0}'' should be replaced from builder url")
+    @ValueSource(strings = ["Host", "host", "HOST"])
+    fun `host header should be replaced regardless of casing`(existingHeaderName: String) {
+        val builder = HttpRequestBuilder().apply {
+            url("https://old.example.com")
+            headers.append(existingHeaderName, "some.other.host")
+        }
+
+        val httpRequest = HttpRequest(path = "/test", method = "GET")
+        httpRequest.buildKTORRequest(builder, URL("http://example.com/path"))
+        assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly("old.example.com")
+        assertThat(builder.url.host).isEqualTo("old.example.com")
+    }
+
+    @Test
+    fun `host header should be set from builder url when no host header exists`() {
+        val builder = HttpRequestBuilder().apply {
+            url("https://old.example.com")
+        }
+
+        val httpRequest = HttpRequest(path = "/test", method = "GET")
+        httpRequest.buildKTORRequest(builder, URL("http://example.com/path"))
+        assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly("old.example.com")
+        assertThat(builder.url.host).isEqualTo("old.example.com")
+    }
+
+    @Test
+    fun `multiple host headers should collapse into single value from builder url`() {
+        val builder = HttpRequestBuilder().apply {
+            url("https://old.example.com")
+            headers.append("host", "a.example.com")
+            headers.append("HOST", "b.example.com")
+            headers.append("Host", "c.example.com")
+        }
+
+        val httpRequest = HttpRequest(path = "/test", method = "GET")
+        httpRequest.buildKTORRequest(builder, URL("http://example.com/path"))
+        assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly("old.example.com")
+        assertThat(builder.url.host).isEqualTo("old.example.com")
+    }
+
+    @ParameterizedTest(name = "builder url {0} should produce Host ''{1}''")
+    @MethodSource("builderHostCases")
+    fun `host header should match builder url host including port and ip`(builderUrl: String, expectedHost: String) {
+        val builder = HttpRequestBuilder().apply {
+            url(builderUrl)
+            headers.append("Host", "wrong.host")
+        }
+
+        val httpRequest = HttpRequest(path = "/test", method = "GET")
+        httpRequest.buildKTORRequest(builder, URL("http://irrelevant.example/path"))
+        assertThat(builder.headers.getAll("Host")).hasSize(1).containsExactly(expectedHost)
+    }
+
+    companion object {
+        @JvmStatic
+        fun builderHostCases() = listOf(
+            Arguments.of("https://old.example.com", "old.example.com"),
+            Arguments.of("https://old.example.com:8443", "old.example.com:8443"),
+            Arguments.of("http://localhost", "localhost"),
+            Arguments.of("http://127.0.0.1:8080", "127.0.0.1:8080")
+        )
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -232,7 +232,7 @@ internal class HttpRequestTest {
             this.url.host = "test.com"
             this.url.port = 80
         }
-        HttpRequest("GET", "/").buildKTORRequest(builderWithPort80, null)
+        HttpRequest("GET", "/").buildKTORRequest(builderWithPort80)
         assertThat(builderWithPort80.headers["Host"]).isEqualTo("test.com")
 
         val httpRequestBuilderWithHTTPS = HttpRequestBuilder().apply {
@@ -240,7 +240,7 @@ internal class HttpRequestTest {
             this.url.host = "test.com"
             this.url.port = 443
         }
-        HttpRequest("GET", "/").buildKTORRequest(httpRequestBuilderWithHTTPS, null)
+        HttpRequest("GET", "/").buildKTORRequest(httpRequestBuilderWithHTTPS)
         assertThat(httpRequestBuilderWithHTTPS.headers["Host"]).isEqualTo("test.com")
     }
 
@@ -251,7 +251,7 @@ internal class HttpRequestTest {
             this.url.port = 80
         }
         HttpRequest("GET", "/", headers = mapOf("host" to "original.com"))
-            .buildKTORRequest(httpRequestBuilder, java.net.URL("http://target.com/"))
+            .buildKTORRequest(httpRequestBuilder)
         assertThat(httpRequestBuilder.headers["Host"]).isEqualTo("target.com")
     }
 


### PR DESCRIPTION
**What**: 
Fix host header management during Ktor HttpRequestBuilder construction by ensuring the Host header is always derived from the builder URL, replacing any existing values in a case-insensitive manner and preventing duplicate Host headers

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
