### PR TITLE
Reapply "Fix Regression in HttpHeaders fillInTheBlanks"

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpHeadersPattern.kt
@@ -2,6 +2,7 @@ package io.specmatic.core
 
 import io.ktor.http.*
 import io.specmatic.core.filters.caseInsensitiveContains
+import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.pattern.isOptional
 import io.specmatic.core.utilities.Flags
@@ -411,7 +412,7 @@ data class HttpHeadersPattern(
     }
 
     fun fillInTheBlanks(headers: Map<String, String>, resolver: Resolver): ReturnValue<Map<String, String>> {
-        val patternWithContentType = adjustPatternAccordanceWithHeaders(headers)
+        val patternWithContentType = adjustPatternForFixAndFill(headers)
         val headersValue = headers.mapValues { (key, value) ->
             val pattern = patternWithContentType[key] ?: patternWithContentType["$key?"] ?: return@mapValues StringValue(value)
             runCatching { pattern.parse(value, resolver) }.getOrDefault(StringValue(value))
@@ -428,7 +429,7 @@ data class HttpHeadersPattern(
     }
 
     fun fixValue(headers: Map<String, String>, resolver: Resolver): Map<String, String> {
-        val patternWithContentType = adjustPatternAccordanceWithHeaders(headers)
+        val patternWithContentType = adjustPatternForFixAndFill(headers)
         val headersValue = headers.mapValues { (key, value) ->
             val pattern = patternWithContentType[key] ?: patternWithContentType["$key?"] ?: return@mapValues StringValue(value)
             try { pattern.parse(value, resolver) } catch(_: Exception) { StringValue(value) }
@@ -440,13 +441,34 @@ data class HttpHeadersPattern(
             jsonPattern = JSONObjectPattern(patternWithContentType, typeAlias = null)
         )
 
-        return fixedHeaders.mapValues { it.value.toStringLiteral() }
+        return if (pattern.containsCaseInsensitiveCheckOptional(CONTENT_TYPE)) {
+            fixedHeaders.mapValues { it.value.toStringLiteral() }
+        } else {
+            fixContentTypeIfMismatch(fixedHeaders).mapValues { it.value.toStringLiteral() }
+        }
     }
 
-    private fun adjustPatternAccordanceWithHeaders(headers: Map<String, String>): Map<String, Pattern> {
-        return if (contentType != null) {
-            pattern.addIfNotExistCaseInsensitiveCheckOptional(CONTENT_TYPE, ExactValuePattern(StringValue(contentType)))
-        } else if (headers.getCaseInsensitive(CONTENT_TYPE) != null) {
+    private fun fixContentTypeIfMismatch(headers: Map<String, Value>): Map<String, Value> {
+        val contentTypeFromSpec = contentType ?: return headers
+        val contentTypeEntry = headers.getCaseInsensitive(CONTENT_TYPE) ?: return headers.plus(
+            CONTENT_TYPE to StringValue(contentTypeFromSpec)
+        )
+
+        return runCatching {
+            val specContentType = simplifiedContentType(contentTypeFromSpec.lowercase())
+            val valueContentType = simplifiedContentType(contentTypeEntry.value.toUnformattedString().lowercase())
+            if (specContentType.equals(valueContentType, ignoreCase = true)) return headers
+            headers.plus(contentTypeEntry.key to StringValue(contentTypeFromSpec))
+        }.getOrElse { e ->
+            logger.debug(e, "Failed to fix $CONTENT_TYPE for entry \"${contentTypeEntry.key}\" with value ${contentTypeEntry.value}")
+            headers.plus(contentTypeEntry.key to StringValue(contentTypeFromSpec))
+        }
+    }
+
+    private fun adjustPatternForFixAndFill(headers: Map<String, String>): Map<String, Pattern> {
+        val contentTypeInSpec = contentType != null
+        val contentTypeInHeaders = headers.getCaseInsensitive(CONTENT_TYPE) != null
+        return if (contentTypeInSpec && contentTypeInHeaders) {
             pattern.addIfNotExistCaseInsensitiveCheckOptional(CONTENT_TYPE, AnyValuePattern)
         } else {
             pattern
@@ -544,13 +566,18 @@ fun Map<String, String>.withoutTransportHeaders(): Map<String, String> =
 
 fun <T> Map<String, T>.getCaseInsensitive(key: String): Map.Entry<String, T>? = this.entries.find { it.key.equals(key, ignoreCase = true) }
 
-fun Map<String, Pattern>.addIfNotExistCaseInsensitiveCheckOptional(key: String, value: Pattern): Map<String, Pattern> {
+fun Map<String, Pattern>.containsCaseInsensitiveCheckOptional(key: String): Boolean {
     val mandatoryEntry = this.getCaseInsensitive(withoutOptionality(key))
-    if (mandatoryEntry != null) return this
+    if (mandatoryEntry != null) return true
 
     val optionalEntry = this.getCaseInsensitive(withOptionality(key))
-    if (optionalEntry != null) return this
+    if (optionalEntry != null) return true
 
+    return false
+}
+
+fun Map<String, Pattern>.addIfNotExistCaseInsensitiveCheckOptional(key: String, value: Pattern): Map<String, Pattern> {
+    if (this.containsCaseInsensitiveCheckOptional(key)) return this
     return this.plus(key to value)
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -9,10 +9,12 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.value.*
 import io.specmatic.test.TestExecutor
 import io.specmatic.toViolationReportString
+import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -792,6 +794,54 @@ internal class HttpHeadersPatternTest {
             val fixedValue = httpHeaders.fixValue(invalidValue, resolver.copy(dictionary = dictionary))
             assertThat(fixedValue).isEqualTo(mapOf("age" to "99", "extraKey" to "extraValue"))
         }
+
+        @Test
+        fun `should not fix content-type when parsed content-type matches`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = "application/json")
+            val validValue = mapOf("Content-Type" to "Application/JSON; charset=utf-8")
+            val fixedValue = httpHeaders.fixValue(validValue, Resolver())
+            assertThat(fixedValue).isEqualTo(validValue)
+        }
+
+        @Test
+        fun `should fix content-type when parsed content-type does not match`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = "application/json")
+            val invalidValue = mapOf("Content-Type" to "application/xml; charset=utf-8")
+            val fixedValue = httpHeaders.fixValue(invalidValue, Resolver())
+            assertThat(fixedValue).isEqualTo(mapOf("Content-Type" to "application/json"))
+        }
+
+        @Test
+        fun `should add content-type when declared in pattern but missing`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = "application/json")
+            val value = emptyMap<String, String>()
+            val fixedValue = httpHeaders.fixValue(value, Resolver())
+            assertThat(fixedValue).isEqualTo(mapOf("Content-Type" to "application/json"))
+        }
+
+        @Test
+        fun `should not remove content-type when not declared in pattern without override`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap())
+            val value = mapOf("Content-Type" to "application/json")
+            val fixedValue = httpHeaders.fixValue(value, Resolver())
+            assertThat(fixedValue).isEqualTo(value)
+        }
+
+        @Test
+        fun `should remove content-type when not declared in pattern on override key check`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap())
+            val value = mapOf("Content-Type" to "application/json")
+            val fixedValue = httpHeaders.fixValue(value, Resolver().disableOverrideUnexpectedKeyCheck())
+            assertThat(fixedValue).isEmpty()
+        }
+
+        @Test
+        fun `should not add content-type when not declared in pattern`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap())
+            val value = emptyMap<String, String>()
+            val fixedValue = httpHeaders.fixValue(value, Resolver())
+            assertThat(fixedValue).isEqualTo(value)
+        }
     }
 
     @ParameterizedTest
