### PR TITLE
Fix: handling of refs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1600,10 +1600,6 @@ class OpenApiSpecification(
             preExistingResult
         }
 
-//        val preExistingResult = patterns["($patternName)"]
-//        if (preExistingResult != null && patternName.isNotBlank()) return preExistingResult
-//        if (typeStack.filter { it == patternName }.size > 1) return DeferredPattern("($patternName)")
-
         val pattern = schema.toSpecmaticPattern(patternName, typeStack, breadCrumb)
         val withFormData = if (pattern.instanceOf(JSONObjectPattern::class) && jsonInFormData) {
             PatternInStringPattern(patterns.getOrDefault("($patternName)", StringPattern()), "($patternName)")

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1593,9 +1593,16 @@ class OpenApiSpecification(
 
         logger.debug(debugMessage)
 
-        val preExistingResult = patterns["($patternName)"]
-        if (preExistingResult != null && patternName.isNotBlank()) return preExistingResult
-        if (typeStack.filter { it == patternName }.size > 1) return DeferredPattern("($patternName)")
+        if (patternName.isNotBlank()) {
+            val preExistingResult = patterns["($patternName)"]
+            if (preExistingResult != null) return preExistingResult
+            if (typeStack.filter { it == patternName }.size > 1) return DeferredPattern("($patternName)")
+            preExistingResult
+        }
+
+//        val preExistingResult = patterns["($patternName)"]
+//        if (preExistingResult != null && patternName.isNotBlank()) return preExistingResult
+//        if (typeStack.filter { it == patternName }.size > 1) return DeferredPattern("($patternName)")
 
         val pattern = schema.toSpecmaticPattern(patternName, typeStack, breadCrumb)
         val withFormData = if (pattern.instanceOf(JSONObjectPattern::class) && jsonInFormData) {


### PR DESCRIPTION

**What**:

Fix bug in how refs were handled in multiple nested oneOfs with anonymous objects at multiple levels

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
