### PR TITLE
fix: Resolve issue loading system properties set in the BeforeAll method when using the JUnit runner

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/ContractTestSettings.kt
@@ -106,30 +106,34 @@ data class ContractTestSettings(
     )
 
     constructor(contractTestSettings: ThreadLocal<ContractTestSettings?>, specmaticConfig: SpecmaticConfig) : this(
-        generative = contractTestSettings.get()?.generative,
-        reportBaseDirectory = contractTestSettings.get()?.reportBaseDirectory,
-        coverageHooks = contractTestSettings.get()?.coverageHooks ?: emptyList(),
-        previousTestRuns = contractTestSettings.get()?.previousTestRuns.orEmpty(),
-        configFile = contractTestSettings.get()?.configFile ?: getConfigFilePath(),
-        strictMode = contractTestSettings.get()?.strictMode ?: SpecmaticConfig().getTestStrictMode(),
-        lenientMode = contractTestSettings.get()?.lenientMode ?: SpecmaticConfig().getTestLenientMode() ?: false,
-        testBaseURL = contractTestSettings.get()?.testBaseURL ?: specmaticConfig.getTestBaseUrl(SpecType.OPENAPI),
-        contractPaths = contractTestSettings.get()?.contractPaths,
-        timeoutInMilliSeconds = contractTestSettings.get()?.timeoutInMilliSeconds,
-        filter = contractTestSettings.get()?.filter ?: specmaticConfig.getTestFilter(),
+        contractTestSettings.get(), specmaticConfig
+    )
+
+    constructor(contractTestSettings: ContractTestSettings?, specmaticConfig: SpecmaticConfig) : this(
+        generative = contractTestSettings?.generative,
+        reportBaseDirectory = contractTestSettings?.reportBaseDirectory,
+        coverageHooks = contractTestSettings?.coverageHooks ?: emptyList(),
+        previousTestRuns = contractTestSettings?.previousTestRuns.orEmpty(),
+        configFile = contractTestSettings?.configFile ?: getConfigFilePath(),
+        strictMode = contractTestSettings?.strictMode ?: SpecmaticConfig().getTestStrictMode(),
+        lenientMode = contractTestSettings?.lenientMode ?: SpecmaticConfig().getTestLenientMode() ?: false,
+        testBaseURL = contractTestSettings?.testBaseURL ?: specmaticConfig.getTestBaseUrl(SpecType.OPENAPI),
+        contractPaths = contractTestSettings?.contractPaths,
+        timeoutInMilliSeconds = contractTestSettings?.timeoutInMilliSeconds,
+        filter = contractTestSettings?.filter ?: specmaticConfig.getTestFilter(),
         otherArguments = DeprecatedArguments(
-            host = contractTestSettings.get()?.otherArguments?.host,
-            port = contractTestSettings.get()?.otherArguments?.port,
-            envName = contractTestSettings.get()?.otherArguments?.envName,
-            protocol = contractTestSettings.get()?.otherArguments?.protocol,
-            useCurrentBranchForCentralRepo = contractTestSettings.get()?.otherArguments?.useCurrentBranchForCentralRepo,
-            suggestionsPath = contractTestSettings.get()?.otherArguments?.suggestionsPath,
-            inlineSuggestions = contractTestSettings.get()?.otherArguments?.inlineSuggestions,
-            variablesFileName = contractTestSettings.get()?.otherArguments?.variablesFileName,
-            exampleDirectories = contractTestSettings.get()?.otherArguments?.exampleDirectories ?: specmaticConfig.getExamples(),
-            filterName = contractTestSettings.get()?.otherArguments?.filterName ?: specmaticConfig.getTestFilterName(),
-            filterNotName = contractTestSettings.get()?.otherArguments?.filterNotName ?: specmaticConfig.getTestFilterNotName(),
-            overlayFilePath = contractTestSettings.get()?.otherArguments?.overlayFilePath,
+            host = contractTestSettings?.otherArguments?.host,
+            port = contractTestSettings?.otherArguments?.port,
+            envName = contractTestSettings?.otherArguments?.envName,
+            protocol = contractTestSettings?.otherArguments?.protocol,
+            useCurrentBranchForCentralRepo = contractTestSettings?.otherArguments?.useCurrentBranchForCentralRepo,
+            suggestionsPath = contractTestSettings?.otherArguments?.suggestionsPath,
+            inlineSuggestions = contractTestSettings?.otherArguments?.inlineSuggestions,
+            variablesFileName = contractTestSettings?.otherArguments?.variablesFileName,
+            exampleDirectories = contractTestSettings?.otherArguments?.exampleDirectories ?: specmaticConfig.getExamples(),
+            filterName = contractTestSettings?.otherArguments?.filterName ?: specmaticConfig.getTestFilterName(),
+            filterNotName = contractTestSettings?.otherArguments?.filterNotName ?: specmaticConfig.getTestFilterNotName(),
+            overlayFilePath = contractTestSettings?.otherArguments?.overlayFilePath,
         ),
     )
 }


### PR DESCRIPTION
**What**:

This PR cleans up initialization of the contract test settings so as not to drop system properties set by a BeforeAll method.

**Why**:

Due to a recent change, contract test settings got initialized before BeforeAll methods ran, so any system properties set in the before all method got lost.

**How**:

Re-initialize ContractTestSettings after the tests start, so as to pick up any system properties set by the users BeforeAll method.

So ContractTestSettings gets initialized twice. The first time is to get off the critical path for any tests running, and the second time is to actually pick up any values from system properties for values that were not set earlier.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
