### PR TITLE
Miscallaneous modifications to Spematic Config classes

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -428,6 +428,30 @@ data class SpecmaticConfigV1V2Common(
         }
 
         @JsonIgnore
+        fun getIgnoreInlineExampleWarningsOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.ignoreInlineExamples
+
+        @JsonIgnore
+        fun getEscapeSoapActionOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.escapeSoapAction
+
+        @JsonIgnore
+        fun getSchemaExampleDefaultOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.schemaExampleDefault
+
+        @JsonIgnore
+        fun getExtensibleQueryParamsOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.extensibleQueryParams
+
+        @JsonIgnore
+        fun getFuzzyMatchingEnabledOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.fuzzy
+
+        @JsonIgnore
+        fun getPrettyPrintOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.prettyPrint
+
+        @JsonIgnore
+        fun isTelemetryDisabledOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.disableTelemetry
+
+        @JsonIgnore
+        fun getReportDirPathOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Path? = specmaticConfig.reportDirPath
+
+        @JsonIgnore
         fun getVirtualServiceConfigOrNull(specmaticConfig: SpecmaticConfigV1V2Common): VirtualServiceConfiguration? {
             return specmaticConfig.virtualService
         }

--- a/core/src/main/kotlin/io/specmatic/core/config/OpenAPIMockConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/OpenAPIMockConfig.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.config
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
@@ -10,16 +11,29 @@ data class OpenAPIMockConfig(
     @JsonProperty("examples")
     val examples: List<String>? = null
 ) {
+    private fun writeConfig(): Map<String, Any> = mapper.convertValue(this, stringMapType)
 
     companion object {
+        private val mapper = ObjectMapper().registerKotlinModule()
+        private val stringMapType = mapper.typeFactory.constructType(object : TypeReference<Map<String, Any>>() {})
+
         fun from(config: Map<String, Any>): OpenAPIMockConfig {
-            try {
-                return ObjectMapper().registerKotlinModule().convertValue(
-                    config,
-                    OpenAPIMockConfig::class.java
-                )
+            return try {
+                readConfig(config).getOrThrow()
             } catch(t: Throwable) {
                 throw IllegalArgumentException("Invalid config provided in openapi mock: ${t.message}")
+            }
+        }
+
+        fun updateWithPort(data: Map<String, Any>, port: Int): Map<String, Any> {
+            val config = readConfig(data).getOrElse { OpenAPIMockConfig(baseUrl = "") }
+            val updatedConfig = config.copy(baseUrl = "http//0.0.0.0:$port")
+            return updatedConfig.writeConfig()
+        }
+
+        private fun readConfig(data: Map<String, Any>): Result<OpenAPIMockConfig> {
+            return runCatching {
+                mapper.convertValue(data, OpenAPIMockConfig::class.java)
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/OpenAPITestConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/OpenAPITestConfig.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.config
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.specmatic.core.ResiliencyTestsConfig
@@ -13,16 +14,29 @@ data class OpenAPITestConfig(
     @JsonProperty("examples")
     val examples: List<String>? = null
 ) {
+    private fun writeConfig(): Map<String, Any> = mapper.convertValue(this, stringMapType)
 
     companion object {
+        private val mapper = ObjectMapper().registerKotlinModule()
+        private val stringMapType = mapper.typeFactory.constructType(object : TypeReference<Map<String, Any>>() {})
+
         fun from(config: Map<String, Any>): OpenAPITestConfig {
-            try {
-                return ObjectMapper().registerKotlinModule().convertValue(
-                    config,
-                    OpenAPITestConfig::class.java
-                )
+            return try {
+                readConfig(config).getOrThrow()
             } catch (t: Throwable) {
                 throw IllegalArgumentException("Invalid config provided in openapi test: ${t.message}")
+            }
+        }
+
+        fun updateWithBaseUrl(data: Map<String, Any>, baseUrl: String, resiliencyTestsConfig: ResiliencyTestsConfig): Map<String, Any> {
+            val config = readConfig(data).getOrElse { OpenAPITestConfig(baseUrl = "") }
+            val updatedConfig = config.copy(baseUrl = baseUrl, resiliencyTests = resiliencyTestsConfig)
+            return updatedConfig.writeConfig()
+        }
+
+        private fun readConfig(data: Map<String, Any>): Result<OpenAPITestConfig> {
+            return runCatching {
+                mapper.convertValue(data, OpenAPITestConfig::class.java)
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/SpecmaticSpecConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/SpecmaticSpecConfig.kt
@@ -4,7 +4,7 @@ import io.specmatic.core.config.v3.components.runOptions.IRunOptionSpecification
 
 class RawRunOptionSpecification(private val config: Map<String, Any>): IRunOptionSpecification {
     override fun getId(): String? = null
-    override fun getBaseUrl(): String? = null
+    override fun getBaseUrl(defaultHost: String): String? = null
     override fun getOverlayFilePath(): String? = null
     override fun getConfig(): Map<String, Any> = config
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v1/SpecmaticConfigV1.kt
@@ -20,16 +20,16 @@ data class SpecmaticConfigV1 (
 	val repository: RepositoryInfo? = null,
 	val report: ReportConfigurationDetails? = null,
 	val security: SecurityConfiguration? = null,
-	val test: TestConfiguration? = TestConfiguration(),
-	val stub: StubConfiguration = StubConfiguration(),
+	val test: TestConfiguration? = null,
+	val stub: StubConfiguration? = null,
 	@field:JsonAlias("virtual_service")
-	val virtualService: VirtualServiceConfiguration = VirtualServiceConfiguration(),
+	val virtualService: VirtualServiceConfiguration? = null,
 	val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
 	val workflow: WorkflowConfiguration? = null,
 	val ignoreInlineExamples: Boolean? = null,
 	val additionalExampleParamsFilePath: String? = getStringValue(Flags.ADDITIONAL_EXAMPLE_PARAMS_FILE),
 	@field:JsonAlias("attribute_selection_pattern")
-	val attributeSelectionPattern: AttributeSelectionPattern = AttributeSelectionPattern(),
+	val attributeSelectionPattern: AttributeSelectionPattern? = null,
 	@field:JsonAlias("all_patterns_mandatory")
 	val allPatternsMandatory: Boolean? = null,
 	@field:JsonAlias("default_pattern_values")

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecExecutionConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecExecutionConfig.kt
@@ -26,6 +26,14 @@ sealed class SpecExecutionConfig {
             val specFile = baseDir.resolve(value).canonicalFile
             return listOf(SpecificationSourceEntry(source, specFile, value, null, null, resiliencyTestSuite))
         }
+
+        override fun use(baseUrl: String, resiliencyTestsConfig: ResiliencyTestsConfig): SpecExecutionConfig {
+            return ObjectValue.FullUrl(baseUrl = baseUrl, specs = specs(), resiliencyTests = resiliencyTestsConfig)
+        }
+
+        override fun use(port: Int): SpecExecutionConfig {
+            return ObjectValue.PartialUrl(port = port, specs = specs())
+        }
     }
 
     sealed class ObjectValue : SpecExecutionConfig() {
@@ -61,6 +69,14 @@ sealed class SpecExecutionConfig {
                     SpecificationSourceEntry(source, specFile, spec, baseUrl, null, resiliency)
                 }
             }
+
+            override fun use(baseUrl: String, resiliencyTestsConfig: ResiliencyTestsConfig): SpecExecutionConfig {
+                return this.copy(baseUrl = baseUrl, resiliencyTests = resiliencyTestsConfig)
+            }
+
+            override fun use(port: Int): SpecExecutionConfig {
+                return PartialUrl(port = port, specs = specs(), resiliencyTests = resiliencyTests)
+            }
         }
 
         data class PartialUrl(
@@ -94,6 +110,14 @@ sealed class SpecExecutionConfig {
                     SpecificationSourceEntry(source, specFile, spec, baseUrl, port, resiliency)
                 }
             }
+
+            override fun use(baseUrl: String, resiliencyTestsConfig: ResiliencyTestsConfig): SpecExecutionConfig {
+                return FullUrl(baseUrl = baseUrl, specs = specs(), resiliencyTests = resiliencyTestsConfig)
+            }
+
+            override fun use(port: Int): SpecExecutionConfig {
+                return this.copy(port = port)
+            }
         }
     }
 
@@ -115,6 +139,16 @@ sealed class SpecExecutionConfig {
                 val specFile = baseDir.resolve(spec)
                 SpecificationSourceEntry(source, specFile, spec, null, null, resiliencyTestSuite)
             }
+        }
+
+        override fun use(baseUrl: String, resiliencyTestsConfig: ResiliencyTestsConfig): SpecExecutionConfig {
+            // Can't convert to either of the types and the config is genric map
+            return this
+        }
+
+        override fun use(port: Int): SpecExecutionConfig {
+            // Can't convert to either of the types and the config is genric map
+            return this
         }
     }
 
@@ -150,6 +184,10 @@ sealed class SpecExecutionConfig {
     abstract fun resolveAgainst(baseDirectory: File): SpecExecutionConfig
 
     abstract fun createSpecificationEntriesFrom(source: Source, baseDir: File, resiliencyTestSuite: ResiliencyTestSuite? = null): List<SpecificationSourceEntry>
+
+    abstract fun use(baseUrl: String, resiliencyTestsConfig: ResiliencyTestsConfig): SpecExecutionConfig
+
+    abstract fun use(port: Int): SpecExecutionConfig
 }
 
 class ConsumesDeserializer(private val consumes: Boolean = true) : JsonDeserializer<List<SpecExecutionConfig>>() {

--- a/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v2/SpecmaticConfigV2.kt
@@ -21,7 +21,6 @@ import io.specmatic.core.config.SpecmaticVersionedConfigLoader
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.EXAMPLE_DIRECTORIES
-import io.specmatic.core.utilities.Flags.Companion.getBooleanValue
 import io.specmatic.core.utilities.Flags.Companion.getStringValue
 import java.io.File
 import java.nio.file.Path
@@ -45,7 +44,7 @@ data class SpecmaticConfigV2(
     val examples: List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",") ?: emptyList(),
     val workflow: WorkflowConfiguration? = null,
     val ignoreInlineExamples: Boolean? = null,
-    val ignoreInlineExampleWarnings: Boolean? = getBooleanValue(Flags.IGNORE_INLINE_EXAMPLE_WARNINGS),
+    val ignoreInlineExampleWarnings: Boolean? = Flags.getBooleanValueOrNull(Flags.IGNORE_INLINE_EXAMPLE_WARNINGS),
     val schemaExampleDefault: Boolean? = null,
     val fuzzy: Boolean? = null,
     val extensibleQueryParams: Boolean? = null,
@@ -132,19 +131,19 @@ data class SpecmaticConfigV2(
                 examples = config.getExamples(),
                 workflow = getWorkflowConfiguration(config),
                 ignoreInlineExamples = SpecmaticConfigV1V2Common.getIgnoreInlineExamples(config),
-                ignoreInlineExampleWarnings = config.getIgnoreInlineExampleWarnings(),
-                schemaExampleDefault = config.getSchemaExampleDefault(),
-                fuzzy = config.getFuzzyMatchingEnabled(),
-                extensibleQueryParams = config.getExtensibleQueryParams(),
-                escapeSoapAction = config.getEscapeSoapAction(),
-                prettyPrint = config.getPrettyPrint(),
+                ignoreInlineExampleWarnings = SpecmaticConfigV1V2Common.getIgnoreInlineExampleWarningsOrNull(config),
+                schemaExampleDefault = SpecmaticConfigV1V2Common.getSchemaExampleDefaultOrNull(config),
+                fuzzy = SpecmaticConfigV1V2Common.getFuzzyMatchingEnabledOrNull(config),
+                extensibleQueryParams = SpecmaticConfigV1V2Common.getExtensibleQueryParamsOrNull(config),
+                escapeSoapAction = SpecmaticConfigV1V2Common.getEscapeSoapActionOrNull(config),
+                prettyPrint = SpecmaticConfigV1V2Common.getPrettyPrintOrNull(config),
                 additionalExampleParamsFilePath = config.getAdditionalExampleParamsFilePath(),
                 attributeSelectionPattern = getAttributeSelectionConfigOrNull(config),
                 allPatternsMandatory = getAllPatternsMandatory(config),
                 defaultPatternValues = config.getDefaultPatternValues(),
-                disableTelemetry = config.isTelemetryDisabled(),
+                disableTelemetry = SpecmaticConfigV1V2Common.isTelemetryDisabledOrNull(config),
                 licensePath = config.getLicensePath(),
-                reportDirPath = config.getReportDirPath(),
+                reportDirPath = SpecmaticConfigV1V2Common.getReportDirPathOrNull(config),
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
@@ -10,7 +10,7 @@ sealed interface AsyncApiRunOptions : IRunOptions {
     @JsonIgnore
     override fun getBaseUrlIfExists(): String? {
         val brokerConfig = config["inMemoryBroker"] as? Map<*, *> ?: return null
-        return extractBaseUrlFromMap(brokerConfig)
+        return extractBaseUrlFromMap(brokerConfig, defaultHost = "localhost")
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
@@ -16,11 +16,14 @@ sealed interface AsyncApiRunOptions : IRunOptions {
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-data class AsyncApiTestConfig(override val specs: List<RunOptionsSpecifications>? = null) : AsyncApiRunOptions {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
-
+data class AsyncApiTestConfig(
+    override val specs: List<RunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
+) : AsyncApiRunOptions {
     @JsonIgnore
     override val type: RunOptionType? = null
+
+    fun withConfig(newConfig: Map<String, Any>): AsyncApiTestConfig = copy(_config = LinkedHashMap(newConfig))
 
     @JsonProperty("type")
     private fun setType(input: RunOptionType?) {
@@ -30,7 +33,7 @@ data class AsyncApiTestConfig(override val specs: List<RunOptionsSpecifications>
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {
@@ -39,11 +42,14 @@ data class AsyncApiTestConfig(override val specs: List<RunOptionsSpecifications>
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
-data class AsyncApiMockConfig(override val specs: List<RunOptionsSpecifications>? = null) : AsyncApiRunOptions {
-    private val _config: MutableMap<String, Any> = linkedMapOf()
-
+data class AsyncApiMockConfig(
+    override val specs: List<RunOptionsSpecifications>? = null,
+    @JsonIgnore private val _config: MutableMap<String, Any> = linkedMapOf()
+) : AsyncApiRunOptions {
     @JsonIgnore
     override val type: RunOptionType? = null
+
+    fun withConfig(newConfig: Map<String, Any>): AsyncApiMockConfig = copy(_config = LinkedHashMap(newConfig))
 
     @JsonProperty("type")
     private fun setType(input: RunOptionType?) {
@@ -53,7 +59,7 @@ data class AsyncApiMockConfig(override val specs: List<RunOptionsSpecifications>
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/AsyncApiRunOptions.kt
@@ -9,9 +9,8 @@ sealed interface AsyncApiRunOptions : IRunOptions {
 
     @JsonIgnore
     override fun getBaseUrlIfExists(): String? {
-        val servers = config["servers"] as? List<*> ?: return null
-        val server = servers.firstOrNull() as? Map<*, *> ?: return null
-        return extractBaseUrlFromMap(server)
+        val brokerConfig = config["inMemoryBroker"] as? Map<*, *> ?: return null
+        return extractBaseUrlFromMap(brokerConfig)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
@@ -31,7 +31,7 @@ data class GraphQLSdlTestConfig(override val specs: List<RunOptionsSpecification
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {
@@ -54,7 +54,7 @@ data class GraphQLSdlMockConfig(override val specs: List<RunOptionsSpecification
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/GraphQLSdlRunOptions.kt
@@ -13,7 +13,10 @@ sealed interface GraphQLSdlRunOptions : IRunOptions {
     val type: RunOptionType?
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? = extractBaseUrlFromMap(config)
+    override fun getBaseUrlIfExists(): String? {
+        val defaultHost = if (this is GraphQLSdlTestConfig) "localhost" else "0.0.0.0"
+        return extractBaseUrlFromMap(config, defaultHost)
+    }
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
@@ -31,8 +31,8 @@ data class OpenApiTestConfig(
     @JsonIgnore
     override fun getBaseUrlIfExists(): String? {
         if (baseUrl != null) return baseUrl
-        if (host == null || port == null) return null
-        return "http://$host:$port"
+        if (port == null) return null
+        return "http://${host ?: "0.0.0.0"}:$port"
     }
 
     init {
@@ -59,9 +59,9 @@ data class OpenApiMockConfig(
     @JsonIgnore
     override fun getBaseUrlIfExists(): String? {
         if (baseUrl != null) return baseUrl
-        if (host == null || port == null) return null
+        if (port == null) return null
         val scheme = if (cert == null) "http" else "https"
-        return "$scheme://$host:$port"
+        return "$scheme://${host ?: "0.0.0.0"}:$port"
     }
 
     init {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/OpenApiRunOptions.kt
@@ -32,7 +32,7 @@ data class OpenApiTestConfig(
     override fun getBaseUrlIfExists(): String? {
         if (baseUrl != null) return baseUrl
         if (port == null) return null
-        return "http://${host ?: "0.0.0.0"}:$port"
+        return "http://${host ?: "localhost"}:$port"
     }
 
     init {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
@@ -31,7 +31,7 @@ data class ProtobufTestConfig(override val specs: List<RunOptionsSpecifications>
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {
@@ -54,7 +54,7 @@ data class ProtobufMockConfig(override val specs: List<RunOptionsSpecifications>
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/ProtobufRunOptions.kt
@@ -13,7 +13,10 @@ sealed interface ProtobufRunOptions : IRunOptions {
     val type: RunOptionType?
 
     @JsonIgnore
-    override fun getBaseUrlIfExists(): String? = extractBaseUrlFromMap(config)
+    override fun getBaseUrlIfExists(): String? {
+        val defaultHost = if (this is ProtobufTestConfig) "localhost" else "0.0.0.0"
+        return extractBaseUrlFromMap(config, defaultHost)
+    }
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
@@ -24,8 +24,8 @@ interface IRunOptions {
         return SpecmaticSpecConfig(getBaseUrlIfExists(), matching, config)
     }
 
-    fun extractBaseUrlFromMap(map: Map<*, *>): String? {
-        val host = map["host"]?.toString() ?: "0.0.0.0"
+    fun extractBaseUrlFromMap(map: Map<*, *>, defaultHost: String): String? {
+        val host = map["host"]?.toString() ?: defaultHost
         val port = map["port"]?.toString()?.toIntOrNull() ?: return null
         return "$host:$port"
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
@@ -25,7 +25,7 @@ interface IRunOptions {
     }
 
     fun extractBaseUrlFromMap(map: Map<*, *>): String? {
-        val host = map["host"]?.toString() ?: return null
+        val host = map["host"]?.toString() ?: "0.0.0.0"
         val port = map["port"]?.toString()?.toIntOrNull() ?: return null
         return "$host:$port"
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -39,17 +39,55 @@ data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
         }
     }
 
-    data class Value(val id: String? = null, val overlayFilePath: String? = null, val host: String? = null, val port: Int? = null) {
+    data class Value(
+        val id: String? = null,
+        val overlayFilePath: String? = null,
+        val host: String? = null,
+        val port: Int? = null,
+        @JsonIgnore
         private val _config: MutableMap<String, Any> = linkedMapOf()
-
+    ) {
         @get:JsonAnyGetter
-        val config: Map<String, Any> get() = _config
+        val config: Map<String, Any> get() = _config.toMap()
 
         @JsonAnySetter
         fun put(key: String, value: Any) {
             _config[key] = value
         }
+
+        fun withConfig(newConfig: Map<String, Any>): Value = copy(_config = LinkedHashMap(newConfig))
     }
+}
+
+data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
+    @JsonIgnore
+    override fun getId(): String? {
+        return spec.id
+    }
+
+    @JsonIgnore
+    override fun getOverlayFilePath(): String? {
+        return null
+    }
+
+    @JsonIgnore
+    override fun getConfig(): Map<String, Any> {
+        return emptyMap()
+    }
+
+    @JsonIgnore
+    override fun getBaseUrl(): String? {
+        if (spec.baseUrl != null) return spec.baseUrl
+        if (spec.host == null || spec.port == null) return null
+        return "http://${spec.host}:${spec.port}"
+    }
+
+    data class Value(
+        val id: String? = null,
+        val baseUrl: String? = null,
+        val host: String? = null,
+        val port: Int? = null,
+    )
 }
 
 data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -26,8 +26,8 @@ data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
 
     @JsonIgnore
     override fun getBaseUrl(): String? {
-        if (spec.host == null || spec.port == null) return null
-        return "${spec.host}:${spec.port}"
+        if (spec.port == null) return null
+        return "${spec.host ?: "0.0.0.0"}:${spec.port}"
     }
 
     @JsonIgnore
@@ -78,8 +78,8 @@ data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecificati
     @JsonIgnore
     override fun getBaseUrl(): String? {
         if (spec.baseUrl != null) return spec.baseUrl
-        if (spec.host == null || spec.port == null) return null
-        return "http://${spec.host}:${spec.port}"
+        if (spec.port == null) return null
+        return "http://${spec.host ?: "0.0.0.0"}:${spec.port}"
     }
 
     data class Value(
@@ -114,8 +114,8 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
     @JsonIgnore
     override fun getBaseUrl(): String? {
         if (spec.baseUrl != null) return spec.baseUrl
-        if (spec.host == null || spec.port == null) return null
-        return "http://${spec.host}:${spec.port}"
+        if (spec.port == null) return null
+        return "http://${spec.host ?: "0.0.0.0"}:${spec.port}"
     }
 
     data class Value(

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -11,6 +11,13 @@ interface IRunOptionSpecification {
     fun getBaseUrl(): String?
     fun getConfig(): Map<String, Any>
     fun getOverlayFilePath(): String?
+
+    fun extractBaseUrlFromMap(map: Map<*, *>?): String? {
+        if (map.isNullOrEmpty()) return null
+        val host = map["host"]?.toString() ?: "0.0.0.0"
+        val port = map["port"]?.toString()?.toIntOrNull() ?: return null
+        return "$host:$port"
+    }
 }
 
 data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
@@ -26,7 +33,7 @@ data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
 
     @JsonIgnore
     override fun getBaseUrl(): String? {
-        if (spec.port == null) return null
+        if (spec.port == null) return extractBaseUrlFromMap(spec.config["inMemoryBroker"] as? Map<*, *>)
         return "${spec.host ?: "0.0.0.0"}:${spec.port}"
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -8,13 +8,13 @@ import kotlin.String
 
 interface IRunOptionSpecification {
     fun getId(): String?
-    fun getBaseUrl(): String?
+    fun getBaseUrl(defaultHost: String): String?
     fun getConfig(): Map<String, Any>
     fun getOverlayFilePath(): String?
 
-    fun extractBaseUrlFromMap(map: Map<*, *>?): String? {
+    fun extractBaseUrlFromMap(map: Map<*, *>?, defaultHost: String): String? {
         if (map.isNullOrEmpty()) return null
-        val host = map["host"]?.toString() ?: "0.0.0.0"
+        val host = map["host"]?.toString() ?: defaultHost
         val port = map["port"]?.toString()?.toIntOrNull() ?: return null
         return "$host:$port"
     }
@@ -32,9 +32,9 @@ data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
     }
 
     @JsonIgnore
-    override fun getBaseUrl(): String? {
-        if (spec.port == null) return extractBaseUrlFromMap(spec.config["inMemoryBroker"] as? Map<*, *>)
-        return "${spec.host ?: "0.0.0.0"}:${spec.port}"
+    override fun getBaseUrl(defaultHost: String): String? {
+        if (spec.port == null) return extractBaseUrlFromMap(spec.config["inMemoryBroker"] as? Map<*, *>, "localhost")
+        return "${spec.host ?: defaultHost}:${spec.port}"
     }
 
     @JsonIgnore
@@ -83,10 +83,10 @@ data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecificati
     }
 
     @JsonIgnore
-    override fun getBaseUrl(): String? {
+    override fun getBaseUrl(defaultHost: String): String? {
         if (spec.baseUrl != null) return spec.baseUrl
         if (spec.port == null) return null
-        return "http://${spec.host ?: "0.0.0.0"}:${spec.port}"
+        return "http://${spec.host ?: defaultHost}:${spec.port}"
     }
 
     data class Value(
@@ -119,10 +119,10 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
     }
 
     @JsonIgnore
-    override fun getBaseUrl(): String? {
+    override fun getBaseUrl(defaultHost: String): String? {
         if (spec.baseUrl != null) return spec.baseUrl
         if (spec.port == null) return null
-        return "http://${spec.host ?: "0.0.0.0"}:${spec.port}"
+        return "http://${spec.host ?: defaultHost}:${spec.port}"
     }
 
     data class Value(

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
@@ -20,7 +20,7 @@ data class WsdlTestConfig(
     @JsonIgnore
     override fun getBaseUrlIfExists(): String? {
         if (baseUrl != null) return baseUrl
-        if (host != null && port != null) return "http://$host:$port"
+        if (port != null) return "http://${host ?: "0.0.0.0"}:$port"
         return null
     }
 
@@ -56,9 +56,9 @@ data class WsdlMockConfig(
     @JsonIgnore
     override fun getBaseUrlIfExists(): String? {
         if (baseUrl != null) return baseUrl
-        if (host == null || port == null) return null
+        if (port == null) return null
         val scheme = if (cert == null) "http" else "https"
-        return "$scheme://$host:$port"
+        return "$scheme://${host ?: "0.0.0.0"}:$port"
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
@@ -20,7 +20,7 @@ data class WsdlTestConfig(
     @JsonIgnore
     override fun getBaseUrlIfExists(): String? {
         if (baseUrl != null) return baseUrl
-        if (port != null) return "http://${host ?: "0.0.0.0"}:$port"
+        if (port != null) return "http://${host ?: "localhost"}:$port"
         return null
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
@@ -13,7 +13,7 @@ data class WsdlTestConfig(
     val baseUrl: String? = null,
     val host: String? = null,
     val port: Int? = null,
-    override val specs: List<RunOptionsSpecifications>? = null
+    override val specs: List<WsdlRunOptionsSpecifications>? = null
 ) : WsdlRunOptions {
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
@@ -35,7 +35,7 @@ data class WsdlTestConfig(
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {
@@ -49,7 +49,7 @@ data class WsdlMockConfig(
     val host: String? = null,
     val port: Int? = null,
     override val cert: RefOrValue<HttpsConfiguration>? = null,
-    override val specs: List<RunOptionsSpecifications>? = null
+    override val specs: List<WsdlRunOptionsSpecifications>? = null
 ) : WsdlRunOptions, ConfigWithCert {
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
@@ -72,7 +72,7 @@ data class WsdlMockConfig(
     }
 
     @get:JsonAnyGetter
-    override val config: Map<String, Any> get() = _config
+    override val config: Map<String, Any> get() = _config.toMap()
 
     @JsonAnySetter
     fun put(key: String, value: Any) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfig.kt
@@ -124,7 +124,7 @@ data class MockServiceConfig(val services: List<Value>, val data: Data? = null, 
         return specTypesToCheck.firstNotNullOfOrNull {
             val runOptions = getRunOptions(service, resolver, it) ?: return@firstNotNullOfOrNull null
             val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
-            runOptionSpecOverride?.getBaseUrl() ?: runOptions.getBaseUrlIfExists()
+            runOptionSpecOverride?.getBaseUrl("0.0.0.0") ?: runOptions.getBaseUrlIfExists()
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
@@ -20,7 +20,7 @@ sealed interface SpecificationDefinition {
         private val _config: MutableMap<String, Any?> = linkedMapOf()
 
         @get:JsonAnyGetter
-        val config: Map<String, Any?> get() = _config
+        val config: Map<String, Any?> get() = _config.toMap()
 
         @JsonAnySetter
         fun put(key: String, value: Any?) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfig.kt
@@ -159,7 +159,7 @@ data class TestServiceConfig(val service: RefOrValue<CommonServiceConfig<TestRun
         return specTypesToCheck.firstNotNullOfOrNull {
             val runOptions = getRunOptions(resolver, it) ?: return@firstNotNullOfOrNull null
             val runOptionSpecOverride = specId?.let(runOptions::getMatchingSpecification)
-            runOptionSpecOverride?.getBaseUrl() ?: runOptions.getBaseUrlIfExists()
+            runOptionSpecOverride?.getBaseUrl("localhost") ?: runOptions.getBaseUrlIfExists()
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/OpenAPIConfigUpdateTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/OpenAPIConfigUpdateTest.kt
@@ -1,0 +1,28 @@
+package io.specmatic.core.config
+
+import io.specmatic.core.ResiliencyTestSuite
+import io.specmatic.core.ResiliencyTestsConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenAPIConfigUpdateTest {
+    @Test
+    fun `updateWithBaseUrl should set base url in openapi test config`() {
+        val updated = OpenAPITestConfig.updateWithBaseUrl(
+            data = emptyMap(),
+            baseUrl = "http://localhost:9000",
+            resiliencyTestsConfig = ResiliencyTestsConfig(enable = ResiliencyTestSuite.all)
+        )
+
+        val config = OpenAPITestConfig.from(updated)
+        assertThat(config.baseUrl).isEqualTo("http://localhost:9000")
+        assertThat(config.resiliencyTests).isEqualTo(ResiliencyTestsConfig(enable = ResiliencyTestSuite.all))
+    }
+
+    @Test
+    fun `updateWithPort should set base url in openapi mock config`() {
+        val updated = OpenAPIMockConfig.updateWithPort(data = emptyMap(), port = 9000)
+        val config = OpenAPIMockConfig.from(updated)
+        assertThat(config.baseUrl).isEqualTo("http//0.0.0.0:9000")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v2/SpecExecutionConfigUseMethodsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v2/SpecExecutionConfigUseMethodsTest.kt
@@ -1,0 +1,125 @@
+package io.specmatic.core.config.v2
+
+import io.specmatic.core.ResiliencyTestSuite
+import io.specmatic.core.ResiliencyTestsConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SpecExecutionConfigUseMethodsTest {
+    private val resiliencyTestsConfig = ResiliencyTestsConfig(enable = ResiliencyTestSuite.all)
+
+    @Test
+    fun `StringValue use with baseUrl should return FullUrl`() {
+        val config = SpecExecutionConfig.StringValue("order.yaml")
+        val result = config.use("http://localhost:9000", resiliencyTestsConfig)
+        assertThat(result).isEqualTo(
+            SpecExecutionConfig.ObjectValue.FullUrl(
+                baseUrl = "http://localhost:9000",
+                specs = listOf("order.yaml"),
+                resiliencyTests = resiliencyTestsConfig
+            )
+        )
+    }
+
+    @Test
+    fun `StringValue use with port should return PartialUrl`() {
+        val config = SpecExecutionConfig.StringValue("order.yaml")
+        val result = config.use(9000)
+        assertThat(result).isEqualTo(
+            SpecExecutionConfig.ObjectValue.PartialUrl(
+                port = 9000,
+                specs = listOf("order.yaml")
+            )
+        )
+    }
+
+    @Test
+    fun `FullUrl use with baseUrl should update baseUrl and resiliency config`() {
+        val config = SpecExecutionConfig.ObjectValue.FullUrl(
+            baseUrl = "http://localhost:8080",
+            specs = listOf("order.yaml"),
+            resiliencyTests = ResiliencyTestsConfig(enable = ResiliencyTestSuite.positiveOnly)
+        )
+
+        val result = config.use("http://localhost:9000", resiliencyTestsConfig)
+        assertThat(result).isEqualTo(
+            SpecExecutionConfig.ObjectValue.FullUrl(
+                baseUrl = "http://localhost:9000",
+                specs = listOf("order.yaml"),
+                resiliencyTests = resiliencyTestsConfig
+            )
+        )
+    }
+
+    @Test
+    fun `FullUrl use with port should return PartialUrl preserving resiliency config`() {
+        val config = SpecExecutionConfig.ObjectValue.FullUrl(
+            baseUrl = "http://localhost:8080",
+            specs = listOf("order.yaml"),
+            resiliencyTests = resiliencyTestsConfig
+        )
+
+        val result = config.use(9000)
+        assertThat(result).isEqualTo(
+            SpecExecutionConfig.ObjectValue.PartialUrl(
+                port = 9000,
+                specs = listOf("order.yaml"),
+                resiliencyTests = resiliencyTestsConfig
+            )
+        )
+    }
+
+    @Test
+    fun `PartialUrl use with baseUrl should return FullUrl`() {
+        val config = SpecExecutionConfig.ObjectValue.PartialUrl(
+            host = "localhost",
+            port = 8080,
+            specs = listOf("order.yaml")
+        )
+
+        val result = config.use("http://localhost:9000", resiliencyTestsConfig)
+        assertThat(result).isEqualTo(
+            SpecExecutionConfig.ObjectValue.FullUrl(
+                baseUrl = "http://localhost:9000",
+                specs = listOf("order.yaml"),
+                resiliencyTests = resiliencyTestsConfig
+            )
+        )
+    }
+
+    @Test
+    fun `PartialUrl use with port should update only port`() {
+        val config = SpecExecutionConfig.ObjectValue.PartialUrl(
+            host = "localhost",
+            port = 8080,
+            basePath = "/api",
+            specs = listOf("order.yaml"),
+            resiliencyTests = resiliencyTestsConfig
+        )
+
+        val result = config.use(9000)
+        assertThat(result).isEqualTo(
+            SpecExecutionConfig.ObjectValue.PartialUrl(
+                host = "localhost",
+                port = 9000,
+                basePath = "/api",
+                specs = listOf("order.yaml"),
+                resiliencyTests = resiliencyTestsConfig
+            )
+        )
+    }
+
+    @Test
+    fun `ConfigValue use with baseUrl should return same config`() {
+        val config = SpecExecutionConfig.ConfigValue(specs = listOf("order.yaml"), specType = "ASYNCAPI", config = mapOf("timeout" to 30))
+        val result = config.use("http://localhost:9000", resiliencyTestsConfig)
+        assertThat(result).isSameAs(config)
+    }
+
+    @Test
+    fun `ConfigValue use with port should return same config`() {
+        val config = SpecExecutionConfig.ConfigValue(specs = listOf("order.yaml"), specType = "ASYNCAPI", config = mapOf("timeout" to 30))
+        val result = config.use(9000)
+        assertThat(result).isSameAs(config)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/RefOrValueTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/RefOrValueTest.kt
@@ -1,0 +1,88 @@
+package io.specmatic.core.config.v3
+
+import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.settings.MockSettings
+import io.specmatic.core.config.v3.components.settings.TestSettings
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RefOrValueTest {
+    @Test
+    fun `resolveElseThrow should deserialize merged ref and extras into typed test service config`() {
+        val resolver = object : RefOrValueResolver {
+            override fun resolveRef(reference: String): Map<*, *> {
+                return mapOf(
+                    "definitions" to emptyList<Map<String, Any>>(),
+                    "runOptions" to mapOf("openapi" to mapOf("baseUrl" to "http://from-reference")),
+                    "settings" to mapOf("strictMode" to false)
+                )
+            }
+        }
+
+        val ref: RefOrValue<CommonServiceConfig<TestRunOptions, TestSettings>> = RefOrValue.Reference(
+            ref = "#/components/services/myTestService",
+            extra = mapOf(
+                "runOptions" to mapOf("openapi" to mapOf("baseUrl" to "http://from-extra")),
+                "settings" to mapOf("timeoutInMilliseconds" to 1234)
+            )
+        )
+
+        val resolved = ref.resolveElseThrow(resolver)
+        val runOptions = resolved.runOptions!!.resolveElseThrow(resolver)
+        val settings = resolved.settings!!.resolveElseThrow(resolver)
+        assertThat(runOptions).isInstanceOf(TestRunOptions::class.java)
+        assertThat(runOptions.openapi?.baseUrl).isEqualTo("http://from-extra")
+        assertThat(settings).isInstanceOf(TestSettings::class.java)
+        assertThat(settings.timeoutInMilliseconds).isEqualTo(1234)
+    }
+
+    @Test
+    fun `resolveElseThrow should deserialize merged ref and extras into typed mock service config`() {
+        val resolver = object : RefOrValueResolver {
+            override fun resolveRef(reference: String): Map<*, *> {
+                return mapOf(
+                    "definitions" to emptyList<Map<String, Any>>(),
+                    "runOptions" to mapOf("openapi" to mapOf("baseUrl" to "http://from-reference")),
+                    "settings" to mapOf("delayInMilliseconds" to 100)
+                )
+            }
+        }
+
+        val ref: RefOrValue<CommonServiceConfig<MockRunOptions, MockSettings>> = RefOrValue.Reference(
+            ref = "#/components/services/myMockService",
+            extra = mapOf(
+                "runOptions" to mapOf("openapi" to mapOf("baseUrl" to "http://from-extra")),
+                "settings" to mapOf("strictMode" to true)
+            )
+        )
+
+        val resolved = ref.resolveElseThrow(resolver)
+        val runOptions = resolved.runOptions!!.resolveElseThrow(resolver)
+        val settings = resolved.settings!!.resolveElseThrow(resolver)
+        assertThat(runOptions).isInstanceOf(MockRunOptions::class.java)
+        assertThat(runOptions.openapi?.baseUrl).isEqualTo("http://from-extra")
+        assertThat(settings).isInstanceOf(MockSettings::class.java)
+        assertThat(settings.strictMode).isTrue()
+    }
+
+    @Test
+    fun `toExampleDirs should resolve referenced examples as typed RefOrValue entries`() {
+        val resolver = object : RefOrValueResolver {
+            override fun resolveRef(reference: String): Any {
+                return listOf(
+                    mapOf("directories" to listOf("examples-from-ref"))
+                )
+            }
+        }
+
+        val data = Data(
+            examples = RefOrValue.Reference(
+                ref = "#/components/examples/testExamples"
+            )
+        )
+
+        assertThat(data.toExampleDirs(resolver)).containsExactly("examples-from-ref")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
@@ -7,42 +7,42 @@ class RunOptionsSpecificationsTest {
     @Test
     fun `openapi getBaseUrl should return baseUrl when present`() {
         val runOptions = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(baseUrl = "http://example.com"))
-        assertEquals("http://example.com", runOptions.getBaseUrl())
+        assertEquals("http://example.com", runOptions.getBaseUrl("localhost"))
     }
 
     @Test
     fun `openapi getBaseUrl should return host and port when baseUrl is absent`() {
         val runOptions = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(host = "localhost", port = 8080))
-        assertEquals("http://localhost:8080", runOptions.getBaseUrl())
+        assertEquals("http://localhost:8080", runOptions.getBaseUrl("localhost"))
 
         val portOnly = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(port = 9000))
-        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl())
+        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl("0.0.0.0"))
     }
 
     @Test
     fun `wsdl getBaseUrl should return baseUrl when present`() {
         val runOptions = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(baseUrl = "http://example.com"))
-        assertEquals("http://example.com", runOptions.getBaseUrl())
+        assertEquals("http://example.com", runOptions.getBaseUrl("localhost"))
     }
 
     @Test
     fun `wsdl getBaseUrl should return host and port when baseUrl is absent`() {
         val runOptions = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(host = "localhost", port = 9000))
-        assertEquals("http://localhost:9000", runOptions.getBaseUrl())
+        assertEquals("http://localhost:9000", runOptions.getBaseUrl("localhost"))
 
         val portOnly = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(port = 9000))
-        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl())
+        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl("0.0.0.0"))
     }
 
     @Test
     fun `for other specs getBaseUrl should return host and port and for async use inMemoryBroker`() {
         val otherSpec = RunOptionsSpecifications(RunOptionsSpecifications.Value(host = "localhost", port = 9090))
-        assertEquals("localhost:9090", otherSpec.getBaseUrl())
+        assertEquals("localhost:9090", otherSpec.getBaseUrl("localhost"))
 
         val otherPortOnly = RunOptionsSpecifications(RunOptionsSpecifications.Value(port = 9090))
-        assertEquals("0.0.0.0:9090", otherPortOnly.getBaseUrl())
+        assertEquals("0.0.0.0:9090", otherPortOnly.getBaseUrl("0.0.0.0"))
 
         val asyncSpec = RunOptionsSpecifications(RunOptionsSpecifications.Value().withConfig(mapOf("inMemoryBroker" to mapOf("host" to "localhost", "port" to 5672))))
-        assertEquals("localhost:5672", asyncSpec.getBaseUrl())
+        assertEquals("localhost:5672", asyncSpec.getBaseUrl("localhost"))
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecificationsTest.kt
@@ -1,0 +1,48 @@
+package io.specmatic.core.config.v3.components.runOptions
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RunOptionsSpecificationsTest {
+    @Test
+    fun `openapi getBaseUrl should return baseUrl when present`() {
+        val runOptions = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(baseUrl = "http://example.com"))
+        assertEquals("http://example.com", runOptions.getBaseUrl())
+    }
+
+    @Test
+    fun `openapi getBaseUrl should return host and port when baseUrl is absent`() {
+        val runOptions = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(host = "localhost", port = 8080))
+        assertEquals("http://localhost:8080", runOptions.getBaseUrl())
+
+        val portOnly = OpenApiRunOptionsSpecifications(OpenApiRunOptionsSpecifications.Value(port = 9000))
+        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl())
+    }
+
+    @Test
+    fun `wsdl getBaseUrl should return baseUrl when present`() {
+        val runOptions = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(baseUrl = "http://example.com"))
+        assertEquals("http://example.com", runOptions.getBaseUrl())
+    }
+
+    @Test
+    fun `wsdl getBaseUrl should return host and port when baseUrl is absent`() {
+        val runOptions = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(host = "localhost", port = 9000))
+        assertEquals("http://localhost:9000", runOptions.getBaseUrl())
+
+        val portOnly = WsdlRunOptionsSpecifications(WsdlRunOptionsSpecifications.Value(port = 9000))
+        assertEquals("http://0.0.0.0:9000", portOnly.getBaseUrl())
+    }
+
+    @Test
+    fun `for other specs getBaseUrl should return host and port and for async use inMemoryBroker`() {
+        val otherSpec = RunOptionsSpecifications(RunOptionsSpecifications.Value(host = "localhost", port = 9090))
+        assertEquals("localhost:9090", otherSpec.getBaseUrl())
+
+        val otherPortOnly = RunOptionsSpecifications(RunOptionsSpecifications.Value(port = 9090))
+        assertEquals("0.0.0.0:9090", otherPortOnly.getBaseUrl())
+
+        val asyncSpec = RunOptionsSpecifications(RunOptionsSpecifications.Value().withConfig(mapOf("inMemoryBroker" to mapOf("host" to "localhost", "port" to 5672))))
+        assertEquals("localhost:5672", asyncSpec.getBaseUrl())
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/MockServiceConfigTest.kt
@@ -61,19 +61,12 @@ class MockServiceConfigTest {
     }
 
     @Test
-    fun `getSpecificationSources should use asyncapi base url when openapi run options are absent`(@TempDir tempDir: File) {
-        val specFile = tempDir.resolve("contract.txt").apply { writeText("not an openapi spec") }
+    fun `getSpecificationSources should use asyncapi inMemoryBroker for async runOptions`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("contract.yaml").apply { writeText("asycnapi: 3.0.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
 
         val asyncApiMockConfig = AsyncApiMockConfig().apply {
-            put(
-                "servers", listOf(
-                    mapOf(
-                        "host" to "localhost",
-                        "port" to 8081
-                    )
-                )
-            )
+            put("inMemoryBroker", mapOf("host" to "localhost", "port" to 8081))
         }
 
         val serviceConfig = CommonServiceConfig<MockRunOptions, MockSettings>(

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/components/services/TestServiceConfigTest.kt
@@ -19,19 +19,11 @@ class TestServiceConfigTest {
     }
 
     @Test
-    fun `getSpecificationSources should use asyncapi base url when openapi run options are absent`(@TempDir tempDir: File) {
-        val specFile = tempDir.resolve("contract.txt").apply { writeText("not an openapi spec") }
+    fun `getSpecificationSources should use asyncapi inMemoryBroker for async runOptions`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("contract.yaml").apply { writeText("asycnapi: 3.0.0") }
         val source = SourceV3.create(filesystem = SourceV3.FileSystem(directory = tempDir.canonicalPath))
-
         val asyncApiTestConfig = AsyncApiTestConfig().apply {
-            put(
-                "servers", listOf(
-                    mapOf(
-                        "host" to "localhost",
-                        "port" to 8082
-                    )
-                )
-            )
+            put("inMemoryBroker", mapOf("host" to "localhost", "port" to 8082))
         }
 
         val serviceConfig = CommonServiceConfig<TestRunOptions, TestSettings>(
@@ -45,9 +37,7 @@ class TestServiceConfigTest {
             ),
             runOptions = RefOrValue.Value(TestRunOptions(asyncapi = asyncApiTestConfig))
         )
-
         val testServiceConfig = TestServiceConfig(service = RefOrValue.Value(serviceConfig))
-
         val sourceEntries = testServiceConfig.getSpecificationSources(resolver, testSettings = null).values.flatten()
 
         assertThat(sourceEntries).hasSize(1)


### PR DESCRIPTION
**What**: Miscallaneous modifications to Spematic Configuration classes

**Why**:
- Ensure that the `V1` and `V2` config classes do not dump defaults and empty objects when they are not set
- Add helper methods to `SpecExecutionConfig` and `OpenApi*Config` for modifying the base URL, port, and other settings
- Separate the `WSDL` SpecRunOptions into its own dedicated class
- Set a default host in SpecRunOptions for V3 when it is not specified to avoid unexpected behavior
- Adjust RefOrValue resolutions to be compatible with ProGuard

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)