### PR TITLE
Make missing config logs debug-only

### DIFF
--- a/application/src/main/kotlin/application/StubLoaderEngine.kt
+++ b/application/src/main/kotlin/application/StubLoaderEngine.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.loadSpecmaticConfigOrDefault
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.ContractPathData
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.stub.SpecmaticConfigSource
 import io.specmatic.stub.loadContractStubsFromFiles
 import io.specmatic.stub.loadContractStubsFromImplicitPaths
 import java.io.File
@@ -14,7 +15,7 @@ class StubLoaderEngine {
     fun loadStubs(
         contractPathDataList: List<ContractPathData>,
         dataDirs: List<String>,
-        specmaticConfigPath: String? = null,
+        specmaticConfigSource: SpecmaticConfigSource,
         strictMode: Boolean
     ): List<Pair<Feature, List<ScenarioStub>>> {
         contractPathDataList.forEach { contractPath ->
@@ -23,7 +24,7 @@ class StubLoaderEngine {
             }
         }
 
-        val specmaticConfig = loadSpecmaticConfigOrDefault(specmaticConfigPath ?: getConfigFilePath())
+        val specmaticConfig = specmaticConfigSource.load().config
 
         return when {
             dataDirs.isNotEmpty() -> {

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -59,7 +59,7 @@ private const val DISPLAY_NAME_PREFIX_IN_SYSTEM_OUT_TAG_TEXT = "display-name: "
         mixinStandardHelpOptions = true,
         description = ["Run contract tests"])
 @Category("Specmatic core")
-class TestCommand(private val junitLauncher: Launcher = LauncherFactory.create()) : Callable<Unit> {
+class TestCommand(private val junitLauncher: Launcher = LauncherFactory.create()) : Callable<Int> {
 
     @CommandLine.Parameters(arity = "0..*", description = ["Contract file paths"])
     var contractPaths: List<String> = emptyList()
@@ -146,7 +146,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     )
     var useCurrentBranchForCentralRepo: Boolean = false
 
-    override fun call() = try {
+    override fun call(): Int = try {
         setParallelism()
 
         if(verboseMode) {
@@ -236,10 +236,15 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             }
         }
 
-        ContractExecutionListener.exitProcess()
+        if (contractPaths.isEmpty() && !File(Configuration.configFilePath).exists()) {
+            1
+        } else {
+            ContractExecutionListener.exitStatus()
+        }
     }
     catch (e: Throwable) {
         logger.log(e)
+        1
     }
 
     private fun setParallelism() {

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -15,7 +15,7 @@ import io.specmatic.core.utilities.Flags.Companion.MATCH_BRANCH
 import io.specmatic.core.utilities.Flags.Companion.TEST_STRICT_MODE
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import io.specmatic.core.utilities.exitWithMessage
-import io.specmatic.core.loadSpecmaticConfigOrNull
+import io.specmatic.core.loadSpecmaticConfigIfExists
 import io.specmatic.core.utilities.newXMLBuilder
 import io.specmatic.core.utilities.xmlToString
 import io.specmatic.license.core.cli.Category
@@ -184,7 +184,8 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty(OVERLAY_FILE_PATH, overlayFilePath.orEmpty())
         System.setProperty(TEST_STRICT_MODE, strictMode.toString())
 
-        val configMatchBranch = loadSpecmaticConfigOrNull(Configuration.configFilePath)?.getMatchBranch() ?: false
+        val specmaticConfig = loadSpecmaticConfigIfExists(Configuration.configFilePath)
+        val configMatchBranch = specmaticConfig?.getMatchBranch() ?: false
         val matchBranchEnabled = useCurrentBranchForCentralRepo || Flags.getBooleanValue(MATCH_BRANCH, false) || configMatchBranch
         if(matchBranchEnabled) {
             System.setProperty(MATCH_BRANCH, matchBranchEnabled.toString())

--- a/application/src/test/kotlin/application/StubCommandTest.kt
+++ b/application/src/test/kotlin/application/StubCommandTest.kt
@@ -51,7 +51,6 @@ internal class StubCommandTest {
     fun cleanUp() {
         clearAllMocks()
         stubCommand.contractPaths = arrayListOf()
-        stubCommand.specmaticConfigPath = null
     }
 
     @Test

--- a/application/src/test/kotlin/application/TestCommandTest.kt
+++ b/application/src/test/kotlin/application/TestCommandTest.kt
@@ -70,11 +70,9 @@ internal class TestCommandTest {
         every { junitLauncher.discover(any()) }.returns(mockk())
         every { junitLauncher.execute(any<LauncherDiscoveryRequest>()) }.returns(Unit)
 
-        val (output, _) = captureStandardOutput {
-            CommandLine(testCommand, factory).execute()
-        }
+        val exitCode = CommandLine(testCommand, factory).execute()
 
-        assertThat(output).doesNotContain("Specmatic config file")
+        assertThat(exitCode).isEqualTo(1)
     }
 
     @Test

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -1088,6 +1088,24 @@ fun loadSpecmaticConfigOrNull(configFileName: String? = null): SpecmaticConfig? 
     }
 }
 
+fun loadSpecmaticConfigIfExists(configFileName: String? = null): SpecmaticConfig? {
+    if (configFileName == null) {
+        return SpecmaticConfig()
+    }
+
+    if (!File(configFileName).exists()) {
+        logger.debug("Specmatic config file $configFileName does not exist")
+        return null
+    }
+
+    return try {
+        loadSpecmaticConfig(configFileName)
+    } catch (e: ContractException) {
+        logger.log(exceptionCauseMessage(e))
+        null
+    }
+}
+
 fun loadSpecmaticConfig(configFileName: String? = null): SpecmaticConfig {
     val configFile = File(configFileName ?: configFilePath)
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -28,7 +28,6 @@ import io.specmatic.core.utilities.*
 import io.specmatic.core.value.*
 import io.specmatic.license.core.LicenseResolver
 import io.specmatic.license.core.LicensedProduct
-import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.license.core.util.LicenseConfig
 import io.specmatic.mock.NoMatchingScenario
 import io.specmatic.mock.ScenarioStub
@@ -773,14 +772,13 @@ class HttpStub(
     override fun close() {
         server.stop(gracePeriodMillis = timeoutMillis, timeoutMillis = timeoutMillis)
         printUsageReport()
-        val specmaticConfig = loadSpecmaticConfigOrDefault(specmaticConfigPath)
         synchronized(ctrfTestResultRecords) {
             ctrfTestResultRecords.addAll(notCoveredTestResultRecords())
             ReportGenerator.generateReport(
                 testResultRecords = ctrfTestResultRecords,
                 startTime = startTime.toEpochMilli(),
                 endTime = Instant.now().toEpochMilli(),
-                specConfigs = ctrfSpecConfigsFrom(specmaticConfig, ctrfTestResultRecords),
+                specConfigs = ctrfSpecConfigsFrom(specmaticConfigInstance, ctrfTestResultRecords),
                 coverage = 0,
                 reportDir = File("$ARTIFACTS_PATH/stub")
             )

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -124,7 +124,7 @@ open class SpecmaticJUnitSupport {
         val response = httpClient.execute(request)
 
         if (response.status != 200) {
-            logger.log("Failed to query swaggerUI, status code: ${response.status}")
+            logger.debug("Failed to query swaggerUI, status code: ${response.status}")
             return ActuatorSetupResult.Failure
         }
 
@@ -145,7 +145,7 @@ open class SpecmaticJUnitSupport {
         val response = LegacyHttpClient(endpointsAPI, log = ignoreLog).execute(request)
 
         if (response.status != 200) {
-            logger.log("Failed to query actuator, status code: ${response.status}")
+            logger.debug("Failed to query actuator, status code: ${response.status}")
             return ActuatorSetupResult.Failure
         }
 
@@ -454,7 +454,7 @@ open class SpecmaticJUnitSupport {
             }
         } catch (exception: Throwable) {
             openApiCoverageReportInput.setEndpointsAPIFlag(false)
-            logger.log(exception, "Failed to query actuator with error")
+            logger.debug(exception, "Failed to query actuator with error")
         }
 
         logger.newLine()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -62,7 +62,7 @@ open class SpecmaticJUnitSupport {
 
     private val specmaticConfig: SpecmaticConfig? =
         settings.getAdjustedConfig()
-            ?: settings.adjust(loadSpecmaticConfigOrNull(getConfigFilePath()))
+            ?: settings.adjust(loadSpecmaticConfigIfExists(getConfigFilePath()))
 
     private val testFilter = ScenarioMetadataFilter.from(settings.filter)
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/listeners/ContractExecutionListener.kt
@@ -38,7 +38,7 @@ class ContractExecutionListener : TestExecutionListener {
             exitProcess(exitStatus())
         }
 
-        internal fun exitStatus(): Int = if (testSuiteFailed || couldNotStart || failure > 0) 1 else 0
+        fun exitStatus(): Int = if (testSuiteFailed || couldNotStart || failure > 0) 1 else 0
 
         internal fun reset() {
             success = 0


### PR DESCRIPTION
**What**:

Adjusts config loading in test and stub flows so missing specmatic.yaml logs only at debug level. Adds CLI tests to assert missing-config logs appear only with --debug.

**Why**:

Avoids noisy "config not found" logs in normal runs while preserving existing behavior.

**How**:

- Use loadSpecmaticConfigIfExists in TestCommand and SpecmaticJUnitSupport, and rely on loaded config in stub reporting.
- Add tests to verify missing-config logging behavior.

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
