### PR TITLE
Config template

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/VersionAwareConfigParser.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.config
 
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -7,6 +8,7 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.config.v1.SpecmaticConfigV1
 import io.specmatic.core.config.v2.SpecmaticConfigV2
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.readEnvVarOrProperty
 import java.io.File
 
 private const val SPECMATIC_CONFIG_VERSION = "version"
@@ -14,14 +16,14 @@ private const val SPECMATIC_CONFIG_VERSION = "version"
 private val objectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
 
 fun File.toSpecmaticConfig(): SpecmaticConfig {
-    val configYaml = this.readText()
-    return when (configYaml.getVersion()) {
+    val configTree = resolveTemplates(objectMapper.readTree(this.readText()))
+    return when (configTree.getVersion()) {
         SpecmaticConfigVersion.VERSION_1 -> {
-            objectMapper.readValue(configYaml, SpecmaticConfigV1::class.java).transform()
+            objectMapper.treeToValue(configTree, SpecmaticConfigV1::class.java).transform()
         }
 
         SpecmaticConfigVersion.VERSION_2 -> {
-            objectMapper.readValue(configYaml, SpecmaticConfigV2::class.java).transform()
+            objectMapper.treeToValue(configTree, SpecmaticConfigV2::class.java).transform()
         }
 
         else -> {
@@ -30,8 +32,55 @@ fun File.toSpecmaticConfig(): SpecmaticConfig {
     }
 }
 
-fun String.getVersion(): SpecmaticConfigVersion? {
-    val version = objectMapper.readTree(this)[SPECMATIC_CONFIG_VERSION]?.asInt()
+private fun JsonNode.getVersion(): SpecmaticConfigVersion? {
+    val versionNode = this[SPECMATIC_CONFIG_VERSION]
+    val version = when {
+        versionNode == null -> null
+        versionNode.isInt || versionNode.isLong -> versionNode.asInt()
+        versionNode.isTextual -> versionNode.asText().toIntOrNull()
+        else -> null
+    }
     if (version == null || version == 0) return SpecmaticConfigVersion.VERSION_1
     return SpecmaticConfigVersion.getByValue(version)
+}
+
+private fun resolveTemplates(node: JsonNode): JsonNode {
+    return when {
+        node.isObject ->
+            node.fields().asSequence().fold(objectMapper.nodeFactory.objectNode()) { acc, entry ->
+                acc.set<JsonNode>(entry.key, resolveTemplates(entry.value))
+                acc
+            }
+
+        node.isArray ->
+            node.elements().asSequence().fold(objectMapper.nodeFactory.arrayNode()) { acc, element ->
+                acc.add(resolveTemplates(element))
+                acc
+            }
+
+        node.isTextual -> resolveTemplateValue(node.asText()) ?: node
+        else -> node
+    }
+}
+
+private fun resolveTemplateValue(value: String): JsonNode? {
+    val template = parseTemplate(value) ?: return null
+    val resolved = readEnvVarOrProperty(template.key, template.key) ?: template.defaultValue
+    return objectMapper.nodeFactory.textNode(resolved)
+}
+
+private data class TemplateDefinition(val key: String, val defaultValue: String)
+
+private fun parseTemplate(value: String): TemplateDefinition? {
+    if (!value.startsWith("{") || !value.endsWith("}")) return null
+    val separatorIndex = value.indexOf(':')
+    if (separatorIndex <= 1) return null
+    val key = value.substring(1, separatorIndex)
+    val defaultValue = value.substring(separatorIndex + 1, value.length - 1)
+    return if (key.isBlank()) null else TemplateDefinition(key, defaultValue)
+}
+
+fun String.getVersion(): SpecmaticConfigVersion? {
+    val configTree = resolveTemplates(objectMapper.readTree(this))
+    return configTree.getVersion()
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/VersionAwareConfigParserTest.kt
@@ -1,0 +1,117 @@
+package io.specmatic.core.config
+
+import io.specmatic.core.SpecmaticConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class VersionAwareConfigParserTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `template values parse json object into stub configuration`() {
+        val configFile =
+            tempDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    contracts: []
+                    stub: '{STUB_CONFIG:{"generative": true}}'
+                    """.trimIndent()
+                )
+            }
+
+        val originalValue = System.getProperty("STUB_CONFIG")
+        try {
+            System.setProperty("STUB_CONFIG", """{"generative": false}""")
+            val config: SpecmaticConfig = configFile.toSpecmaticConfig()
+            assertThat(config.getStubGenerative()).isFalse()
+        } finally {
+            restoreProperty("STUB_CONFIG", originalValue)
+        }
+    }
+
+    @Test
+    fun `quoted json in template values stays a string`() {
+        val configFile =
+            tempDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    contracts: []
+                    hooks:
+                      after: '{HOOK_VALUE:default}'
+                    """.trimIndent()
+                )
+            }
+
+        val originalValue = System.getProperty("HOOK_VALUE")
+        try {
+            System.setProperty("HOOK_VALUE", "\"{\\\"generative\\\": true}\"")
+            val config: SpecmaticConfig = configFile.toSpecmaticConfig()
+            assertThat(SpecmaticConfig.getHooks(config)["after"]).isEqualTo("""{"generative": true}""")
+        } finally {
+            restoreProperty("HOOK_VALUE", originalValue)
+        }
+    }
+
+    @Test
+    fun `template values parse json array into examples list`() {
+        val configFile =
+            tempDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    contracts: []
+                    examples: '{EXAMPLE_DIRS:["a","b"]}'
+                    """.trimIndent()
+                )
+            }
+
+        val originalValue = System.getProperty("EXAMPLE_DIRS")
+        try {
+            System.setProperty("EXAMPLE_DIRS", """["examples/one","examples/two"]""")
+            val config: SpecmaticConfig = configFile.toSpecmaticConfig()
+            assertThat(config.getExamples()).containsExactly("examples/one", "examples/two")
+        } finally {
+            restoreProperty("EXAMPLE_DIRS", originalValue)
+        }
+    }
+
+    @Test
+    fun `quoted non-json string keeps content without quotes`() {
+        val configFile =
+            tempDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    contracts: []
+                    hooks:
+                      after: '{HOOK_VALUE:default}'
+                    """.trimIndent()
+                )
+            }
+
+        val originalValue = System.getProperty("HOOK_VALUE")
+        try {
+            System.setProperty("HOOK_VALUE", "\"hello world\"")
+            val config: SpecmaticConfig = configFile.toSpecmaticConfig()
+            assertThat(SpecmaticConfig.getHooks(config)["after"]).isEqualTo("hello world")
+        } finally {
+            restoreProperty("HOOK_VALUE", originalValue)
+        }
+    }
+
+    private fun restoreProperty(
+        name: String,
+        originalValue: String?,
+    ) {
+        if (originalValue == null) {
+            System.clearProperty(name)
+        } else {
+            System.setProperty(name, originalValue)
+        }
+    }
+}


### PR DESCRIPTION
**What**:

Add the ability to use templated values in specmatic config. The template syntax allows a default to be specified, along with a key that be fed by an environment variable or a system property.

e.g.

```yaml
version: 2
contracts:
- provides:
  - spec.yaml
stub:
  generative: "{GENERATIVE:all}"
```

To switch off generative tests, you can now run the tests using:

```shell
GENERATIVE=none specmatic test
```

**Why**:

This simplifies things. Environment variables and system properties are declared, all config is in one place, and this paves the way for removing further support for environment variables and command line parameters.

**How**:

There's a new configuration pre-processor that updates the config values per environment variable/system property/default before parsing it.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

<!-- Kindly link the issue that this PR will be addressing -->
**Issue ID**:
Closes: #123

<!-- feel free to add additional comments -->
