### PR TITLE
Fix WSDL example discovery when loading contracts

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -112,12 +112,12 @@ fun parseContractFileToFeature(
             checkExists(file).readText(),
             file.canonicalPath,
             specmaticConfig
-        )
+        ).copy(exampleDirPaths = exampleDirPaths)
         in CONTRACT_EXTENSIONS -> parseGherkinStringToFeature(
             checkExists(file).readText().trim(),
             file.canonicalPath,
             specmaticConfig = specmaticConfig
-        )
+        ).copy(exampleDirPaths = exampleDirPaths)
         else -> throw unsupportedFileExtensionContractException(file.path, file.extension)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -662,6 +662,23 @@ Feature: Math API
     }
 
     @Test
+    fun `loadContractStubsFromFilesAsResults should load WSDL external examples from configured exampleDirPaths`() {
+        val specFile = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
+        val externalExamplesDir = "src/test/resources/wsdl/with_examples/order_api_examples"
+        val contractPathData = listOf(
+            ContractPathData("", specFile.path, exampleDirPaths = listOf(externalExamplesDir))
+        )
+
+        val result = loadContractStubsFromFilesAsResults(contractPathData, emptyList(), SpecmaticConfig(), withImplicitStubs = false)
+
+        assertThat(result).anySatisfy {
+            assertThat(it).isInstanceOf(FeatureStubsResult.Success::class.java); it as FeatureStubsResult.Success
+            assertThat(it.scenarioStubs).hasSize(1)
+            assertThat(it.scenarioStubs.single().name).isEqualTo("createProduct")
+        }
+    }
+
+    @Test
     fun `loadContractStubsFromFilesAsResults should be able to load WSDL specifications with external examples`() {
         val specFile = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
         val contractPathData = listOf(ContractPathData("", specFile.path))

--- a/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/ApiKtTest.kt
@@ -679,6 +679,27 @@ Feature: Math API
     }
 
     @Test
+    fun `loadContractStubsFromFilesAsResults should load WSDL examples from directory not ending with underscore examples`(@TempDir tempDir: File) {
+        val specFile = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
+        val sourceExample = File("src/test/resources/wsdl/with_examples/order_api_examples/create_product.json")
+        val customExamplesDir = tempDir.resolve("wsdl-external-data")
+        customExamplesDir.mkdirs()
+        sourceExample.copyTo(customExamplesDir.resolve("create_product.json"))
+
+        val contractPathData = listOf(
+            ContractPathData("", specFile.path, exampleDirPaths = listOf(customExamplesDir.path))
+        )
+
+        val result = loadContractStubsFromFilesAsResults(contractPathData, emptyList(), SpecmaticConfig(), withImplicitStubs = false)
+
+        assertThat(result).anySatisfy {
+            assertThat(it).isInstanceOf(FeatureStubsResult.Success::class.java); it as FeatureStubsResult.Success
+            assertThat(it.scenarioStubs).hasSize(1)
+            assertThat(it.scenarioStubs.single().name).isEqualTo("createProduct")
+        }
+    }
+
+    @Test
     fun `loadContractStubsFromFilesAsResults should be able to load WSDL specifications with external examples`() {
         val specFile = File("src/test/resources/wsdl/with_examples/order_api.wsdl")
         val contractPathData = listOf(ContractPathData("", specFile.path))


### PR DESCRIPTION
Summary
- keep example directory paths while parsing contract files so WSDL examples configured via `ContractPathData` survive the conversion to `Feature`
- add regression coverage ensuring `loadContractStubsFromFilesAsResults` reads WSDL examples from the provided directory list

Testing
- Not run (not requested)