@@ -959,6 +1009,46 @@ internal class HttpHeadersPatternTest {
                 assertThat(result).isInstanceOf(HasValue::class.java); result as HasValue
                 println(result.value)
             }
+        }
+
+        @Test
+        fun `should not throw when parsed content-type matches`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = "application/json")
+            val headers = mapOf("Content-Type" to "Application/JSON; charset=utf-8")
+            val value = assertDoesNotThrow { httpHeaders.fillInTheBlanks(headers, Resolver()).value }
+            assertThat(value).isEqualTo(headers)
+        }
+
+        @Test
+        fun `should throw when parsed content-type does not match`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = "application/json")
+            val headers = mapOf("Content-Type" to "application/xml; charset=utf-8")
+            val value = assertDoesNotThrow { httpHeaders.fillInTheBlanks(headers, Resolver()).value }
+            assertThat(value).isEqualTo(headers)
+        }
+
+        @Test
+        fun `should not throw when content-type is declared but missing in value`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap(), contentType = "application/json")
+            val headers = emptyMap<String, String>()
+            val value = assertDoesNotThrow { httpHeaders.fillInTheBlanks(headers, Resolver()).value }
+            assertThat(value).isEqualTo(headers)
+        }
+
+        @Test
+        fun `should not throw when content-type is present but not declared in pattern`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap())
+            val headers = mapOf("Content-Type" to "application/json")
+            val value = assertDoesNotThrow { httpHeaders.fillInTheBlanks(headers, Resolver()).value }
+            assertThat(value).isEqualTo(headers)
+        }
+
+        @Test
+        fun `should not throw when content-type is absent and not declared in pattern`() {
+            val httpHeaders = HttpHeadersPattern(emptyMap())
+            val headers = emptyMap<String, String>()
+            val value = assertDoesNotThrow { httpHeaders.fillInTheBlanks(headers, Resolver()).value }
+            assertThat(value).isEqualTo(headers)
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpHeadersPatternTest.kt
@@ -820,7 +820,7 @@ internal class HttpHeadersPatternTest {
         }
 
         @Test
-        fun `should not remove content-type when not declared in pattern without override`() {
+        fun `should not remove content-type when not declared in pattern and override is not disabled`() {
             val httpHeaders = HttpHeadersPattern(emptyMap())
             val value = mapOf("Content-Type" to "application/json")
             val fixedValue = httpHeaders.fixValue(value, Resolver())
@@ -828,7 +828,7 @@ internal class HttpHeadersPatternTest {
         }
 
         @Test
-        fun `should remove content-type when not declared in pattern on override key check`() {
+        fun `should remove content-type when not declared in pattern on and override is disabled`() {
             val httpHeaders = HttpHeadersPattern(emptyMap())
             val value = mapOf("Content-Type" to "application/json")
             val fixedValue = httpHeaders.fixValue(value, Resolver().disableOverrideUnexpectedKeyCheck())


### PR DESCRIPTION
This reverts commit 18809f2bc9a3ca416f95b89935bf9be4c319ac93.

**What**: Fix the regression that was introduced in the HttpHeaders fillInTheBlanks method

**Why**:
- Regression was introduced in https://github.com/specmatic/specmatic/pull/2194
- In an effort to make HttpHeaders validate unexpected keys, the contentType was cast to an exact pattern.
- This works well in most cases, but when contentType includes additional attributes like `charset=utf-8`, the hidden nature of fillInTheBlanks also validates the value in question, resulting in an invalid value violation at the pattern level

**How**: Ensure that `fillInTheBlanks` never attempts to fill in or validate the `Content-Type` header

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
