### PR TITLE
Refactor linter pointers to enhance human readability

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -13,7 +13,6 @@ import io.cucumber.messages.types.Step
 import io.ktor.util.reflect.*
 import io.specmatic.conversions.SchemaUtils.mergeResolvedIfJsonSchema
 import io.specmatic.conversions.lenient.CollectorContext
-import io.specmatic.conversions.lenient.DEFAULT_ARRAY_INDEX
 import io.specmatic.core.*
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.log.LogStrategy
@@ -2388,7 +2387,13 @@ class OpenApiSpecification(
             }
 
             val paramName = pathSegment.removeSurrounding("{", "}")
-            val parameter = parameterContext.at(pathParamMap[paramName]?.index ?: DEFAULT_ARRAY_INDEX).requirePojo(
+            val pathParamContext = if (pathParamMap.containsKey(paramName)) {
+                parameterContext.at(pathParamMap.getValue(paramName).index)
+            } else {
+                parameterContext
+            }
+
+            val parameter = pathParamContext.requirePojo(
                 message = { "Expected path parameter with name $paramName is missing, defaulting to empty schema" },
                 extract = { pathParamMap[paramName]?.value },
                 ruleViolation = { OpenApiLintViolations.PATH_PARAMETER_MISSING },
@@ -2402,10 +2407,9 @@ class OpenApiSpecification(
                 }
             )
 
-            val pathParameterContext = parameterContext.at(pathParamMap[paramName]?.index ?: DEFAULT_ARRAY_INDEX)
             URLPathSegmentPattern(
                 key = paramName,
-                pattern = toSpecmaticPattern(parameter.schema, typeStack = emptyList(), collectorContext = pathParameterContext.at("schema")),
+                pattern = toSpecmaticPattern(parameter.schema, typeStack = emptyList(), collectorContext = pathParamContext.at("schema")),
             )
         }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/lenient/CollectorContext.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/lenient/CollectorContext.kt
@@ -7,7 +7,6 @@ import io.specmatic.core.jsonoperator.PathSegment
 import io.specmatic.core.value.toBigDecimal
 import io.specmatic.test.asserts.toFailure
 
-const val DEFAULT_ARRAY_INDEX = -1
 data class CollectorContext(private val collector: DiagnosticCollector = DiagnosticCollector(), private val pathSegments: List<PathSegment> = emptyList()) {
     val path: String? = pathSegments.joinToString(".", transform = PathSegment::internalPointerRepresentation).takeUnless(String::isBlank)
     val hasPath: Boolean = path != null

--- a/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/EnumPattern.kt
@@ -152,7 +152,13 @@ data class EnumPattern(override val pattern: AnyPattern, val nullable: Boolean) 
 
             val distinctValues = values.distinct()
             val indexOfNullValue = distinctValues.indexOfFirst { it is NullValue }
-            return collectorContext.at("enum").at(indexOfNullValue).check(
+            val nullValueContext = if (indexOfNullValue != -1) {
+                collectorContext.at("enum").at(indexOfNullValue)
+            } else {
+                collectorContext.at("enum")
+            }
+
+            return nullValueContext.check(
                 value = Pair(distinctValues, isNullable),
                 isValid = {
                     when {

--- a/core/src/test/kotlin/integration_tests/LenientParserTest.kt
+++ b/core/src/test/kotlin/integration_tests/LenientParserTest.kt
@@ -127,7 +127,7 @@ class LenientParserTest {
                         }
                     }
                     assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(1) }
-                    assert("paths./test/{id}.get.parameters[-1]") {
+                    assert("paths./test/{id}.get.parameters") {
                         toHaveSeverity(IssueSeverity.ERROR)
                         toContainViolation(OpenApiLintViolations.PATH_PARAMETER_MISSING)
                         toMatchText("Expected path parameter with name id is missing, defaulting to empty schema")
@@ -1951,7 +1951,7 @@ class LenientParserTest {
                         }
                     }
                     assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
-                    assert("paths./test.get.responses.200.content.application/json.schema.enum[-1]") {
+                    assert("paths./test.get.responses.200.content.application/json.schema.enum") {
                         toContainText("Enum values must contain null if the enum is marked nullable")
                     }
                 },
@@ -1975,7 +1975,7 @@ class LenientParserTest {
                         }
                     }
                     assert(RuleViolationAssertion.ALL_ISSUES) { totalIssues(1); totalViolations(0) }
-                    assert("paths./test.get.responses.200.content.application/json.schema.enum[-1]") {
+                    assert("paths./test.get.responses.200.content.application/json.schema.enum") {
                         toContainText("Enum values must contain null if the enum is marked nullable")
                     }
                 },


### PR DESCRIPTION
**What**: Ensure [-1] index doesn't show up for non-existing array pointers

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)