### PR TITLE
Add http2 support

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.14.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.14.2")
     testImplementation("io.kotest:kotest-assertions-core-jvm:6.1.2")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("com.squareup.okhttp3:okhttp-tls:4.12.0")
 
 }
 

--- a/application/src/test/kotlin/io/specmatic/test/ApacheHttpClientFactoryTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/ApacheHttpClientFactoryTest.kt
@@ -91,4 +91,22 @@ class ApacheHttpClientFactoryTest {
             assertThat(server.takeRequest().path).isEqualTo("/")
         }
     }
+
+    @Test
+    fun `HttpClient should add Host header from request URL authority for HTTP1_1 targets`() {
+        MockWebServer().use { server ->
+            server.protocols = listOf(Protocol.HTTP_1_1)
+            server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+            server.start()
+
+            val baseUrl = server.url("/").toString().removeSuffix("/")
+            val response = HttpClient(baseUrl).use { client ->
+                client.execute(HttpRequest(method = "GET", path = "/"))
+            }
+
+            val recordedRequest = server.takeRequest()
+            assertThat(response.status).isEqualTo(200)
+            assertThat(recordedRequest.getHeader("Host")).isEqualTo("localhost:${server.port}")
+        }
+    }
 }

--- a/application/src/test/kotlin/io/specmatic/test/ApacheHttpClientFactoryTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/ApacheHttpClientFactoryTest.kt
@@ -3,6 +3,15 @@ package io.specmatic.test
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
+import io.ktor.client.request.get
+import io.ktor.http.HttpProtocolVersion
+import io.specmatic.core.HttpRequest
+import kotlinx.coroutines.runBlocking
+import okhttp3.Protocol
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
@@ -31,5 +40,55 @@ class ApacheHttpClientFactoryTest {
         ApacheHttpClientFactory(timeoutPolicy).create().close()
 
         verify(exactly = 1) { timeoutPolicy.configure(any()) }
+    }
+
+    @Test
+    fun `the http client should negotiate HTTP2 when the server supports it`() {
+        val localhostCertificate = HeldCertificate.Builder()
+            .addSubjectAlternativeName("localhost")
+            .build()
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(localhostCertificate)
+            .build()
+
+        MockWebServer().use { server ->
+            server.protocols = listOf(Protocol.HTTP_2, Protocol.HTTP_1_1)
+            server.useHttps(serverCertificates.sslSocketFactory(), false)
+            server.enqueue(MockResponse().setBody("ok"))
+            server.start()
+
+            val responseProtocol = runBlocking {
+                ApacheHttpClientFactory(1000L).create().use { client ->
+                    client.get(server.url("/").toString()).version
+                }
+            }
+
+            assertThat(responseProtocol).isEqualTo(HttpProtocolVersion.HTTP_2_0)
+        }
+    }
+
+    @Test
+    fun `HttpClient should work with an HTTP2-capable target when instantiated directly`() {
+        val localhostCertificate = HeldCertificate.Builder()
+            .addSubjectAlternativeName("localhost")
+            .build()
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(localhostCertificate)
+            .build()
+
+        MockWebServer().use { server ->
+            server.protocols = listOf(Protocol.HTTP_2, Protocol.HTTP_1_1)
+            server.useHttps(serverCertificates.sslSocketFactory(), false)
+            server.enqueue(MockResponse().setBody("ok"))
+            server.start()
+
+            val baseUrl = server.url("/").toString().removeSuffix("/")
+            val response = HttpClient(baseUrl).use { client ->
+                client.execute(HttpRequest(method = "GET", path = "/"))
+            }
+
+            assertThat(response.status).isEqualTo(200)
+            assertThat(server.takeRequest().path).isEqualTo("/")
+        }
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     testImplementation("io.mockk:mockk-jvm:1.14.9")
     testImplementation("org.assertj:assertj-core:3.27.7")
     testImplementation("io.ktor:ktor-client-mock-jvm:2.3.13")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("com.squareup.okhttp3:okhttp-tls:4.12.0")
     implementation("org.thymeleaf:thymeleaf:3.1.3.RELEASE")
     implementation("org.junit.platform:junit-platform-launcher:1.14.2")
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation("io.ktor:ktor-server-netty-jvm:2.3.13")
     implementation("io.ktor:ktor-server-core-jvm:2.3.13")
     implementation("io.ktor:ktor-client-core-jvm:2.3.13")
-    implementation("io.ktor:ktor-client-apache-jvm:2.3.13")
+    implementation("io.ktor:ktor-client-apache5-jvm:2.3.13")
     implementation("io.ktor:ktor-server-cors-jvm:2.3.13")
     implementation("io.ktor:ktor-server-double-receive-jvm:2.3.13")
     implementation("io.ktor:ktor-server-content-negotiation-jvm:2.3.13")

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -254,6 +254,7 @@ data class HttpRequest(
 
     fun buildKTORRequest(httpRequestBuilder: HttpRequestBuilder) {
         httpRequestBuilder.method = HttpMethod.parse(method as String)
+        httpRequestBuilder.headers.remove(HttpHeaders.Host)
 
         val listOfExcludedHeaders: List<String> = listOfExcludedHeaders()
         headers.map { Triple(it.key.trim(), it.key.trim().lowercase(), it.value.trim()) }
@@ -695,14 +696,22 @@ fun formFieldsToGherkin(
     return Triple(formFieldClauses, newTypes, exampleDeclarations.plus(newExamples))
 }
 
-fun listOfExcludedHeaders(): List<String> = HttpHeaders.UnsafeHeadersList.plus(
-    arrayOf(
-        HttpHeaders.ContentLength,
-        HttpHeaders.ContentType,
-        HttpHeaders.TransferEncoding,
-        HttpHeaders.Upgrade
-    )
-).distinct().map { it.lowercase() }
+fun listOfExcludedHeaders(): List<String> =
+    HttpHeaders.UnsafeHeadersList.map { it.toString().lowercase() }.plus(
+        listOf(
+            "connection",
+            HttpHeaders.ContentLength.lowercase(),
+            HttpHeaders.ContentType.lowercase(),
+            HttpHeaders.Host.lowercase(),
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-authorization",
+            "te",
+            "trailer",
+            HttpHeaders.TransferEncoding.lowercase(),
+            HttpHeaders.Upgrade.lowercase()
+        )
+    ).distinct()
 
 fun escapeSpaceInPath(path: String): String {
     return path.split("/").joinToString("/") { segment ->

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequest.kt
@@ -262,10 +262,6 @@ data class HttpRequest(
                 httpRequestBuilder.header(key, value)
             }
 
-        httpRequestBuilder.url.let {
-            httpRequestBuilder.headers.set(name = "Host", value = it.authority)
-        }
-
         if(body !is NoBodyValue) {
             httpRequestBuilder.setBody(
                 when {

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.Closeable
 import java.io.File
-import java.net.URI
 import java.net.URL
 import java.util.*
 
@@ -122,14 +121,6 @@ class Proxy(
         )
     )
 
-    private val targetHost =
-        baseURL.let {
-            when {
-                it.isBlank() -> null
-                else -> URI(baseURL).host
-            }
-        }
-
     private val environment =
         applicationEngineEnvironment {
             module {
@@ -202,14 +193,7 @@ class Proxy(
                                     }
 
                                     // Send the ORIGINAL request to the target (not the tracked one)
-                                    val requestToSend =
-                                        targetHost?.let {
-                                            if (httpRequest.hasHeader("host")) {
-                                                httpRequest.withHost(targetHost)
-                                            } else {
-                                                httpRequest
-                                            }
-                                        } ?: httpRequest
+                                    val requestToSend = httpRequest
 
                                     // continue as before, if not matching filter
                                     val httpResponse =

--- a/core/src/main/kotlin/io/specmatic/test/ApacheHttpClientFactory.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ApacheHttpClientFactory.kt
@@ -1,36 +1,58 @@
 package io.specmatic.test
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.apache.*
+import io.ktor.client.engine.apache5.*
 import io.ktor.client.plugins.*
-import org.apache.http.conn.ssl.NoopHostnameVerifier
-import org.apache.http.conn.ssl.TrustAllStrategy
-import org.apache.http.ssl.SSLContextBuilder
+import org.apache.hc.client5.http.config.TlsConfig
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier
+import org.apache.hc.client5.http.ssl.TrustAllStrategy
+import org.apache.hc.core5.http2.HttpVersionPolicy
+import org.apache.hc.core5.ssl.SSLContextBuilder
 
 const val BREATHING_ROOM_FOR_REQUEST_TIMEOUT_TO_KICK_IN_FIRST = 1
 
 class ApacheHttpClientFactory(override val timeoutPolicy: TimeoutPolicy): HttpClientFactory {
     constructor(timeoutInMilliseconds: Long): this(TimeoutPolicy(timeoutInMilliseconds))
 
-    override fun create(): HttpClient = HttpClient(Apache) {
-        expectSuccess = false
+    override fun create(): HttpClient {
+        val permissiveSslContext = SSLContextBuilder.create()
+            .loadTrustMaterial(TrustAllStrategy.INSTANCE)
+            .build()
 
-        followRedirects = false
+        return HttpClient(Apache5) {
+            expectSuccess = false
 
-        engine {
-            customizeClient {
-                setSSLContext(
-                    SSLContextBuilder.create()
-                        .loadTrustMaterial(TrustAllStrategy())
-                        .build()
-                )
-                setSSLHostnameVerifier(NoopHostnameVerifier())
-                useSystemProperties()
+            followRedirects = false
+
+            engine {
+                sslContext = permissiveSslContext
+
+                customizeClient {
+                    setConnectionManager(
+                        PoolingAsyncClientConnectionManagerBuilder.create()
+                            .setDefaultTlsConfig(
+                                TlsConfig.custom()
+                                    .setVersionPolicy(HttpVersionPolicy.NEGOTIATE)
+                                    .build()
+                            )
+                            .setTlsStrategy(
+                                ClientTlsStrategyBuilder.create()
+                                    .setSslContext(permissiveSslContext)
+                                    .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                                    .useSystemProperties()
+                                    .build()
+                            )
+                            .build()
+                    )
+                    useSystemProperties()
+                }
             }
-        }
 
-        install(HttpTimeout) {
-            timeoutPolicy.configure(this)
+            install(HttpTimeout) {
+                timeoutPolicy.configure(this)
+            }
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpRequestTest.kt
@@ -227,13 +227,13 @@ internal class HttpRequestTest {
     }
 
     @Test
-    fun `override the host header to exclude the port suffix when the default port is used`() {
+    fun `should not inject Host header from request URL`() {
         val builderWithPort80 = HttpRequestBuilder().apply {
             this.url.host = "test.com"
             this.url.port = 80
         }
         HttpRequest("GET", "/").buildKTORRequest(builderWithPort80)
-        assertThat(builderWithPort80.headers["Host"]).isEqualTo("test.com")
+        assertThat(builderWithPort80.headers["Host"]).isNull()
 
         val httpRequestBuilderWithHTTPS = HttpRequestBuilder().apply {
             this.url.protocol = URLProtocol.HTTPS
@@ -241,18 +241,18 @@ internal class HttpRequestTest {
             this.url.port = 443
         }
         HttpRequest("GET", "/").buildKTORRequest(httpRequestBuilderWithHTTPS)
-        assertThat(httpRequestBuilderWithHTTPS.headers["Host"]).isEqualTo("test.com")
+        assertThat(httpRequestBuilderWithHTTPS.headers["Host"]).isNull()
     }
 
     @Test
-    fun `should remove lowercase host header to avoid duplicates`() {
+    fun `should not forward incoming host header`() {
         val httpRequestBuilder = HttpRequestBuilder().apply {
             this.url.host = "target.com"
             this.url.port = 80
         }
         HttpRequest("GET", "/", headers = mapOf("host" to "original.com"))
             .buildKTORRequest(httpRequestBuilder)
-        assertThat(httpRequestBuilder.headers["Host"]).isEqualTo("target.com")
+        assertThat(httpRequestBuilder.headers["Host"]).isNull()
     }
 
     @Test


### PR DESCRIPTION
**What**

Add support for HTTP/2.

**Why**

There have been multiple requests from users.

**How**

Specmatic was using an older library which didn't support HTTP/2 and had to be upgraded. There is also a difference in the legality of setting the Host header between HTTP/1.1 and HTTP/2. This PR addresses both points.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)