### PR TITLE
Modify `HttpHeaders.fixValue` method to be non-extensible

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -949,7 +949,7 @@ data class HttpRequestPattern(
             method = method,
             path = httpPathPattern?.fixValue(request.path, resolver),
             queryParams = httpQueryParamPattern.fixValue(request.queryParams, resolver),
-            headers = headersPattern.fixValue(request.headers, resolver.updateLookupPath(BreadCrumb.PARAMETERS.value)),
+            headers = headersPattern.fixValue(request.headers, resolver.disableOverrideUnexpectedKeyCheck().updateLookupPath(BreadCrumb.PARAMETERS.value)),
             body = body.fixValue(request.body, resolver)
         )
     }

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -248,9 +248,7 @@ data class HttpResponsePattern(
     fun fixResponse(response: HttpResponse, resolver: Resolver): HttpResponse {
         return response.copy(
             status = status,
-            headers = headersPattern.fixValue(
-                response.headers, resolver.updateLookupPath(BreadCrumb.RESPONSE.value)
-            ),
+            headers = headersPattern.fixValue(response.headers, resolver.disableOverrideUnexpectedKeyCheck().updateLookupPath(BreadCrumb.RESPONSE.value)),
             body = body.fixValue(response.body, resolver)
         )
     }


### PR DESCRIPTION
**What**: Modify `HttpHeaders.fixValue` method to be non-extensible, by disabling `overrideKeyCheck` externally

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)