### PR TITLE
Ensure PreProcessor errors are recorded during the parse phase

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
@@ -87,6 +87,12 @@ enum class OpenApiLintViolations(override val id: String, override val title: St
         summary = "A \$ref should not define sibling properties as per OAS 3.0 standards"
     ),
 
+    INVALID_ADDITIONAL_PROPERTIES_USAGE(
+        id = "OAS0044",
+        title = "Invalid additionalProperties usage",
+        summary = "additionalProperties should only be used within object schemas"
+    ),
+
     SCHEMA_UNCLEAR(
         id = "OAS0043",
         title = "Unclear schema",

--- a/core/src/main/kotlin/io/specmatic/conversions/lenient/CollectorContext.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/lenient/CollectorContext.kt
@@ -13,6 +13,12 @@ data class CollectorContext(private val collector: DiagnosticCollector = Diagnos
     val hasPath: Boolean = path != null
     val pathOrRoot: String = path ?: "/"
 
+    fun combineImmutable(other: CollectorContext): CollectorContext {
+        val otherCollector = other.toCollector()
+        collector.addEntries(otherCollector.getEntries())
+        return this
+    }
+
     fun at(name: String): CollectorContext {
         val newFullPath = BreadCrumb.combine(pathOrRoot, name)
         return CollectorContext(collector, pathSegments + PathSegment.Key(name, newFullPath))

--- a/core/src/main/kotlin/io/specmatic/conversions/lenient/DiagnosticCollector.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/lenient/DiagnosticCollector.kt
@@ -16,5 +16,7 @@ class DiagnosticCollector {
             Result.fromFailures(entries.distinctBy { it.reportString() })
     }
 
+    fun addEntries(entries: List<Result.Failure>) { this.entries.addAll(entries) }
+
     fun getEntries(): List<Result.Failure> = entries
 }

--- a/core/src/test/kotlin/integration_tests/LenientParserTest.kt
+++ b/core/src/test/kotlin/integration_tests/LenientParserTest.kt
@@ -3226,6 +3226,65 @@ class LenientParserTest {
                         toContainViolation(OpenApiLintViolations.SCHEMA_UNCLEAR)
                     }
                 },
+                multiVersionLenientCase(name = "additionalProps on non-objects", *OpenApiVersion.allVersions()) {
+                    openApi {
+                        paths {
+                            path("/test") {
+                                operation("get") {
+                                    requestBody {
+                                        content {
+                                            mediaType("application/json") {
+                                                schema {
+                                                    put("type", "string")
+                                                    put("additionalProperties", true)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
+                    assert("paths./test.get.requestBody.content.application/json.schema.additionalProperties") {
+                        toHaveSeverity(IssueSeverity.WARNING)
+                        toContainViolation(OpenApiLintViolations.INVALID_ADDITIONAL_PROPERTIES_USAGE)
+                        toContainText("additionalProperties should only be defined for object schema")
+                    }
+                },
+                multiVersionLenientCase(name = "additionalProps on non-objects ref", *OpenApiVersion.allVersions()) {
+                    openApi {
+                        paths {
+                            path("/test") {
+                                operation("get") {
+                                    requestBody {
+                                        requestBody {
+                                            content {
+                                                mediaType("application/json") {
+                                                    schemaRef("NonObjectSchema")
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        components {
+                            schemas {
+                                schema("NonObjectSchema") {
+                                    put("type", "string")
+                                    put("additionalProperties", true)
+                                }
+                            }
+                        }
+                    }
+                    assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
+                    assert("components.schemas.NonObjectSchema.additionalProperties") {
+                        toHaveSeverity(IssueSeverity.WARNING)
+                        toContainViolation(OpenApiLintViolations.INVALID_ADDITIONAL_PROPERTIES_USAGE)
+                        toContainText("additionalProperties should only be defined for object schema")
+                    }
+                },
             ).flatten().stream()
         }
 


### PR DESCRIPTION
**What**: Ensure `PreProcessor` errors are recorded during the parse phase

**Why**: This enables them to be escalated to the final error or warning log and to the specmatic studio editor

**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
