### PR TITLE
chore: add SpecmaticMockRunner interface and make StubCommand implement the same

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -20,6 +20,7 @@ import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.SpecmaticConfigSource
+import io.specmatic.stub.SpecmaticMockRunner
 import io.specmatic.stub.endPointFromHostAndPort
 import io.specmatic.stub.extractHost
 import io.specmatic.stub.extractPort
@@ -42,7 +43,7 @@ class StubCommand(
     private val specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
     private val watchMaker: WatchMaker = WatchMaker(),
     private val httpClientFactory: HttpClientFactory = HttpClientFactory()
-) : Callable<Int> {
+) : SpecmaticMockRunner {
     var httpStub: ContractStub? = null
 
     @Parameters(arity = "0..*", description = ["Contract file paths", "Spec file paths"])
@@ -52,7 +53,7 @@ class StubCommand(
     var exampleDirs: List<String> = mutableListOf()
 
     @Option(names = ["--host"], description = ["Host for the http stub"], defaultValue = DEFAULT_HTTP_STUB_HOST)
-    lateinit var host: String
+    var host: String = DEFAULT_HTTP_STUB_HOST
 
     @Option(names = ["--port"], description = ["Port for the http stub"], defaultValue = DEFAULT_HTTP_STUB_PORT)
     var port: Int = 0
@@ -370,6 +371,10 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         val method = request.method
         val path = request.path
         return "$method $path"
+    }
+
+    override fun close() {
+        stopServer()
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/SpecmaticMockRunner.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/SpecmaticMockRunner.kt
@@ -1,0 +1,6 @@
+package io.specmatic.stub
+
+import java.io.Closeable
+import java.util.concurrent.Callable
+
+interface SpecmaticMockRunner  : Callable<Int>, Closeable


### PR DESCRIPTION
This is required so that for other stub commands for other protocols like grpc or async we can use this interface to start and stop the servers using a common interface.