### PR TITLE
Support custom path ordering in proxy generated specifications

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
@@ -39,7 +39,12 @@ private fun orderStubsByProxyOperations(namedStubs: List<NamedStub>, sortOrder: 
     for (stub in namedStubs) {
         val request = stub.stub.requestElsePartialRequest()
         val method = request.method?.lowercase()
-        val opIndex = operationsByMethod[method]?.firstOrNull { it.value.matches(request) }?.index ?: sortOrder.size
+        val opIndex =
+            operationsByMethod[method]
+                ?.firstOrNull { (_, proxyOperation) ->
+                    proxyOperation.matches(request)
+                }?.index
+                ?: sortOrder.size
         buckets[opIndex].add(stub)
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/StubExamplesToOpenApi.kt
@@ -3,23 +3,22 @@ package io.specmatic.core.utilities
 import io.specmatic.core.NamedStub
 import io.specmatic.core.parseGherkinStringToFeature
 import io.specmatic.core.toGherkinFeature
-import io.specmatic.core.urlDecodePathSegments
 import io.specmatic.mock.ScenarioStub
+import io.specmatic.proxy.ProxyOperation
 import io.swagger.v3.core.util.Yaml
-import io.swagger.v3.oas.models.Paths
 import java.io.File
+import kotlin.collections.flatten
 
-fun openApiYamlFromExampleDir(examplesDir: File, featureName: String = "New feature"): String? {
+fun openApiYamlFromExampleDir(examplesDir: File, featureName: String = "New feature", sortOrder: List<ProxyOperation>): String? {
     if (!examplesDir.exists() || !examplesDir.isDirectory) return null
 
-    val namedStubs = examplesDir.listFiles().orEmpty()
-        .filter { it.isFile && it.extension == "json" }
-        .sortedBy { it.name }
-        .map { file ->
-            val stub = ScenarioStub.readFromFile(file)
-            val name = stub.name ?: file.nameWithoutExtension
-            NamedStub(name, file.nameWithoutExtension, stub)
-        }
+    val namedStubs = examplesDir.listFiles().orEmpty().filter { it.isFile && it.extension == "json" }.map { file ->
+        val stub = ScenarioStub.readFromFile(file)
+        val name = stub.name ?: file.nameWithoutExtension
+        NamedStub(name, file.nameWithoutExtension, stub)
+    }.let {
+        orderStubsByProxyOperations(it, sortOrder)
+    }
 
     if (namedStubs.isEmpty()) return null
 
@@ -27,4 +26,22 @@ fun openApiYamlFromExampleDir(examplesDir: File, featureName: String = "New feat
     val feature = parseGherkinStringToFeature(gherkin)
     val openApi = feature.toOpenApi()
     return Yaml.pretty(openApi)
+}
+
+private fun indexOperationsByMethod(sortOrder: List<ProxyOperation>): Map<String, List<IndexedValue<ProxyOperation>>> {
+    return sortOrder.withIndex().groupBy(keySelector = { it.value.method.lowercase() }, valueTransform = { it })
+}
+
+private fun orderStubsByProxyOperations(namedStubs: List<NamedStub>, sortOrder: List<ProxyOperation>): List<NamedStub> {
+    if (sortOrder.isEmpty()) return namedStubs
+    val operationsByMethod = indexOperationsByMethod(sortOrder)
+    val buckets: List<MutableList<NamedStub>> = List(sortOrder.size + 1) { mutableListOf() }
+    for (stub in namedStubs) {
+        val request = stub.stub.requestElsePartialRequest()
+        val method = request.method?.lowercase()
+        val opIndex = operationsByMethod[method]?.firstOrNull { it.value.matches(request) }?.index ?: sortOrder.size
+        buckets[opIndex].add(stub)
+    }
+
+    return buckets.flatten()
 }

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -437,9 +437,14 @@ class Proxy(
             outputDirectory.createDirectory()
             stubDataDirectory.createDirectory()
 
-            val (matchingStubs, remainingStubs) = stubs.partition { stub ->
-                operationDetails.isNotEmpty() && operationDetails.any { stub.matches(it) }
-            }
+            val (matchingStubs, remainingStubs) =
+                if (operationDetails.isEmpty()) {
+                    copyOfRecordings() to emptyList()
+                } else {
+                    stubs.partition { stub ->
+                        operationDetails.any { stub.matches(it) }
+                    }
+                }
 
             stubs.clear()
             stubs.addAll(remainingStubs)
@@ -455,6 +460,8 @@ class Proxy(
             outputDirectory.writeText(specName, openApiYaml)
             return true
         }
+
+    private fun copyOfRecordings(): List<NamedStub> = stubs.toList()
 
     private fun writeMatchingStubs(examplesDir: File, stubDataDirectory: FileWriter, matchingStubs: List<NamedStub>) {
         if (matchingStubs.isEmpty()) return

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -80,7 +80,6 @@ class Proxy(
     )
 
     private val stubs = mutableListOf<NamedStub>()
-
     private val requestInterceptors: MutableList<RequestInterceptor> = mutableListOf()
     private val responseInterceptors: MutableList<ResponseInterceptor> = mutableListOf()
     private val proxyRequestHandlers: MutableList<ProxyRequestHandler> = mutableListOf()
@@ -394,9 +393,9 @@ class Proxy(
         }
     }
 
-    fun record(specName: String, operationDetails: List<ProxyOperation> = emptyList(), clearPrevious: Boolean = false): Boolean {
+    fun record(specName: String, operationDetails: List<ProxyOperation> = emptyList()): Boolean {
         return runBlocking {
-            recordInternal(specName, operationDetails, clearPrevious)
+            recordInternal(specName, operationDetails)
         }
     }
 
@@ -428,32 +427,25 @@ class Proxy(
             .booleanValue
     }
 
-    private suspend fun recordInternal(specName: String, operationDetails: List<ProxyOperation>, clearPrevious: Boolean = false): Boolean =
+    private suspend fun recordInternal(specName: String, operationDetails: List<ProxyOperation>): Boolean =
         recordMutex.withLock {
             val basePath = specName.dropExtension()
             val examplesDirName = "${basePath}$EXAMPLES_DIR_SUFFIX"
             val examplesDir = File(outputDirectory.fileName(examplesDirName))
             val stubDataDirectory = outputDirectory.subDirectory(examplesDirName)
 
-            if (clearPrevious) stubDataDirectory.clearDirectory()
             outputDirectory.createDirectory()
             stubDataDirectory.createDirectory()
 
-            val matchingStubs = stubs.filter { stub ->
-                if (operationDetails.isEmpty()) return@filter true
-                operationDetails.any { stub.matches(it) }
+            val (matchingStubs, remainingStubs) = stubs.partition { stub ->
+                operationDetails.isNotEmpty() && operationDetails.any { stub.matches(it) }
             }
 
-            if (matchingStubs.isNotEmpty()) {
-                val existingCount = examplesDir.listFiles().orEmpty().count { it.isFile && it.extension == "json" }
-                matchingStubs.forEachIndexed { index, namedStub ->
-                    val fileName = "${namedStub.shortName}_${existingCount + index + 1}.json"
-                    println("Writing stub data to $fileName")
-                    stubDataDirectory.writeText(fileName, namedStub.stub.toJSON().toStringLiteral())
-                }
-            }
+            stubs.clear()
+            stubs.addAll(remainingStubs)
+            writeMatchingStubs(examplesDir, stubDataDirectory, matchingStubs)
 
-            val openApiYaml = openApiYamlFromExampleDir(examplesDir, File(basePath).name)
+            val openApiYaml = openApiYamlFromExampleDir(examplesDir, File(basePath).name, operationDetails)
             if (openApiYaml == null) {
                 println("No stubs were recorded. No contract will be written.")
                 return false
@@ -463,6 +455,17 @@ class Proxy(
             outputDirectory.writeText(specName, openApiYaml)
             return true
         }
+
+    private fun writeMatchingStubs(examplesDir: File, stubDataDirectory: FileWriter, matchingStubs: List<NamedStub>) {
+        if (matchingStubs.isEmpty()) return
+        val existingFiles = examplesDir.listFiles().orEmpty().filter { it.isFile && it.extension == "json" }.map(File::getName).toMutableSet()
+        matchingStubs.forEach { namedStub ->
+            val fileName = generateSequence(1) { it + 1 }.map { "${namedStub.shortName}_$it.json" }.first { it !in existingFiles }
+            println("Writing stub data to $fileName")
+            stubDataDirectory.writeText(fileName, namedStub.stub.toJSON().toStringLiteral())
+            existingFiles.add(fileName)
+        }
+    }
 
     private suspend fun dumpSpecAndExamplesIntoOutputDir() =
         recordInternal("$specificationFileName.yaml", emptyList())

--- a/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/OpenApiYamlFromExampleDirTest.kt
@@ -1,0 +1,79 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.mock.ScenarioStub
+import io.specmatic.proxy.ProxyOperation
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.parser.OpenAPIV3Parser
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class OpenApiYamlFromExampleDirTest {
+    @Test
+    fun `openapi spec should respect proxy operation path sort order`(@TempDir tempDir: File) {
+        writeStub(tempDir, "a.json", httpMethod = "GET", path = "/orders")
+        writeStub(tempDir, "m.json", httpMethod = "POST", path = "/users")
+        writeStub(tempDir, "z.json", httpMethod = "GET", path = "/users")
+
+        val sortOrder = listOf(proxyOperation("POST", "/users"), proxyOperation("GET", "/users"), proxyOperation("GET", "/orders"))
+        val yaml = openApiYamlFromExampleDir(examplesDir = tempDir, featureName = "Ordered Feature", sortOrder = sortOrder)
+        assertThat(yaml).isNotNull; yaml as String
+
+        val openApi = parseYamlToOpenApi(yaml)
+        val actualOrder = extractOperationsInOrder(openApi)
+
+        val expectedOrder = listOf("get /users", "post /users", "get /orders")
+        assertThat(actualOrder).isEqualTo(expectedOrder)
+    }
+
+    @Test
+    fun `stubs not matching any proxy operation should be ordered last`(@TempDir tempDir: File) {
+        writeStub(tempDir, "a.json", "GET", "/orders")
+        writeStub(tempDir, "m.json", "GET", "/unmatched")
+        writeStub(tempDir, "z.json", "GET", "/users")
+
+        val sortOrder = listOf(proxyOperation("GET", "/users"), proxyOperation("GET", "/orders"))
+        val yaml = openApiYamlFromExampleDir(examplesDir = tempDir, featureName = "Unmatched Feature", sortOrder = sortOrder)
+        assertThat(yaml).isNotNull; yaml as String
+
+        val openApi = parseYamlToOpenApi(yaml)
+        val actualOrder = extractOperationsInOrder(openApi)
+
+        val expectedOrderedPrefix = listOf("get /users", "get /orders")
+        assertThat(actualOrder.take(expectedOrderedPrefix.size))
+            .withFailMessage("Matched operations should appear first in sortOrder sequence")
+            .isEqualTo(expectedOrderedPrefix)
+
+        assertThat(actualOrder.last())
+            .withFailMessage("Unmatched stubs should be placed after all matched operations")
+            .isEqualTo("get /unmatched")
+    }
+
+    private fun writeStub(dir: File, fileName: String, httpMethod: String, path: String) {
+        val stub = ScenarioStub(request = HttpRequest(method = httpMethod, path = path), response = HttpResponse.ok("ok"))
+        dir.resolve(fileName).writeText(stub.toJSON().toStringLiteral())
+    }
+
+    private fun proxyOperation(method: String, path: String): ProxyOperation =
+        ProxyOperation(method = method, pathPattern = OpenApiPath.from(path).toHttpPathPattern())
+
+    private fun parseYamlToOpenApi(yaml: String): OpenAPI {
+        println(yaml)
+        return OpenAPIV3Parser().readContents(yaml).openAPI
+    }
+
+    private fun extractOperationsInOrder(openApi: OpenAPI): List<String> {
+        val result = mutableListOf<String>()
+        openApi.paths.forEach { (path, pathItem) ->
+            pathItem.readOperationsMap().forEach { (method, _) ->
+                result.add("${method.name.lowercase()} $path")
+            }
+        }
+
+        return result
+    }
+}


### PR DESCRIPTION
**What**: Support custom path ordering in proxy generated specifications

**How**: Order stubs according to a given `sortOrder` of `ProxyOperations` before generating the OpenAPI specifiation

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)