### PR TITLE
fix: resolve example directories and improve fallback logic in service configuration

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -385,8 +385,8 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun getTestFilter(): String? {
-        val runOpts = specmaticConfig.systemUnderTest?.getRunOptions(resolver, SpecType.OPENAPI) as? OpenApiTestConfig ?: return null
-        return runOpts.filter ?: readEnvVarOrProperty(TEST_FILTER_ENV_VAR, TEST_FILTER_PROPERTY)
+        val runOpts = specmaticConfig.systemUnderTest?.getRunOptions(resolver, SpecType.OPENAPI) as? OpenApiTestConfig
+        return runOpts?.filter ?: readEnvVarOrProperty(TEST_FILTER_ENV_VAR, TEST_FILTER_PROPERTY)
     }
 
     override fun getTestFilterName(): String? {
@@ -398,16 +398,18 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun getTestOverlayFilePath(specFile: File, specType: SpecType): String? {
-        val specId = specmaticConfig.systemUnderTest?.getSpecDefinitionFor(specFile, resolver)?.getSpecificationId() ?: return null
-        val runOpts = specmaticConfig.systemUnderTest.getRunOptions(resolver, specType) ?: return null
-        return runOpts.getMatchingSpecification(specId)?.getOverlayFilePath() ?: readEnvVarOrProperty(TEST_OVERLAY_FILE_PATH_ENV_VAR, TEST_OVERLAY_FILE_PATH_PROPERTY)
+        val fromEnvOrProperty = readEnvVarOrProperty(TEST_OVERLAY_FILE_PATH_ENV_VAR, TEST_OVERLAY_FILE_PATH_PROPERTY)
+        val specId = specmaticConfig.systemUnderTest?.getSpecDefinitionFor(specFile, resolver)?.getSpecificationId() ?: return fromEnvOrProperty
+        val runOpts = specmaticConfig.systemUnderTest.getRunOptions(resolver, specType) ?: return fromEnvOrProperty
+        return runOpts.getMatchingSpecification(specId)?.getOverlayFilePath() ?: fromEnvOrProperty
     }
 
     override fun getStubOverlayFilePath(specFile: File, specType: SpecType): String? {
-        val service = specmaticConfig.dependencies?.getService(specFile, resolver) ?: return null
-        val specId = specmaticConfig.dependencies.getSpecDefinitionFor(specFile, service, resolver)?.getSpecificationId() ?: return null
-        val runOpts = specmaticConfig.dependencies.getRunOptions(service, resolver, specType) ?: return null
-        return runOpts.getMatchingSpecification(specId)?.getOverlayFilePath() ?: readEnvVarOrProperty(TEST_OVERLAY_FILE_PATH_ENV_VAR, TEST_OVERLAY_FILE_PATH_PROPERTY)
+        val fromEnvOrProperty = readEnvVarOrProperty(TEST_OVERLAY_FILE_PATH_ENV_VAR, TEST_OVERLAY_FILE_PATH_PROPERTY)
+        val service = specmaticConfig.dependencies?.getService(specFile, resolver) ?: return fromEnvOrProperty
+        val specId = specmaticConfig.dependencies.getSpecDefinitionFor(specFile, service, resolver)?.getSpecificationId() ?: return fromEnvOrProperty
+        val runOpts = specmaticConfig.dependencies.getRunOptions(service, resolver, specType) ?: return fromEnvOrProperty
+        return runOpts.getMatchingSpecification(specId)?.getOverlayFilePath() ?: fromEnvOrProperty
     }
 
     override fun getTestBaseUrl(specType: SpecType): String? {
@@ -761,7 +763,8 @@ data class SpecmaticConfigV3Impl(val file: File? = null, private val specmaticCo
     }
 
     override fun stubSpecPathFromConfigFor(absoluteSpecPath: String): String? {
-        val specDefinition = specmaticConfig.systemUnderTest?.getSpecDefinitionFor(File(absoluteSpecPath), resolver)
+        val service = specmaticConfig.dependencies?.getService(File(absoluteSpecPath), resolver) ?: return null
+        val specDefinition = specmaticConfig.dependencies.getSpecDefinitionFor(File(absoluteSpecPath), service, resolver)
         return specDefinition?.getSpecificationPath()
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -77,7 +77,7 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
                 val definition = defRef.definition
                 val source = definition.source.resolveElseThrow(resolver)
                 val serviceExamples = service?.data?.toExampleDirs(resolver)
-                val examples = mergeExamples(dependencyExamples, dependencyExamples)
+                val examples = mergeExamples(dependencyExamples, serviceExamples)
                 definition.specs.map {
                     it.toSpecificationSource(source, null, examples) { specId, file ->
                         getFirstBaseUrlFromRunOpts(specId, file , service, resolver)
@@ -122,7 +122,7 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
         }
 
         return specTypesToCheck.firstNotNullOfOrNull {
-            val runOptions = getRunOptions(service, resolver, it) ?: return null
+            val runOptions = getRunOptions(service, resolver, it) ?: return@firstNotNullOfOrNull null
             val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
             runOptionSpecOverride?.getBaseUrl() ?: runOptions.getBaseUrlIfExists()
         }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
@@ -92,9 +92,9 @@ sealed interface SpecificationDefinition {
 
     fun matchesFile(source: SourceV3, file: File): Boolean {
         val resolvedSpecFile = source.resolveSpecification(File(getSpecificationPath()))
-        val resolvedSpecPath = resolvedSpecFile.toPath().normalize()
+        val specPath = File(getSpecificationPath()).toPath().normalize()
         if (file.isAbsolute && resolvedSpecFile.isAbsolute) return resolvedSpecFile.sameAs(file)
-        if (!file.isAbsolute) return file.toPath().normalize().endsWith(resolvedSpecPath)
+        if (!file.isAbsolute) return file.toPath().normalize().endsWith(specPath)
         return false
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplRegressionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplRegressionTest.kt
@@ -1,0 +1,153 @@
+package io.specmatic.core.config.v3
+
+import io.specmatic.core.TEST_FILTER_PROPERTY
+import io.specmatic.core.TEST_OVERLAY_FILE_PATH_PROPERTY
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.Definition
+import io.specmatic.core.config.v3.components.services.MockServiceConfig
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.config.v3.components.settings.MockSettings
+import io.specmatic.core.config.v3.components.settings.TestSettings
+import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.reporter.model.SpecType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class SpecmaticConfigV3ImplRegressionTest {
+    @Test
+    fun `stubSpecPathFromConfigFor should resolve stub spec from dependencies`(@TempDir tempDir: File) {
+        val stubFile = tempDir.resolve("stub-contract.yaml").apply { writeText("openapi: 3.0.0") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val dependencies = MockServiceConfig(
+            services = listOf(
+                MockServiceConfig.Value(
+                    service = RefOrValue.Value(
+                        CommonServiceConfig<MockRunOptions, MockSettings>(
+                            definitions = listOf(
+                                Definition(
+                                    Definition.Value(
+                                        source = RefOrValue.Value(source),
+                                        specs = listOf(SpecificationDefinition.StringValue(stubFile.name))
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            settings = null
+        )
+
+        val config = SpecmaticConfigV3Impl(
+            file = tempDir.resolve("specmatic.yaml"),
+            specmaticConfig = SpecmaticConfigV3(
+                version = SpecmaticConfigVersion.VERSION_3,
+                dependencies = dependencies
+            )
+        )
+
+        assertThat(config.stubSpecPathFromConfigFor(stubFile.canonicalPath)).isEqualTo(stubFile.name)
+    }
+
+    @Test
+    fun `getTestFilter should fallback to system property when openapi test run options are absent`(@TempDir tempDir: File) {
+        val original = System.getProperty(TEST_FILTER_PROPERTY)
+        System.setProperty(TEST_FILTER_PROPERTY, "status==204")
+        try {
+            val config = SpecmaticConfigV3Impl(
+                file = tempDir.resolve("specmatic.yaml"),
+                specmaticConfig = SpecmaticConfigV3(version = SpecmaticConfigVersion.VERSION_3)
+            )
+
+            assertThat(config.getTestFilter()).isEqualTo("status==204")
+        } finally {
+            if (original == null) System.clearProperty(TEST_FILTER_PROPERTY) else System.setProperty(TEST_FILTER_PROPERTY, original)
+        }
+    }
+
+    @Test
+    fun `getTestOverlayFilePath should fallback to system property when run options are absent`(@TempDir tempDir: File) {
+        val original = System.getProperty(TEST_OVERLAY_FILE_PATH_PROPERTY)
+        System.setProperty(TEST_OVERLAY_FILE_PATH_PROPERTY, "overlay-from-property.yaml")
+        try {
+            val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+            val specFile = tempDir.resolve("sut-contract.yaml").apply { writeText("openapi: 3.0.0") }
+
+            val sut = TestServiceConfig(
+                service = RefOrValue.Value(
+                    CommonServiceConfig<TestRunOptions, TestSettings>(
+                        definitions = listOf(
+                            Definition(
+                                Definition.Value(
+                                    source = RefOrValue.Value(source),
+                                    specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+            val config = SpecmaticConfigV3Impl(
+                file = tempDir.resolve("specmatic.yaml"),
+                specmaticConfig = SpecmaticConfigV3(
+                    version = SpecmaticConfigVersion.VERSION_3,
+                    systemUnderTest = sut
+                )
+            )
+
+            assertThat(config.getTestOverlayFilePath(specFile, SpecType.OPENAPI)).isEqualTo("overlay-from-property.yaml")
+        } finally {
+            if (original == null) System.clearProperty(TEST_OVERLAY_FILE_PATH_PROPERTY) else System.setProperty(TEST_OVERLAY_FILE_PATH_PROPERTY, original)
+        }
+    }
+
+    @Test
+    fun `getStubOverlayFilePath should fallback to system property when run options are absent`(@TempDir tempDir: File) {
+        val original = System.getProperty(TEST_OVERLAY_FILE_PATH_PROPERTY)
+        System.setProperty(TEST_OVERLAY_FILE_PATH_PROPERTY, "overlay-from-property.yaml")
+        try {
+            val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+            val specFile = tempDir.resolve("stub-contract.yaml").apply { writeText("openapi: 3.0.0") }
+
+            val dependencies = MockServiceConfig(
+                services = listOf(
+                    MockServiceConfig.Value(
+                        service = RefOrValue.Value(
+                            CommonServiceConfig<MockRunOptions, MockSettings>(
+                                definitions = listOf(
+                                    Definition(
+                                        Definition.Value(
+                                            source = RefOrValue.Value(source),
+                                            specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+                settings = null
+            )
+
+            val config = SpecmaticConfigV3Impl(
+                file = tempDir.resolve("specmatic.yaml"),
+                specmaticConfig = SpecmaticConfigV3(
+                    version = SpecmaticConfigVersion.VERSION_3,
+                    dependencies = dependencies
+                )
+            )
+
+            assertThat(config.getStubOverlayFilePath(specFile, SpecType.OPENAPI)).isEqualTo("overlay-from-property.yaml")
+        } finally {
+            if (original == null) System.clearProperty(TEST_OVERLAY_FILE_PATH_PROPERTY) else System.setProperty(TEST_OVERLAY_FILE_PATH_PROPERTY, original)
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
@@ -1,0 +1,101 @@
+package io.specmatic.core.config.v3.components.services
+
+import io.specmatic.core.config.v3.Data
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.RefOrValueResolver
+import io.specmatic.core.config.v3.components.ExampleDirectories
+import io.specmatic.core.config.v3.components.runOptions.AsyncApiMockConfig
+import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.config.v3.components.settings.MockSettings
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class MockServiceConfigTest {
+    private val resolver = object : RefOrValueResolver {
+        override fun resolveRef(reference: String): Map<*, *> {
+            error("Unexpected ref resolution in test: $reference")
+        }
+    }
+
+    @Test
+    fun `getSpecificationSources should merge service and dependency example dirs`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("contract.txt").apply { writeText("not an openapi spec") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val dependencyData = Data(
+            examples = RefOrValue.Value(
+                listOf(RefOrValue.Value(ExampleDirectories(directories = listOf("dependency-examples"))))
+            )
+        )
+        val serviceData = Data(
+            examples = RefOrValue.Value(
+                listOf(RefOrValue.Value(ExampleDirectories(directories = listOf("service-examples"))))
+            )
+        )
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                    )
+                )
+            ),
+            data = serviceData
+        )
+
+        val mockServiceConfig = MockServiceConfig(
+            services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))),
+            data = dependencyData,
+            settings = null
+        )
+
+        val sourceEntries = mockServiceConfig.getSpecificationSources(resolver).values.flatten()
+
+        assertThat(sourceEntries).hasSize(1)
+        assertThat(sourceEntries.single().exampleDirs).containsExactlyInAnyOrder("service-examples", "dependency-examples")
+    }
+
+    @Test
+    fun `getSpecificationSources should use asyncapi base url when openapi run options are absent`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("contract.txt").apply { writeText("not an openapi spec") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val asyncApiMockConfig = AsyncApiMockConfig().apply {
+            put(
+                "servers", listOf(
+                    mapOf(
+                        "host" to "localhost",
+                        "port" to 8081
+                    )
+                )
+            )
+        }
+
+        val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(MockRunOptions(asyncapi = asyncApiMockConfig))
+        )
+
+        val mockServiceConfig = MockServiceConfig(
+            services = listOf(MockServiceConfig.Value(service = RefOrValue.Value(serviceConfig))),
+            settings = null
+        )
+
+        val sourceEntries = mockServiceConfig.getSpecificationSources(resolver).values.flatten()
+
+        assertThat(sourceEntries).hasSize(1)
+        assertThat(sourceEntries.single().baseUrl).isEqualTo("localhost:8081")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinitionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinitionTest.kt
@@ -1,0 +1,19 @@
+package io.specmatic.core.config.v3.components.services
+
+import io.specmatic.core.config.v3.components.sources.SourceV3
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class SpecificationDefinitionTest {
+    @Test
+    fun `matchesFile should match relative spec file paths for filesystem source`(@TempDir tempDir: File) {
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+        val definition = SpecificationDefinition.StringValue("contracts/orders.yaml")
+
+        val relativeInputPath = File("contracts/orders.yaml")
+
+        assertThat(definition.matchesFile(source, relativeInputPath)).isTrue()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
@@ -1,0 +1,87 @@
+package io.specmatic.core.config.v3.components.services
+
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.RefOrValueResolver
+import io.specmatic.core.config.v3.components.runOptions.AsyncApiTestConfig
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.settings.TestSettings
+import io.specmatic.core.config.v3.components.sources.SourceV3
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class TestServiceConfigTest {
+    private val resolver = object : RefOrValueResolver {
+        override fun resolveRef(reference: String): Map<*, *> {
+            error("Unexpected ref resolution in test: $reference")
+        }
+    }
+
+    @Test
+    fun `getSpecificationSources should use asyncapi base url when openapi run options are absent`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("contract.txt").apply { writeText("not an openapi spec") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val asyncApiTestConfig = AsyncApiTestConfig().apply {
+            put(
+                "servers", listOf(
+                    mapOf(
+                        "host" to "localhost",
+                        "port" to 8082
+                    )
+                )
+            )
+        }
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(SpecificationDefinition.StringValue(specFile.name))
+                    )
+                )
+            ),
+            runOptions = RefOrValue.Value(TestRunOptions(asyncapi = asyncApiTestConfig))
+        )
+
+        val testServiceConfig = TestServiceConfig(service = RefOrValue.Value(serviceConfig))
+
+        val sourceEntries = testServiceConfig.getSpecificationSources(resolver, testSettings = null).values.flatten()
+
+        assertThat(sourceEntries).hasSize(1)
+        assertThat(sourceEntries.single().baseUrl).isEqualTo("localhost:8082")
+    }
+
+    @Test
+    fun `getSpecificationSources should retain specs from multiple definitions with same source`(@TempDir tempDir: File) {
+        val firstSpec = tempDir.resolve("first.txt").apply { writeText("not an openapi spec") }
+        val secondSpec = tempDir.resolve("second.txt").apply { writeText("not an openapi spec") }
+        val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
+
+        val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = listOf(
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(SpecificationDefinition.StringValue(firstSpec.name))
+                    )
+                ),
+                Definition(
+                    Definition.Value(
+                        source = RefOrValue.Value(source),
+                        specs = listOf(SpecificationDefinition.StringValue(secondSpec.name))
+                    )
+                )
+            )
+        )
+
+        val testServiceConfig = TestServiceConfig(service = RefOrValue.Value(serviceConfig))
+
+        val sourceEntriesBySource = testServiceConfig.getSpecificationSources(resolver, testSettings = null)
+
+        assertThat(sourceEntriesBySource).hasSize(1)
+        assertThat(sourceEntriesBySource.values.single()).hasSize(2)
+    }
+}


### PR DESCRIPTION
**What**:

BFF Project was failing  because example dirs in V3 spec  were not being loaded correctly.

- [x] Unit Tests
- [X] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)