### PR TITLE
Cleanup noisy config actuator logs

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -161,7 +161,10 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty(SPECMATIC_BASE_URL, baseUrl)
 
         try {
-            val configMatchBranch = loadSpecmaticConfigOrNull(Configuration.configFilePath)?.getMatchBranch() ?: false
+            val configMatchBranch = loadSpecmaticConfigOrNull(
+                Configuration.configFilePath,
+                explicitlySpecifiedByUser = configFileName != null
+            )?.getMatchBranch() ?: false
             val matchBranchEnabled = useCurrentBranchForCentralRepo || Flags.getBooleanValue(MATCH_BRANCH, false) || configMatchBranch
             
             contractSources = when (contractPaths.isEmpty()) {

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -184,7 +184,10 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         System.setProperty(OVERLAY_FILE_PATH, overlayFilePath.orEmpty())
         System.setProperty(TEST_STRICT_MODE, strictMode.toString())
 
-        val configMatchBranch = loadSpecmaticConfigOrNull(Configuration.configFilePath)?.getMatchBranch() ?: false
+        val configMatchBranch = loadSpecmaticConfigOrNull(
+            Configuration.configFilePath,
+            explicitlySpecifiedByUser = configFileName != null
+        )?.getMatchBranch() ?: false
         val matchBranchEnabled = useCurrentBranchForCentralRepo || Flags.getBooleanValue(MATCH_BRANCH, false) || configMatchBranch
         if(matchBranchEnabled) {
             System.setProperty(MATCH_BRANCH, matchBranchEnabled.toString())

--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfig.kt
@@ -1075,14 +1075,28 @@ fun loadSpecmaticConfigOrDefault(configFileName: String? = null): SpecmaticConfi
     return loadSpecmaticConfigOrNull(configFileName) ?: SpecmaticConfig()
 }
 
-fun loadSpecmaticConfigOrNull(configFileName: String? = null): SpecmaticConfig? {
+fun loadSpecmaticConfigOrNull(configFileName: String? = null): SpecmaticConfig? =
+    loadSpecmaticConfigOrNull(configFileName, explicitlySpecifiedByUser = false)
+
+fun loadSpecmaticConfigOrNull(
+    configFileName: String? = null,
+    explicitlySpecifiedByUser: Boolean = false
+): SpecmaticConfig? {
     return if (configFileName == null) {
         SpecmaticConfig()
     } else {
         try {
             loadSpecmaticConfig(configFileName)
         } catch (e: ContractException) {
-            logger.log(exceptionCauseMessage(e))
+            val message = exceptionCauseMessage(e)
+            val configFile = File(configFileName)
+
+            if (!configFile.exists() && !explicitlySpecifiedByUser) {
+                logger.debug(message)
+            } else {
+                logger.log(message)
+            }
+
             null
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigLoggingTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/SpecmaticConfigLoggingTest.kt
@@ -1,0 +1,48 @@
+package io.specmatic.core
+
+import io.specmatic.core.log.CompositePrinter
+import io.specmatic.core.log.LogMessage
+import io.specmatic.core.log.LogPrinter
+import io.specmatic.core.log.NonVerbose
+import io.specmatic.core.log.withLogger
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+internal class SpecmaticConfigLoggingTest {
+    private class CapturingPrinter : LogPrinter {
+        val logged: MutableList<LogMessage> = mutableListOf()
+
+        override fun print(msg: LogMessage, indentation: String) {
+            logged.add(msg)
+        }
+    }
+
+    @Test
+    fun `missing inferred config does not log when using non-verbose logger`(@TempDir tempDir: File) {
+        val printer = CapturingPrinter()
+        val logStrategy = NonVerbose(CompositePrinter(listOf(printer)))
+        val missingConfig = File(tempDir, "specmatic.yaml")
+
+        withLogger(logStrategy) {
+            loadSpecmaticConfigOrNull(missingConfig.path)
+        }
+
+        assertThat(printer.logged).isEmpty()
+    }
+
+    @Test
+    fun `missing explicit config logs message`(@TempDir tempDir: File) {
+        val printer = CapturingPrinter()
+        val logStrategy = NonVerbose(CompositePrinter(listOf(printer)))
+        val missingConfig = File(tempDir, "specmatic.yaml")
+
+        withLogger(logStrategy) {
+            loadSpecmaticConfigOrNull(missingConfig.path, explicitlySpecifiedByUser = true)
+        }
+
+        val logged = printer.logged.single()
+        assertThat(logged.toLogString()).contains("Could not find the Specmatic configuration at path")
+    }
+}

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -127,7 +127,7 @@ open class SpecmaticJUnitSupport {
         val response = httpClient.execute(request)
 
         if (response.status != 200) {
-            logger.log("Failed to query swaggerUI, status code: ${response.status}")
+            logger.debug("Failed to query swaggerUI, status code: ${response.status}")
             return ActuatorSetupResult.Failure
         }
 
@@ -148,7 +148,7 @@ open class SpecmaticJUnitSupport {
         val response = LegacyHttpClient(endpointsAPI, log = ignoreLog).execute(request)
 
         if (response.status != 200) {
-            logger.log("Failed to query actuator, status code: ${response.status}")
+            logger.debug("Failed to query actuator, status code: ${response.status}")
             return ActuatorSetupResult.Failure
         }
 
@@ -453,11 +453,12 @@ open class SpecmaticJUnitSupport {
         try {
             if (queryActuator().failed && actuatorFromSwagger(actuatorBaseURL).failed) {
                 openApiCoverageReportInput.setEndpointsAPIFlag(false)
-                logger.log("EndpointsAPI and SwaggerUI URL missing; cannot calculate actual coverage")
+                logger.boundary()
+                logger.log("Endpoints API and SwaggerUI URL were not exposed by the application, so cannot calculate actual coverage")
             }
         } catch (exception: Throwable) {
             openApiCoverageReportInput.setEndpointsAPIFlag(false)
-            logger.log(exception, "Failed to query actuator with error")
+            logger.debug(exception, "Failed to query actuator with error")
         }
 
         logger.newLine()


### PR DESCRIPTION
**What**:
Reduce noisy config/actuator logging and add tests for config logging behavior.

**Why**:
Missing inferred config files and unavailable actuator/swagger endpoints were logging too loudly, obscuring real issues.

**How**:
- Add an explicit flag to control config-missing log severity and pass it from commands.
- Downgrade actuator/swagger query failures to debug and clarify coverage message.
- Add logging tests for missing config behavior.

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
