### PR TITLE
feat: add ability to hook in before and after fixtures execution in ScenarioAsTest

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/ExampleFromFile.kt
@@ -59,7 +59,8 @@ class ExampleFromFile(private val scenarioStub: ScenarioStub, val file: File) {
             responseExampleForAssertion = response,
             requestExample = scenarioStub.getRequestWithAdditionalParamsIfAny(specmaticConfig.getAdditionalExampleParamsFilePath()),
             responseExample = response,
-            isPartial = scenarioStub.partial != null
+            isPartial = scenarioStub.partial != null,
+            scenarioStub = scenarioStub
         ).let { ExampleProcessor.resolve(it, ExampleProcessor::ifNotExitsToLookupPattern) }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.*
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONComposite
 import io.specmatic.core.value.JSONObjectValue
+import io.specmatic.mock.ScenarioStub
 
 const val DEREFERENCE_PREFIX = "$"
 const val FILENAME_PREFIX = "@"
@@ -21,7 +22,8 @@ data class Row(
     val exactResponseExample: ResponseExample? = null,
     val requestExample: HttpRequest? = null,
     val responseExample: HttpResponse? = null,
-    val isPartial: Boolean = false
+    val isPartial: Boolean = false,
+    val scenarioStub: ScenarioStub? = null
 ) {
     constructor(examples: Map<String, String>) :this(examples.keys.toList(), examples.values.toList())
 

--- a/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
+++ b/core/src/main/kotlin/io/specmatic/mock/ScenarioStub.kt
@@ -35,7 +35,9 @@ data class ScenarioStub(
     val rawJsonData: JSONObjectValue = JSONObjectValue(),
     val validationErrors: Result = Result.Success(),
     val strictMode: Boolean = true,
-    val id: String? = null
+    val id: String? = null,
+    val beforeFixtures: List<Value> = emptyList(),
+    val afterFixtures: List<Value> = emptyList()
 ) {
     init {
         if (strictMode && !validationErrors.isSuccess()) validationErrors.throwOnFailure()
@@ -385,6 +387,8 @@ const val REQUEST_BODY_REGEX = "bodyRegex"
 const val IS_TRANSIENT_MOCK = "transient"
 const val PARTIAL = "partial"
 const val ID = "id"
+const val BEFORE_FIXTURES = "before"
+const val AFTER_FIXTURES = "after"
 private val nonMetadataDataKeys = listOf(MOCK_HTTP_REQUEST, MOCK_HTTP_RESPONSE, PARTIAL)
 
 fun mockFromJSON(mockSpec: Map<String, Value>, strictMode: Boolean = true): ScenarioStub {
@@ -434,6 +438,8 @@ private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String,
     val stubToken = explicitStubToken ?: if (isTransientMock) UUID.randomUUID().toString() else null
     val requestBodyRegex = getRequestBodyRegexOrNull(mockSpec)
     val id = getStringOrNull(ID, mockSpec)
+    val beforeFixtures = getArrayOrNull(BEFORE_FIXTURES, mockSpec).orEmpty()
+    val afterFixtures = getArrayOrNull(AFTER_FIXTURES, mockSpec).orEmpty()
 
     return ScenarioStub(
         request = mockRequest,
@@ -445,7 +451,9 @@ private fun parseStandardExample(mockSpec: Map<String, Value>, data: Map<String,
         rawJsonData = JSONObjectValue(mockSpec),
         validationErrors = validationResult,
         strictMode = strictMode,
-        id = id
+        id = id,
+        beforeFixtures = beforeFixtures,
+        afterFixtures = afterFixtures
     )
 }
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -1,28 +1,25 @@
 package io.specmatic.test
 
 import io.specmatic.conversions.convertPathParameterStyle
-import io.specmatic.core.SpecificationAndResponseMismatch
-import io.specmatic.core.Feature
-import io.specmatic.core.FlagsBased
-import io.specmatic.core.HttpRequest
-import io.specmatic.core.HttpResponse
-import io.specmatic.core.Result
-import io.specmatic.core.Scenario
-import io.specmatic.core.ValidateUnexpectedKeys
-import io.specmatic.core.Workflow
+import io.specmatic.core.*
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.Value
 import io.specmatic.license.core.SpecmaticProtocol
-import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.SPECMATIC_RESPONSE_CODE_HEADER
+import io.specmatic.test.fixtures.OpenAPIFixtureExecutor
 import io.specmatic.test.handlers.ResponseHandler
 import io.specmatic.test.handlers.ResponseHandlerRegistry
 import io.specmatic.test.handlers.ResponseHandlingResult
 import java.time.Instant
+import java.util.ServiceLoader
+import kotlin.jvm.java
+
+private const val BEFORE_FIXTURE_DISCRIMINATOR_KEY = "before"
+private const val AFTER_FIXTURE_DISCRIMINATOR_KEY = "after"
 
 data class ScenarioAsTest(
     val scenario: Scenario,
@@ -122,6 +119,10 @@ data class ScenarioAsTest(
         flagsBased: FlagsBased
     ): ContractTestExecutionResult {
         try {
+            val beforeFixtureExecutionResult = fixtureExecutionResult(BEFORE_FIXTURE_DISCRIMINATOR_KEY)
+            if (beforeFixtureExecutionResult.isSuccess().not()) {
+                return ContractTestExecutionResult(result = beforeFixtureExecutionResult)
+            }
             val request = testScenario.generateHttpRequest(flagsBased).let {
                 workflow.updateRequest(it, originalScenario).adjustPayloadForContentType()
             }.addHeaderIfMissing(SPECMATIC_RESPONSE_CODE_HEADER, testScenario.status.toString())
@@ -132,7 +133,19 @@ data class ScenarioAsTest(
 
             //TODO: Review - Do we need workflow anymore
             workflow.extractDataFrom(response, originalScenario)
-            val validatorResult = validators.asSequence().map { it.validate(scenario, response) }.filterNotNull().firstOrNull()
+            val validatorResult = validators.asSequence().mapNotNull { it.validate(scenario, response) }.firstOrNull()
+
+            if(validatorResult !is Result.Failure) {
+                val afterFixtureExecutionResult = fixtureExecutionResult(AFTER_FIXTURE_DISCRIMINATOR_KEY)
+                if (afterFixtureExecutionResult.isSuccess().not()) {
+                    return ContractTestExecutionResult(
+                        result = afterFixtureExecutionResult,
+                        request = request,
+                        response = response
+                    )
+                }
+            }
+
             if (validatorResult is Result.Failure) {
                 return ContractTestExecutionResult(
                     result = validatorResult.withBindings(testScenario.bindings, response),
@@ -186,6 +199,18 @@ data class ScenarioAsTest(
                     .also { failure -> failure.updateScenario(testScenario) }
             )
         }
+    }
+
+    private fun fixtureExecutionResult(fixtureDiscriminatorKey: String): Result {
+        val row = scenario.exampleRow ?: return Result.Success()
+        val scenarioStub = row.scenarioStub ?: return Result.Success()
+        val id = scenarioStub.id.orEmpty()
+        val fixtures = when (fixtureDiscriminatorKey) {
+            BEFORE_FIXTURE_DISCRIMINATOR_KEY -> scenarioStub.beforeFixtures
+            else -> scenarioStub.afterFixtures
+        }
+        return ServiceLoader.load(OpenAPIFixtureExecutor::class.java)
+            .firstOrNull()?.execute(id, fixtures, fixtureDiscriminatorKey) ?: Result.Success()
     }
 
     private fun testResult(

--- a/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
@@ -1,0 +1,8 @@
+package io.specmatic.test.fixtures
+
+import io.specmatic.core.Result
+import io.specmatic.core.value.Value
+
+interface OpenAPIFixtureExecutor {
+    fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String): Result
+}


### PR DESCRIPTION
Reason for change -
We want to support the before and after fixture execution where these fixtures will be defined in the externalised examples.