### PR TITLE
Miscellaneous fixes and improvements to the lenient parser

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
@@ -90,7 +90,7 @@ enum class OpenApiLintViolations(override val id: String, override val title: St
     SCHEMA_UNCLEAR(
         id = "OAS0043",
         title = "Unclear schema",
-        summary = "Schemas should be sufficiently defined to determine intent"
+        summary = "The intent of this schema is unclear or may not be supported. Consider reaching out if this is an issue"
     ),
 
     /* -------- Others -------- */

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -472,7 +472,7 @@ class OpenApiSpecification(
         return openApiSchemas().filterNot { withPatternDelimiters(it.key) in patterns }.map {
             val schemaContext = componentSchemasContext.at(it.key)
             withPatternDelimiters(it.key) to schemaContext.safely(
-                message = "Failed to convert OpenAPI schema to internal format, defaulting to any json schema",
+                message = "Failed to convert schema to internal format, defaulting to any schema",
                 fallback = { AnythingPattern },
                 block = { schemaScope ->
                     toSpecmaticPattern(schema = it.value, typeStack = emptyList(), patternName = it.key, collectorContext = schemaScope)
@@ -2275,7 +2275,7 @@ class OpenApiSpecification(
         val components = parsedOpenApi.components ?: Components()
         val schemas = components.schemas.orEmpty()
         return componentName to collectorContext.at("\$ref").requirePojo(
-            message = { "Failed to resolve reference to schema $componentName, defaulting to any json schema\"" },
+            message = { "Failed to resolve reference to schema $componentName, defaulting to any schema" },
             extract = { schemas[componentName] },
             createDefault = { Schema<Any>().also { it.properties = emptyMap() } },
             ruleViolation = { OpenApiLintViolations.UNRESOLVED_REFERENCE }
@@ -2428,7 +2428,7 @@ class OpenApiSpecification(
         ).filter { (_, value) -> value != null }.map { (key, value) -> key to value!! }.toMap()
     }
 
-    private fun Schema<*>.toSpecmaticPattern(patternName: String, typeStack: List<String>, collectorContext: CollectorContext): Pattern = collectorContext.safely(fallback = { AnythingPattern }, message = "Failed to convert schema to internal representation, defaulting to any json schema") {
+    private fun Schema<*>.toSpecmaticPattern(patternName: String, typeStack: List<String>, collectorContext: CollectorContext): Pattern = collectorContext.safely(fallback = { AnythingPattern }, message = "Failed to convert schema to internal representation, defaulting to any schema") {
         if (this.`$ref` != null) return@safely handleReference(this, typeStack, patternName, collectorContext)
         if (this.allOf != null) return@safely handleAllOf(this, typeStack, patternName, collectorContext)
         if (this.oneOf != null) return@safely handleOneOf(this, typeStack, patternName, collectorContext)
@@ -2499,7 +2499,7 @@ class OpenApiSpecification(
         return collectorContext
             .check(AnythingPattern, isValid = { declaredTypes.isEmpty() })
             .violation { OpenApiLintViolations.SCHEMA_UNCLEAR }
-            .message { "Schema is unclear, defaulting to any json schema" }
+            .message { "Schema is unclear, defaulting to any schema" }
             .orUse { AnythingPattern }
             .build(isWarning = true)
     }

--- a/core/src/test/kotlin/integration_tests/LenientParserTest.kt
+++ b/core/src/test/kotlin/integration_tests/LenientParserTest.kt
@@ -2358,7 +2358,7 @@ class LenientParserTest {
                         }
                     }
                     assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
-                    assert("paths./test.get.responses.200.content.application/json.schema.required[0]") {
+                    assert("paths./test.get.responses.200.content.application/json.schema.required") {
                         toHaveSeverity(IssueSeverity.WARNING)
                         toContainText("Required property \"id\" is not defined in properties, ignoring this requirement")
                     }
@@ -3243,6 +3243,7 @@ class LenientParserTest {
                     assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
                     assert("paths./test.get.responses.200.content.application/json.schema.discriminator.mapping.X") {
                         toContainViolation(OpenApiLintViolations.UNRESOLVED_REFERENCE)
+                        toContainText("Failed to resolve reference to discriminator mapping")
                     }
                 },
                 multiVersionLenientCase(name = "oneOf discriminator mapping has invalid ref", *OpenApiVersion.allVersions()) {
@@ -3273,6 +3274,7 @@ class LenientParserTest {
                     assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1);totalViolations(1) }
                     assert("paths./test.get.responses.200.content.application/json.schema.discriminator.mapping.X") {
                         toContainViolation(OpenApiLintViolations.UNRESOLVED_REFERENCE)
+                        toContainText("Failed to resolve reference to discriminator mapping")
                     }
                 },
                 multiVersionLenientCase(name = "deep allOf discriminator mapping has invalid ref", *OpenApiVersion.allVersions()) {
@@ -3302,9 +3304,14 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1);totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2);totalViolations(2) }
                     assert("components.schemas.Inner.discriminator.mapping.BAD") {
                         toContainViolation(OpenApiLintViolations.UNRESOLVED_REFERENCE)
+                        toContainText("Failed to resolve reference to discriminator mapping BAD")
+                    }
+                    assert("components.schemas.Inner.\$ref") {
+                        toContainViolation(OpenApiLintViolations.UNRESOLVED_REFERENCE)
+                        toContainText("Failed to resolve reference to schema MissingAllOf")
                     }
                 }
             ).flatten().stream()

--- a/core/src/test/kotlin/integration_tests/LenientParserTest.kt
+++ b/core/src/test/kotlin/integration_tests/LenientParserTest.kt
@@ -359,6 +359,10 @@ class LenientParserTest {
     @MethodSource("refTestCases")
     fun `ref test cases`(version: OpenApiVersion, case: LenientParseTestCase, info: TestInfo) = runLenientCase(version, case)
 
+    @ParameterizedTest
+    @MethodSource("schemaTestCases")
+    fun `schema test cases`(version: OpenApiVersion, case: LenientParseTestCase, info: TestInfo) = runLenientCase(version, case)
+
     companion object {
         @JvmStatic
         fun pathParameterTestCases(): Stream<Arguments> {
@@ -378,19 +382,13 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(2) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
                     assert("paths./test/{id}.get.parameters[-1]") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toContainViolation(OpenApiLintViolations.PATH_PARAMETER_MISSING)
                         toMatchText("Expected path parameter with name id is missing, defaulting to empty schema")
                     }
-                    assert("paths./test/{id}.get.parameters[-1].schema") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
                 },
-
                 multiVersionLenientCase(name = "has no schema", *OpenApiVersion.allVersions()) {
                     openApi {
                         paths {
@@ -405,46 +403,13 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(2) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
                     assert("paths./test/{id}.get.parameters[0]") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toContainViolation(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION)
                         toMatchText("Parameter has no schema defined, defaulting to empty schema")
                     }
-                    assert("paths./test/{id}.get.parameters[0].schema") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
                 },
-                multiVersionLenientCase(name = "refed out and has no schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test/{id}") {
-                                operation("get") {
-                                    parameter {
-                                        put("name", "id")
-                                        put("in", "path")
-                                        put("required", true)
-                                        put("schema", mapOf("\$ref" to "#/components/schemas/PathItem"))
-                                    }
-                                }
-                            }
-                            components {
-                                schemas {
-                                    schema("PathItem", block = {})
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("components.schemas.PathItem") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
-                },
-
                 multiVersionLenientCase(name = "schema has issue", *OpenApiVersion.allVersions()) {
                     openApi {
                         paths {
@@ -517,43 +482,11 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(2) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
                     assert("paths./test.get.parameters[0]") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toContainViolation(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION)
                         toMatchText("Parameter has no schema defined, defaulting to empty schema")
-                    }
-                    assert("paths./test.get.parameters[0].schema") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
-                },
-                multiVersionLenientCase(name = "refed out and has no schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    parameter {
-                                        put("name", "q")
-                                        put("in", "query")
-                                        put("required", true)
-                                        put("schema", mapOf("\$ref" to "#/components/schemas/QueryItem"))
-                                    }
-                                }
-                            }
-                            components {
-                                schemas {
-                                    schema("QueryItem", block = {})
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("components.schemas.QueryItem") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
                     }
                 },
 
@@ -623,15 +556,10 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(2) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
                     assert("paths./test.get.parameters[0].schema") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toMatchText("Array Parameter has no items schema defined, defaulting to empty schema")
-                    }
-                    assert("paths./test.get.parameters[0].schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
                     }
                 },
                 multiVersionLenientCase(name = "refed out array with no items schema", *OpenApiVersion.allVersions()) {
@@ -655,66 +583,10 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
                     assert("components.schemas.IdArray") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toMatchText("No items schema defined for array schema defaulting to empty schema")
-                    }
-                    assert("components.schemas.IdArray.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
-                },
-
-                multiVersionLenientCase(name = "array with empty items schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    parameter {
-                                        put("name", "ids")
-                                        put("in", "query")
-                                        put("schema", mapOf("type" to "array", "items" to emptyMap<String, Any>()))
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("paths./test.get.parameters[0].schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
-                },
-                multiVersionLenientCase(name = "refed out array with empty items schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    parameter {
-                                        put("name", "ids")
-                                        put("in", "query")
-                                        put("schema", mapOf("\$ref" to "#/components/schemas/IdArray"))
-                                    }
-                                }
-                            }
-                            components {
-                                schemas {
-                                    schema("IdArray") {
-                                        put("type", "array")
-                                        put("items", emptyMap<String, Any>())
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("components.schemas.IdArray.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
                     }
                 },
 
@@ -787,43 +659,11 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(2) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
                     assert("paths./test.get.parameters[0]") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toContainViolation(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION)
                         toMatchText("Parameter has no schema defined, defaulting to empty schema")
-                    }
-                    assert("paths./test.get.parameters[0].schema") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
-                },
-                multiVersionLenientCase(name = "refed out and has no schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    parameter {
-                                        put("name", "X-Request-Id")
-                                        put("in", "header")
-                                        put("required", true)
-                                        put("schema", mapOf("\$ref" to "#/components/schemas/HeaderId"))
-                                    }
-                                }
-                            }
-                            components {
-                                schemas {
-                                    schema("HeaderId", block = {})
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("components.schemas.HeaderId") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
                     }
                 },
 
