### PR TITLE
Handle recursive anyOf references in OpenAPI 3.1

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -1840,6 +1840,7 @@ class OpenApiSpecification(
     private fun ensureAllObjectPatternsHaveAdditionalProperties(patterns: List<Pattern>): List<Pattern> {
         val resolver = Resolver(newPatterns = this@OpenApiSpecification.patterns)
         return patterns.map { pattern ->
+            if (pattern is DeferredPattern && !resolver.hasPattern(pattern.pattern)) return@map pattern
             if (pattern !is PossibleJsonObjectPatternContainer) return@map pattern
             pattern.ensureAdditionalProperties(resolver)
         }


### PR DESCRIPTION
**What**:

Recursively resolve anyOf references to ensure schemas are correctly resolved in OpenAPI 3.1

**Why**:

To address #2213 

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)

**Issue ID**:
Closes: #2213 
