### PR TITLE
Add ability to set the request handler from StubCommand and add id field in externalised example

### DIFF
--- a/application/src/main/kotlin/application/HTTPStubEngine.kt
+++ b/application/src/main/kotlin/application/HTTPStubEngine.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.log.consoleLog
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.HttpClientFactory
 import io.specmatic.stub.HttpStub
+import io.specmatic.stub.RequestHandler
 import io.specmatic.stub.SpecmaticConfigSource
 import io.specmatic.stub.contractInfoToHttpExpectations
 import io.specmatic.stub.listener.MockEventListener
@@ -24,7 +25,8 @@ class HTTPStubEngine {
         workingDirectory: WorkingDirectory,
         gracefulRestartTimeoutInMs: Long,
         specToBaseUrlMap: Map<String, String?>,
-        listeners: List<MockEventListener> = emptyList()
+        listeners: List<MockEventListener> = emptyList(),
+        requestHandlers: List<RequestHandler> = emptyList()
     ): HttpStub {
         return HttpStub(
             features = stubs.map { it.first },
@@ -40,7 +42,8 @@ class HTTPStubEngine {
             specmaticConfigSource = specmaticConfigSource,
             timeoutMillis = gracefulRestartTimeoutInMs,
             specToStubBaseUrlMap = specToBaseUrlMap,
-            listeners = listeners
+            listeners = listeners,
+            requestHandlers = requestHandlers.toMutableList()
         ).also {
             it.printStartupMessage()
         }

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -19,6 +19,8 @@ import io.specmatic.license.core.cli.Category
 import io.specmatic.mock.ScenarioStub
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.HttpClientFactory
+import io.specmatic.stub.HttpStub
+import io.specmatic.stub.RequestHandler
 import io.specmatic.stub.SpecmaticConfigSource
 import io.specmatic.stub.SpecmaticMockRunner
 import io.specmatic.stub.endPointFromHostAndPort
@@ -29,7 +31,6 @@ import io.specmatic.stub.listener.MockEventListener
 import picocli.CommandLine.*
 import picocli.CommandLine.Model.CommandSpec
 import java.io.File
-import java.util.concurrent.Callable
 
 @Command(
     name = "stub",
@@ -146,6 +147,11 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
 
     var listeners: List<MockEventListener> = emptyList()
     var registerShutdownHook: Boolean = true
+    var requestHandlers: List<RequestHandler> = emptyList()
+
+    // used by plugins
+    @Suppress("unused")
+    fun ctrfTestResultRecords() = (httpStub as? HttpStub)?.ctrfTestResultRecords().orEmpty()
 
     private val specmaticConfiguration: io.specmatic.core.SpecmaticConfig by lazy(LazyThreadSafetyMode.NONE) {
         if (configFileName != null) Configuration.configFilePath = configFileName as String
@@ -303,7 +309,8 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             workingDirectory = workingDirectory,
             gracefulRestartTimeoutInMs = configuredGracefulTimeout(),
             specToBaseUrlMap = contractSources.specToBaseUrlMap(),
-            listeners = listeners
+            listeners = listeners,
+            requestHandlers = requestHandlers
         )
 
         LogTail.storeSnapshot()

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -963,14 +963,7 @@ data class Feature(
                 scenarioStub.request,
                 scenarioStub.response,
                 mismatchMessages
-            ).copy(
-                delayInMilliseconds = scenarioStub.delayInMilliseconds,
-                requestBodyRegex = scenarioStub.requestBodyRegex?.let { Regex(it) },
-                stubToken = scenarioStub.stubToken,
-                data = scenarioStub.data,
-                examplePath = scenarioStub.filePath,
-                name = scenarioStub.nameOrFileName
-            )
+            ).copy(scenarioStub = scenarioStub)
         }
 
         val results = scenarios.asSequence().map { scenario ->
@@ -1003,12 +996,9 @@ data class Feature(
             HttpResponse(),
             matchingScenario.resolver,
             responsePattern = responseTypeWithAncestors,
-            examplePath = scenarioStub.filePath,
             scenario = matchingScenario,
-            data = scenarioStub.data,
             contractPath = this.path,
-            partial = scenarioStub.partial.copy(response = scenarioStub.partial.response),
-            name = scenarioStub.nameOrFileName
+            scenarioStub = scenarioStub
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -35,7 +35,7 @@ data class ScenarioStub(
     val rawJsonData: JSONObjectValue = JSONObjectValue(),
     val validationErrors: Result = Result.Success(),
     val strictMode: Boolean = true,
-    val exampleId: String? = null
+    val id: String? = null
 ) {
     init {
         if (strictMode && !validationErrors.isSuccess()) validationErrors.throwOnFailure()
@@ -384,7 +384,7 @@ const val TRANSIENT_MOCK_ID = "$TRANSIENT_MOCK-id"
 const val REQUEST_BODY_REGEX = "bodyRegex"
 const val IS_TRANSIENT_MOCK = "transient"
 const val PARTIAL = "partial"
-const val EXAMPLE_ID = "id"
+const val ID = "id"
 private val nonMetadataDataKeys = listOf(MOCK_HTTP_REQUEST, MOCK_HTTP_RESPONSE, PARTIAL)
 
 fun mockFromJSON(mockSpec: Map<String, Value>, strictMode: Boolean = true): ScenarioStub {
@@ -433,7 +433,7 @@ private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String,
     val isTransientMock = getBooleanOrNull(IS_TRANSIENT_MOCK, mockSpec) ?: false
     val stubToken = explicitStubToken ?: if (isTransientMock) UUID.randomUUID().toString() else null
     val requestBodyRegex = getRequestBodyRegexOrNull(mockSpec)
-    val exampleId = getStringOrNull(EXAMPLE_ID, mockSpec)
+    val id = getStringOrNull(ID, mockSpec)
 
     return ScenarioStub(
         request = mockRequest,
@@ -445,7 +445,7 @@ private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String,
         rawJsonData = JSONObjectValue(mockSpec),
         validationErrors = validationResult,
         strictMode = strictMode,
-        exampleId = exampleId
+        id = id
     )
 }
 

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -28,13 +28,14 @@ data class ScenarioStub(
     val response: HttpResponse = HttpResponse(0, emptyMap()),
     val delayInMilliseconds: Long? = null,
     val stubToken: String? = null,
-    val requestBodyRegex: String? = null,
+    val requestBodyRegex: Regex? = null,
     val data: JSONObjectValue = JSONObjectValue(),
     val filePath: String? = null,
     val partial: ScenarioStub? = null,
     val rawJsonData: JSONObjectValue = JSONObjectValue(),
     val validationErrors: Result = Result.Success(),
-    val strictMode: Boolean = true
+    val strictMode: Boolean = true,
+    val exampleId: String? = null
 ) {
     init {
         if (strictMode && !validationErrors.isSuccess()) validationErrors.throwOnFailure()
@@ -383,6 +384,7 @@ const val TRANSIENT_MOCK_ID = "$TRANSIENT_MOCK-id"
 const val REQUEST_BODY_REGEX = "bodyRegex"
 const val IS_TRANSIENT_MOCK = "transient"
 const val PARTIAL = "partial"
+const val EXAMPLE_ID = "id"
 private val nonMetadataDataKeys = listOf(MOCK_HTTP_REQUEST, MOCK_HTTP_RESPONSE, PARTIAL)
 
 fun mockFromJSON(mockSpec: Map<String, Value>, strictMode: Boolean = true): ScenarioStub {
@@ -431,6 +433,7 @@ private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String,
     val isTransientMock = getBooleanOrNull(IS_TRANSIENT_MOCK, mockSpec) ?: false
     val stubToken = explicitStubToken ?: if (isTransientMock) UUID.randomUUID().toString() else null
     val requestBodyRegex = getRequestBodyRegexOrNull(mockSpec)
+    val exampleId = getStringOrNull(EXAMPLE_ID, mockSpec)
 
     return ScenarioStub(
         request = mockRequest,
@@ -441,17 +444,29 @@ private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String,
         data = JSONObjectValue(data),
         rawJsonData = JSONObjectValue(mockSpec),
         validationErrors = validationResult,
-        strictMode = strictMode
+        strictMode = strictMode,
+        exampleId = exampleId
     )
 }
 
-fun getRequestBodyRegexOrNull(mockSpec: Map<String, Value>): String? {
+fun getRequestBodyRegexOrNull(mockSpec: Map<String, Value>): Regex? {
     return try {
         val requestSpec = getJSONObjectValueOrNull(MOCK_HTTP_REQUEST, mockSpec)
-        requestSpec?.get(REQUEST_BODY_REGEX)?.toStringLiteral()
+        val regexString = requestSpec?.get(REQUEST_BODY_REGEX)?.toStringLiteral()
+        parseRegex(regexString)
     } catch (e: Exception) {
         logger.debug(e, "Failed to parse $REQUEST_BODY_REGEX")
         null
+    }
+}
+
+private fun parseRegex(regex: String?): Regex? {
+    return regex?.let {
+        try {
+            Regex(it)
+        } catch (e: Throwable) {
+            throw ContractException("Couldn't parse regex $regex", exceptionCause = e)
+        }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -808,8 +808,7 @@ class HttpStub(
             }
 
             else -> {
-                val requestBodyRegex = parseRegex(stub.requestBodyRegex)
-                val stubData = firstResult.second.map { it.copy(requestBodyRegex = requestBodyRegex) }
+                val stubData = firstResult.second.map { it.copy(scenarioStub = stub) }
                 val resultWithRequestBodyRegex = stubData.map { Pair(firstResult.first, it) }
 
                 if (stub.stubToken != null) {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -465,7 +465,7 @@ class HttpStub(
             operations = setOf(
                 OpenAPIOperation(path, method, requestContentType, responseStatus, protocol)
             ),
-            exampleId = httpStubResponse.mock?.scenarioStub?.exampleId
+            exampleId = httpStubResponse.mock?.scenarioStub?.id
         )
         synchronized(ctrfTestResultRecords) { ctrfTestResultRecords.add(ctrfTestResultRecord) }
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
@@ -53,7 +53,7 @@ data class HttpStubData(
     val scenarioStub: ScenarioStub? = null
 ) {
     val name = scenarioStub?.name
-    val partial = scenarioStub?.let { it.partial?.copy(response = it.partial.response) }
+    val partial = scenarioStub?.partial
     val data = scenarioStub?.data ?: JSONObjectValue()
     val examplePath = scenarioStub?.filePath
     val stubToken = scenarioStub?.stubToken

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubData.kt
@@ -45,19 +45,21 @@ data class HttpStubData(
     val requestType: HttpRequestPattern,
     val response: HttpResponse,
     val resolver: Resolver,
-    val delayInMilliseconds: Long? = null,
     val responsePattern: HttpResponsePattern,
     val contractPath: String = "",
-    val examplePath: String? = null,
-    val stubToken: String? = null,
-    val requestBodyRegex: Regex? = null,
     val feature: Feature? = null,
     val scenario: Scenario? = null,
     private val originalRequest: HttpRequest? = null,
-    val data: JSONObjectValue = JSONObjectValue(),
-    val partial: ScenarioStub? = null,
-    val name: String? = null,
+    val scenarioStub: ScenarioStub? = null
 ) {
+    val name = scenarioStub?.name
+    val partial = scenarioStub?.let { it.partial?.copy(response = it.partial.response) }
+    val data = scenarioStub?.data ?: JSONObjectValue()
+    val examplePath = scenarioStub?.filePath
+    val stubToken = scenarioStub?.stubToken
+    val requestBodyRegex = scenarioStub?.requestBodyRegex
+    val delayInMilliseconds = scenarioStub?.delayInMilliseconds
+
     private val matcher: CompositeMatcher? by lazy { buildMatcherFromRequest() }
     private val sharedState: Transactional<ObjectValueOperator> = Transactional(ObjectValueOperator())
     private val defaultMismatchMessages: MismatchMessages = ExampleAndRequestMismatchMessages(name)

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStubResponse.kt
@@ -10,7 +10,8 @@ data class HttpStubResponse(
     val examplePath: String? = null,
     val feature: Feature? = null,
     val scenario: Scenario? = null,
-    val mock: HttpStubData? = null
+    val mock: HttpStubData? = null,
+    val isInternalStubPath: Boolean = false
 ) {
     val responseBody = response.body
 

--- a/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/ThreadSafeListOfStubs.kt
@@ -40,7 +40,7 @@ class ThreadSafeListOfStubs(
         synchronized(this) {
             result.second.let {
                 if(it != null)
-                    httpStubs.add(0, it.copy(delayInMilliseconds = stub.delayInMilliseconds, stubToken = stub.stubToken))
+                    httpStubs.add(0, it.copy(scenarioStub = stub))
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -47,7 +47,8 @@ data class TestResultRecord(
             responseCode = responseStatus,
             protocol = SpecmaticProtocol.HTTP
         )
-    )
+    ),
+    val exampleId: String? = null
 ): CtrfTestResultRecord {
     val isExercised = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
     val isCovered = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -604,7 +604,11 @@ Scenario: Square of a number
             stubResponse,
             Resolver(),
             responsePattern = HttpResponsePattern(),
-            name = "TestExample"
+            scenarioStub = ScenarioStub(
+                data = JSONObjectValue(
+                    mapOf("name" to StringValue("TestExample"))
+                )
+            )
         )
 
         val request = HttpRequest(method = "GET", path = "/count")

--- a/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ThreadSafeListOfStubsTest.kt
@@ -205,7 +205,13 @@ class ThreadSafeListOfStubsTest {
                 response = HttpResponse.ok(""),
                 responsePattern = HttpResponsePattern(HttpResponse.OK),
                 resolver = Resolver(),
-                partial = ScenarioStub(request = lowSpecificityRequest, response = HttpResponse.ok(parsedJSONObject("{\"id\": 1}")))
+                scenarioStub = ScenarioStub(
+                    partial =
+                        ScenarioStub(
+                            request = lowSpecificityRequest,
+                            response = HttpResponse.ok(parsedJSONObject("{\"id\": 1}"))
+                        )
+                )
             )
             
             val highSpecificityStub = HttpStubData(
@@ -213,7 +219,13 @@ class ThreadSafeListOfStubsTest {
                 response = HttpResponse.ok(""),
                 responsePattern = HttpResponsePattern(HttpResponse.OK),
                 resolver = Resolver(),
-                partial = ScenarioStub(request = highSpecificityRequest, response = HttpResponse.ok(parsedJSONObject("{\"id\": 2}")))
+                scenarioStub = ScenarioStub(
+                    partial =
+                        ScenarioStub(
+                            request = highSpecificityRequest,
+                            response = HttpResponse.ok(parsedJSONObject("{\"id\": 2}"))
+                        )
+                )
             )
             
             val partials = listOf(
@@ -238,7 +250,10 @@ class ThreadSafeListOfStubsTest {
                 response = HttpResponse.ok(""),
                 responsePattern = HttpResponsePattern(HttpResponse.OK),
                 resolver = Resolver(),
-                partial = ScenarioStub(request = lowGeneralityRequest, response = HttpResponse.ok(parsedJSONObject("{\"id\": 1}")))
+                scenarioStub = ScenarioStub(
+                    partial =
+                        ScenarioStub(request = lowGeneralityRequest, response = HttpResponse.ok(parsedJSONObject("{\"id\": 1}")))
+                )
             )
             
             val highGeneralityStub = HttpStubData(
@@ -246,7 +261,10 @@ class ThreadSafeListOfStubsTest {
                 response = HttpResponse.ok(""),
                 responsePattern = HttpResponsePattern(HttpResponse.OK),
                 resolver = Resolver(),
-                partial = ScenarioStub(request = highGeneralityRequest, response = HttpResponse.ok(parsedJSONObject("{\"id\": 2}")))
+                scenarioStub = ScenarioStub(
+                    partial =
+                        ScenarioStub(request = highGeneralityRequest, response = HttpResponse.ok(parsedJSONObject("{\"id\": 2}")))
+                )
             )
             
             val partials = listOf(


### PR DESCRIPTION
- Add nullable "id" field in externalised example
- Refactor HttpStubData to include ScenarioStub directly
- Add "exampleId" field in ctrfTestResultRecord
- Add ability to set the request handlers from StubCommand
- Add a method that exposes the ctrfTestResultRecords collected by HttpStub through StubCommand