@@ -841,16 +681,11 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(2) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
                     assert("paths./test.get.parameters[0].schema") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toContainViolation(OpenApiLintViolations.INVALID_PARAMETER_DEFINITION)
                         toMatchText("Array Parameter has no items schema defined, defaulting to empty schema")
-                    }
-                    assert("paths./test.get.parameters[0].schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
                     }
                 },
                 multiVersionLenientCase(name = "refed out array with no items schema", *OpenApiVersion.allVersions()) {
@@ -874,65 +709,10 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
                     assert("components.schemas.HeaderIdArray") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toMatchText("No items schema defined for array schema defaulting to empty schema")
-                    }
-                    assert("components.schemas.HeaderIdArray.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
-                },
-
-                multiVersionLenientCase(name = "array with empty items schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    parameter {
-                                        put("name", "X-Ids")
-                                        put("in", "header")
-                                        put("schema", mapOf("type" to "array", "items" to emptyMap<String, Any>()))
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    assert("paths./test.get.parameters[0].schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
-                    }
-                },
-                multiVersionLenientCase(name = "refed out array with empty items schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    parameter {
-                                        put("name", "X-Ids")
-                                        put("in", "header")
-                                        put("schema", mapOf("\$ref" to "#/components/schemas/HeaderIdArray"))
-                                    }
-                                }
-                            }
-                            components {
-                                schemas {
-                                    schema("HeaderIdArray") {
-                                        put("type", "array")
-                                        put("items", emptyMap<String, Any>())
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("components.schemas.HeaderIdArray.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
                     }
                 },
 
@@ -1576,13 +1356,9 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
                     assert("paths./test.get.responses.200.headers.X-Request-Id") {
                         toMatchText("No schema defined, defaulting to empty schema")
-                    }
-                    assert("paths./test.get.responses.200.headers.X-Request-Id.schema") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
                     }
                 },
                 multiVersionLenientCase(name = "array with no items schema", *OpenApiVersion.allVersions()) {
@@ -1599,14 +1375,10 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
                     assert("paths./test.get.responses.200.headers.X-Ids.schema") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toMatchText("No items schema defined for array schema defaulting to empty schema")
-                    }
-                    assert("paths./test.get.responses.200.headers.X-Ids.schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
                     }
                 },
 
