### PR TITLE
feat(cli): make mock the primary command and align user-facing stub text

### DIFF
--- a/application/readme.docker.md
+++ b/application/readme.docker.md
@@ -13,11 +13,11 @@ docker run -v "$(pwd)/openapi.yaml:/openapi.yaml" specmatic/specmatic test "/ope
 ```
 Will use the OpenAPI file `openapi.yaml` to run contract tests against the service running at `http://localhost:8080`.
 
-#### 2. Running Specmatic Service Virtualization
+#### 2. Running Specmatic Service Mocking
 ```shell
-docker run -v "$(pwd)/openapi.yaml:/openapi.yaml" -p "9000:9000"  specmatic/specmatic virtualize "/openapi.yaml"
+docker run -v "$(pwd)/openapi.yaml:/openapi.yaml" -p "9000:9000"  specmatic/specmatic mock "/openapi.yaml"
 ```
-Will use the OpenAPI file `openapi.yaml` to start a stub server on http://localhost:9000 and will respond to API requests as per the examples in the OpenAPI file.
+Will use the OpenAPI file `openapi.yaml` to start a mock server on http://localhost:9000 and will respond to API requests as per the examples in the OpenAPI file.
 
 #### 3. Running Specmatic Backward Compatibility Tests
 ```shell

--- a/application/src/main/kotlin/application/ProxyCommand.kt
+++ b/application/src/main/kotlin/application/ProxyCommand.kt
@@ -165,7 +165,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         Runtime.getRuntime().addShutdownHook(object : Thread() {
             override fun run() {
                 try {
-                    println("Shutting down stub servers")
+                    println("Shutting down mock servers")
                     proxy?.close()
                 } catch (e: InterruptedException) {
                     currentThread().interrupt()

--- a/application/src/main/kotlin/application/ProxyCommand.kt
+++ b/application/src/main/kotlin/application/ProxyCommand.kt
@@ -165,7 +165,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         Runtime.getRuntime().addShutdownHook(object : Thread() {
             override fun run() {
                 try {
-                    println("Shutting down mock servers")
+                    println("Shutting down proxy server")
                     proxy?.close()
                 } catch (e: InterruptedException) {
                     currentThread().interrupt()

--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -32,10 +32,10 @@ import picocli.CommandLine.Model.CommandSpec
 import java.io.File
 
 @Command(
-    name = "stub",
-    aliases = ["virtualize"],
+    name = "mock",
+    aliases = ["virtualize", "stub"],
     mixinStandardHelpOptions = true,
-    description = ["Start a stub server with contract"]
+    description = ["Start a mock server with contract"]
 )
 @Category("Specmatic core")
 class StubCommand(
@@ -53,13 +53,13 @@ class StubCommand(
     @Option(names = ["--data", "--examples"], description = ["Directories containing JSON examples"], required = false)
     var exampleDirs: List<String> = mutableListOf()
 
-    @Option(names = ["--host"], description = ["Host for the http stub"], defaultValue = DEFAULT_HTTP_STUB_HOST)
+    @Option(names = ["--host"], description = ["Host for the HTTP mock server"], defaultValue = DEFAULT_HTTP_STUB_HOST)
     var host: String = DEFAULT_HTTP_STUB_HOST
 
-    @Option(names = ["--port"], description = ["Port for the http stub"], defaultValue = DEFAULT_HTTP_STUB_PORT)
+    @Option(names = ["--port"], description = ["Port for the HTTP mock server"], defaultValue = DEFAULT_HTTP_STUB_PORT)
     var port: Int = 0
 
-    @Option(names = ["--strict"], description = ["Start HTTP stub in strict mode"], required = false)
+    @Option(names = ["--strict"], description = ["Start HTTP mock server in strict mode"], required = false)
     var strictMode: Boolean? = null
 
     @Option(names = ["--passThroughTargetBase"], description = ["All requests that did not match a url in any contract will be forwarded to this service"])
@@ -118,7 +118,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--logPrefix"], description = ["Prefix of log file"])
     var logPrefix: String? = null
 
-    @Option(names = ["--delay-in-ms"], description = ["Stub response delay in milliseconds"])
+    @Option(names = ["--delay-in-ms"], description = ["Mock response delay in milliseconds"])
     var delayInMilliseconds: Long? = null
 
     @Spec
@@ -127,7 +127,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     @Option(names = ["--graceful-restart-timeout-in-ms"], description = ["Time to wait for the server to stop before starting it again"])
     var gracefulRestartTimeoutInMs: Long? = null
 
-    @Option(names = ["--hot-reload"], description = ["Restart the stub when the example files are updated (enabled by default)"])
+    @Option(names = ["--hot-reload"], description = ["Restart the mock server when the example files are updated (enabled by default)"])
     var hotReload: Switch? = null
 
     @Option(
@@ -287,13 +287,13 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         }
 
         if (filterAccumulator.isNotEmpty() && filteredStubData.isEmpty()) {
-            consoleLog(StringLog("FATAL: No stubs found for the given filters $filterAccumulator"))
+            consoleLog(StringLog("FATAL: No examples found for the given filters $filterAccumulator"))
             return
         }
 
         if (configuredHotReload() == Switch.disabled) {
             val warningMessage =
-                "WARNING: Hot reload has been disabled. Specmatic will not restart the stub server automatically when the specifications or examples change."
+                "WARNING: Hot reload has been disabled. Specmatic will not restart the mock server automatically when the specifications or examples change."
             logger.boundary()
             logger.log(warningMessage)
             logger.boundary()
@@ -328,7 +328,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
             val port = extractPort(baseUrl)
             if (host.isBlank()) null else host to port
         } catch (e: Throwable) {
-            logger.log("Invalid stub baseUrl '$baseUrl' in config. Falling back to defaults.")
+            logger.log("Invalid mock server baseUrl '$baseUrl' in config. Falling back to defaults.")
             null
         }
     }
@@ -356,7 +356,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
         Runtime.getRuntime().addShutdownHook(object : Thread() {
             override fun run() {
                 try {
-                    consoleLog(StringLog("Shutting down stub servers"))
+                    consoleLog(StringLog("Shutting down mock servers"))
                     httpStub?.close()
                 } catch (e: InterruptedException) {
                     currentThread().interrupt()
@@ -370,7 +370,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
 
         if (verbose == true) {
             logger.boundary()
-            consoleLog(StringLog("Loaded stubs:"))
+            consoleLog(StringLog("Loaded examples:"))
             stubData.forEach { (feature, stubs) ->
                 val featureName = feature.specification ?: feature.path
                 stubs.forEach { stub ->

--- a/application/src/test/kotlin/application/HTTPStubEngineTest.kt
+++ b/application/src/test/kotlin/application/HTTPStubEngineTest.kt
@@ -51,7 +51,7 @@ class HTTPStubEngineTest {
         }
 
         assertThat(stdOut).containsIgnoringNewLines("""
-        |Stub server is running on the following URLs:
+        |Mock server is running on the following URLs:
         |- http://localhost:8000/api/v3 serving endpoints from specs:
         |\t1. api.yaml
         |
@@ -73,7 +73,7 @@ class HTTPStubEngineTest {
         }
 
         assertThat(stdOut).containsIgnoringNewLines("""
-        |Stub server is running on the following URLs:
+        |Mock server is running on the following URLs:
         |- http://localhost:8000/api/v3 serving endpoints from specs:
         |\t1. api.yaml
         |
@@ -92,7 +92,7 @@ class HTTPStubEngineTest {
         }
 
         assertThat(stdOut).containsIgnoringNewLines("""
-        |Stub server is running on the following URLs:
+        |Mock server is running on the following URLs:
         |- http://0.0.0.0:9000 serving endpoints from specs:
         |\t1. api.yaml
         |\t2. uuid.yaml

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -965,7 +965,7 @@ class HttpStub(
         val baseUrlToSpecsMap = specToStubBaseUrlMap.entries.groupBy({ it.value }, { it.key })
 
         return buildString {
-            appendLine("Stub server is running on the following URLs:")
+            appendLine("Mock server is running on the following URLs:")
             baseUrlToSpecsMap.entries.sortedBy { it.key }.forEachIndexed { urlIndex, (url, specs) ->
                 appendLine("- $url serving endpoints from specs:")
                 specs.sorted().forEachIndexed { index, spec ->


### PR DESCRIPTION
Specmatic stub is really a mock now and hence changing specmatic stub to mock in the CLI. Kept stub for backward compatibility 

- [x] Unit Tests
- [x] Build passing locally