@@ -1627,13 +1399,9 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
                     assert("components.headers.HeaderId") {
                         toMatchText("No schema defined, defaulting to empty schema")
-                    }
-                    assert("components.headers.HeaderId.schema") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
                     }
                 },
                 multiVersionLenientCase(name = "refed header array no items schema", *OpenApiVersion.allVersions()) {
@@ -1655,14 +1423,10 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
                     assert("components.headers.HeaderIdArray.schema") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toMatchText("No items schema defined for array schema defaulting to empty schema")
-                    }
-                    assert("components.headers.HeaderIdArray.schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
                     }
                 },
 
@@ -1776,34 +1540,6 @@ class LenientParserTest {
                     assert("paths./test.get.responses.200.content.application/json") {
                         toHaveSeverity(IssueSeverity.WARNING)
                         toMatchText(" No schema property defined under mediaType application/json, defaulting to free-form object")
-                    }
-                },
-                multiVersionLenientCase(name = "refed media type schema has no schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    response("200") {
-                                        content {
-                                            mediaType("application/json") {
-                                                schemaRef("JsonMedia")
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        components {
-                            schemas {
-                                schema("JsonMedia") { }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("components.schemas.JsonMedia") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                        toMatchText("Schema is unclear, defaulting to non-null json schema")
                     }
                 },
                 multiVersionLenientCase(name = "schema has issue", *OpenApiVersion.allVersions()) {
@@ -2512,31 +2248,6 @@ class LenientParserTest {
         @JvmStatic
         fun objectSchemaTestCases(): Stream<Arguments> {
             return listOf(
-                multiVersionLenientCase(name = "object property has no schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    response(200) {
-                                        content {
-                                            mediaType("application/json") {
-                                                schema {
-                                                    put("type", "object")
-                                                    put("properties", mapOf("foo" to emptyMap<String, Any>()))
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("paths./test.get.responses.200.content.application/json.schema.properties.foo") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                    }
-                },
                 multiVersionLenientCase(name = "property schema has invalid bounds", *OpenApiVersion.allVersions()) {
                     openApi {
                         paths {
@@ -2763,39 +2474,10 @@ class LenientParserTest {
                             }
                         }
                     }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(2); totalViolations(1) }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
                     assert("paths./test.get.responses.200.content.application/json.schema") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toContainText("No items schema defined for array schema defaulting to empty schema")
-                    }
-                    assert("paths./test.get.responses.200.content.application/json.schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                    }
-                },
-                multiVersionLenientCase(name = "array items has no schema", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    response(200) {
-                                        content {
-                                            mediaType("application/json") {
-                                                schema {
-                                                    put("type", "array")
-                                                    put("items", emptyMap<String, Any>())
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("paths./test.get.responses.200.content.application/json.schema.items") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
                     }
                 },
                 multiVersionLenientCase(name = "array schema ref with invalid items", *OpenApiVersion.allVersions()) {
@@ -3123,36 +2805,6 @@ class LenientParserTest {
         @JvmStatic
         fun oneOfSchemaTestCases(): Stream<Arguments> {
             return listOf(
-                multiVersionLenientCase(name = "oneOf contains nullable empty object", *OpenApiVersion.allVersions()) {
-                    openApi {
-                        paths {
-                            path("/test") {
-                                operation("get") {
-                                    response(200) {
-                                        content {
-                                            mediaType("application/json") {
-                                                schema {
-                                                    put("oneOf", listOf(
-                                                        emptyMap<String, Any>(),
-                                                        mapOf(
-                                                            "type" to "object",
-                                                            "properties" to mapOf("id" to mapOf("type" to "string"))
-                                                        )
-                                                    ))
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("paths./test.get.responses.200.content.application/json.schema.oneOf[0]") {
-                        toHaveSeverity(IssueSeverity.WARNING)
-                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
-                    }
-                },
                 multiVersionLenientCase(name = "oneOf element has invalid bounds", *OpenApiVersion.allVersions()) {
                     openApi {
                         paths {
@@ -3655,6 +3307,38 @@ class LenientParserTest {
                         toContainViolation(OpenApiLintViolations.UNRESOLVED_REFERENCE)
                     }
                 }
+            ).flatten().stream()
+        }
+
+        @JvmStatic
+        fun schemaTestCases(): Stream<Arguments> {
+            return listOf(
+                multiVersionLenientCase(name = "schema is empty should have no issues", *OpenApiVersion.allVersions()) {
+                    openApi {
+                        components {
+                            schemas {
+                                schema("UnknownSchema") {}
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(0); totalViolations(0) }
+                },
+                multiVersionLenientCase(name = "schema is of unknown type", *OpenApiVersion.allVersions()) {
+                    openApi {
+                        components {
+                            schemas {
+                                schema("UnknownSchema") {
+                                    put("type", "unknownType")
+                                }
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
+                    assert("components.schemas.UnknownSchema") {
+                        toHaveSeverity(IssueSeverity.WARNING)
+                        toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
+                    }
+                },
             ).flatten().stream()
         }
 

--- a/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
+++ b/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
@@ -11,6 +11,7 @@ import io.specmatic.core.examples.server.ScenarioFilter
 import io.specmatic.core.pattern.AnyNonNullJSONValue
 import io.specmatic.core.pattern.AnyOfPattern
 import io.specmatic.core.pattern.AnyPattern
+import io.specmatic.core.pattern.AnythingPattern
 import io.specmatic.core.pattern.BooleanPattern
 import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.EmailPattern
@@ -287,7 +288,7 @@ class OpenApi31Test {
         assertThat(requestBody).isEqualTo(responseBody)
         assertThat(requestBody).isInstanceOf(JSONObjectPattern::class.java); requestBody as JSONObjectPattern
         assertThat(requestBody.pattern["iHaveAnIdea"]).isInstanceOf(AnyOfPattern::class.java)
-        assertThat(requestBody.pattern["noIdea"]).isInstanceOf(AnyNonNullJSONValue::class.java) // Unimplemented type
+        assertThat(requestBody.pattern["noIdea"]).isInstanceOf(AnythingPattern::class.java) // Unimplemented type
         assertThat((requestBody.pattern.getValue("iHaveAnIdea") as AnyOfPattern).pattern.map { it::class.java })
             .containsExactlyInAnyOrder(StringPattern::class.java, NumberPattern::class.java)
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7656,7 +7656,7 @@ paths:
     }
 
     @Test
-    fun `a JSON key with no type cannot hold a null`() {
+    fun `a JSON key with no type can hold a null`() {
         val feature = OpenApiSpecification.fromYAML(
             """
                 ---
@@ -7691,7 +7691,7 @@ paths:
             HttpRequest("POST", "/person", body = parsedJSONObject("""{"id": null}""")),
             HttpResponse.OK
         ).let { matchResult ->
-            assertThat(matchResult).isInstanceOf(Result.Failure::class.java)
+            assertThat(matchResult).isInstanceOf(Result.Success::class.java)
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/mock/ScenarioStubKtTest.kt
@@ -740,44 +740,6 @@ internal class ScenarioStubKtTest {
     }
 
     @Test
-    fun `null in request body throws an exception`() {
-        val stubText = """
-{
-  "http-request": {
-    "method": "POST",
-    "path": "/square",
-    "body": null
-  },
-
-  "http-response": {
-    "status": 200
-  }
-}
-        """.trim()
-
-        assertThatThrownBy { mockFromJSON(jsonStringToValueMap(stubText)) }.isInstanceOf(ContractException::class.java)
-    }
-
-    @Test
-    fun `null in response body throws an exception`() {
-        val stubText = """
-{
-  "http-request": {
-    "method": "POST",
-    "path": "/square"
-  },
-
-  "http-response": {
-    "status": 200,
-    "body": null
-  }
-}
-        """.trim()
-
-        assertThatThrownBy { mockFromJSON(jsonStringToValueMap(stubText)) }.isInstanceOf(ContractException::class.java)
-    }
-
-    @Test
     fun `load delay from stub info in seconds`() {
         val stubText = """
 {
@@ -1073,16 +1035,6 @@ paths:
                     )
                 ),
                 Arguments.of("""{
-                    "http-request": { "path": "/add", "method": "POST", body: null },
-                    "http-response": { "status": 200 }
-                    }""".trimIndent(),
-                    toViolationReportString(
-                        breadCrumb = "http-request.body",
-                        details = FuzzyExampleMisMatchMessages.mismatchMessage("non-null value", "null"),
-                        StandardRuleViolation.VALUE_MISMATCH
-                    )
-                ),
-                Arguments.of("""{
                     "http-request": { "path": "/add", "method": "POST" },
                     "http-response": { "supposed-to-be-status": 200 }
                     }""".trimIndent(),
@@ -1090,16 +1042,6 @@ paths:
                         breadCrumb = "http-response.supposed-to-be-status",
                         details = unexpectedKeyButMatches("supposed-to-be-status", "status"),
                         StandardRuleViolation.REQUIRED_PROPERTY_MISSING
-                    )
-                ),
-                Arguments.of("""{
-                    "http-request": { "path": "/add", "method": "POST" },
-                    "http-response": { "status": 200,  body: null }
-                    }""".trimIndent(),
-                    toViolationReportString(
-                        breadCrumb = "http-response.body",
-                        details = FuzzyExampleMisMatchMessages.mismatchMessage("non-null value", "null"),
-                        StandardRuleViolation.VALUE_MISMATCH
                     )
                 )
             )


### PR DESCRIPTION
**What**:
- The Swagger parser prioritizes invalid required fields by moving them to the top, which results in highlighting the corresponding invalid indices. Instead, we now highlight the entire list, specifically the required key itself.  
- Unresolvable security schemes are represented as null rather than NoSecurityScheme for safety purposes.  
- Update the error message for invalid discriminator mapping references.  

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
