### PR TITLE
Response-content-type awareness in example module flows

### DIFF
--- a/application/src/test/kotlin/io/specmatic/test/SpecmaticJUnitSupportKtTest.kt
+++ b/application/src/test/kotlin/io/specmatic/test/SpecmaticJUnitSupportKtTest.kt
@@ -1,6 +1,7 @@
 package io.specmatic.test
 
 import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.utilities.Decision
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -10,7 +11,10 @@ fun <T> selectTestsToRunWrapper(
     filterNotName: String? = null,
     getTestDescription: (T) -> String
 ): List<T> {
-    return selectTestsToRun(testScenarios, filterName, filterNotName, getTestDescription).toList()
+    return selectTestsToRun(testScenarios, filterName, filterNotName, getTestDescription).mapNotNull { decision ->
+        if (decision !is Decision.Execute) return@mapNotNull null
+        decision.value
+    }.toList()
 }
 
 class SpecmaticJUnitSupportKtTest {

--- a/core/src/main/kotlin/io/specmatic/core/AcceptHeader.kt
+++ b/core/src/main/kotlin/io/specmatic/core/AcceptHeader.kt
@@ -9,7 +9,7 @@ fun isAcceptHeaderCompatibleWithResponse(requestHeaders: Map<String, String>, re
     val responseType = responseContentType?.trim().orEmpty()
     if (responseType.isBlank()) return true
 
-    return isResponseContentTypeAccepted(acceptHeader, responseType)
+    return runCatching { isResponseContentTypeAccepted(acceptHeader, responseType) }.getOrDefault(true)
 }
 
 fun isResponseContentTypeAccepted(acceptHeader: String, responseContentType: String): Boolean {

--- a/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core
 
+import io.ktor.http.HttpStatusCode
+
 class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponsePattern>, private val defaultResponse: HttpResponsePattern?) {
     fun matches(httpResponse: HttpResponse, resolver: Resolver): Result =
         when(httpResponse.status) {
@@ -11,4 +13,9 @@ class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponse
 
     fun supports(httpStatus: Int): Boolean =
         httpStatus in badRequestResponses || defaultResponse != null
+
+    fun getBadRequestStatus(): Int {
+        if (badRequestResponses.containsKey(HttpStatusCode.BadRequest.value)) return HttpStatusCode.BadRequest.value
+        return badRequestResponses.keys.firstOrNull() ?: defaultResponse?.status ?: HttpStatusCode.BadRequest.value
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
@@ -1,14 +1,30 @@
 package io.specmatic.core
 
-class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponsePattern>, private val defaultResponse: HttpResponsePattern?) {
+import io.ktor.http.HttpStatusCode
+
+class BadRequestOrDefault(private val badRequestResponses: Map<Int, Scenario>, private val defaultResponse: Scenario?) {
     fun matches(httpResponse: HttpResponse, resolver: Resolver): Result =
         when(httpResponse.status) {
-            in badRequestResponses -> badRequestResponses.getValue(httpResponse.status).matchesResponse(httpResponse, resolver)
-            else -> defaultResponse?.matchesResponse(httpResponse, resolver)?.partialSuccess("The response matched the default response, but the contract should declare a ${httpResponse.status} response.") ?: Result.Failure(
+            in badRequestResponses -> badRequestResponses.getValue(httpResponse.status).httpResponsePattern.matchesResponse(httpResponse, resolver)
+            else -> defaultResponse?.httpResponsePattern?.matchesResponse(httpResponse, resolver)?.partialSuccess("The response matched the default response, but the contract should declare a ${httpResponse.status} response.") ?: Result.Failure(
                 "Neither is the status code declared nor is there a default response."
             )
         }
 
     fun supports(httpStatus: Int): Boolean =
         httpStatus in badRequestResponses || defaultResponse != null
+
+    private fun getBadRequestScenarioOrFirst(): Scenario? {
+        if (badRequestResponses.containsKey(HttpStatusCode.BadRequest.value)) return badRequestResponses.getValue(HttpStatusCode.BadRequest.value)
+        return badRequestResponses.values.firstOrNull() ?: defaultResponse
+    }
+
+    companion object {
+        fun BadRequestOrDefault?.updateScenarioWithBadRequestPattern(successScenario: Scenario): Scenario {
+            return this?.getBadRequestScenarioOrFirst() ?: successScenario.copy(
+                statusInDescription = HttpStatusCode.BadRequest.value.toString(),
+                httpResponsePattern = successScenario.httpResponsePattern.copy(status = HttpStatusCode.BadRequest.value),
+            )
+        }
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
@@ -1,7 +1,5 @@
 package io.specmatic.core
 
-import io.ktor.http.HttpStatusCode
-
 class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponsePattern>, private val defaultResponse: HttpResponsePattern?) {
     fun matches(httpResponse: HttpResponse, resolver: Resolver): Result =
         when(httpResponse.status) {
@@ -13,9 +11,4 @@ class BadRequestOrDefault(private val badRequestResponses: Map<Int, HttpResponse
 
     fun supports(httpStatus: Int): Boolean =
         httpStatus in badRequestResponses || defaultResponse != null
-
-    fun getBadRequestStatus(): Int {
-        if (badRequestResponses.containsKey(HttpStatusCode.BadRequest.value)) return HttpStatusCode.BadRequest.value
-        return badRequestResponses.keys.firstOrNull() ?: defaultResponse?.status ?: HttpStatusCode.BadRequest.value
-    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -980,7 +980,7 @@ data class Feature(
         return this.scenarioAssociatedTo(
             scenarios = scenarios,
             path = scenario.path, method = scenario.method,
-            responseStatusCode = responseStatusCode, contentType = scenario.requestContentType
+            responseStatusCode = responseStatusCode, reqContentType = scenario.requestContentType
         ) != null
     }
 
@@ -1173,18 +1173,29 @@ data class Feature(
         method: String,
         path: String,
         responseStatusCode: Int,
-        contentType: String? = null,
+        reqContentType: String? = null,
+        resContentType: String? = null,
         scenarios: List<Scenario> = this.scenarios,
     ): Scenario? {
         return scenarios.firstOrNull {
             it.method == method && it.status == responseStatusCode && it.path == path
-                    && (contentType == null || it.requestContentType == null || it.requestContentType == contentType)
+            && (reqContentType == null || it.requestContentType == reqContentType)
+            && (resContentType == null || it.responseContentType == resContentType)
         }
     }
 
     fun identifierMatchingScenario(httpRequest: HttpRequest, furtherPredicate: (Scenario) -> Boolean = { true }, updateResolver: (Resolver) -> Resolver = { it }): Scenario? {
         return scenarios.firstOrNull { scenario ->
-            scenario.httpRequestPattern.matchesPathStructureMethodAndContentType(httpRequest, updateResolver(scenario.resolver)).isSuccess() && furtherPredicate(scenario)
+            scenario.httpRequestPattern.matchesPathStructureMethodAndContentType(httpRequest, updateResolver(scenario.resolver)).isSuccess()
+            && furtherPredicate(scenario)
+        }
+    }
+
+    fun identifierMatchingScenario(httpRequest: HttpRequest, httpResponse: HttpResponse, furtherPredicate: (Scenario) -> Boolean = { true }, updateResolver: (Resolver) -> Resolver = { it }): Scenario? {
+        return scenarios.firstOrNull { scenario ->
+            scenario.httpRequestPattern.matchesPathStructureMethodAndContentType(httpRequest, updateResolver(scenario.resolver)).isSuccess()
+            && scenario.httpResponsePattern.matchesStatusAndContentType(httpResponse, updateResolver(scenario.resolver)).isSuccess()
+            && furtherPredicate(scenario)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -19,6 +19,7 @@ import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.pattern.Examples.Companion.examplesFrom
 import io.specmatic.core.utilities.*
+import io.specmatic.core.utilities.Decision
 import io.specmatic.core.value.*
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.mock.NoMatchingScenario
@@ -812,71 +813,69 @@ data class Feature(
         return EarlyResult.Failures(failures.filterIsInstance<Result.Failure>())
     }
 
-    private fun failureResults(results: List<Pair<HttpStubData?, Result>>): Results =
-        Results(results.map { it.second }.filterIsInstance<Result.Failure>().toMutableList())
+    private fun Decision<ReturnValue<Scenario>, Scenario>.normalizeAcceptHeader(): Decision<ReturnValue<Scenario>, Scenario> {
+        return this.map { generatedScenarioReturnValue, originalScenario ->
+            if (generatedScenarioReturnValue !is HasValue) return@map generatedScenarioReturnValue
+            val normalisedScenario = normaliseAcceptHeaderForContractTest(generatedScenario = generatedScenarioReturnValue.value, originalScenario = originalScenario)
+            HasValue(normalisedScenario, generatedScenarioReturnValue.valueDetails)
+        }
+    }
+
+    private fun Decision<ReturnValue<Scenario>, Scenario>.checkAcceptCompatibility(): Decision<ReturnValue<Scenario>, Scenario> {
+        return this.flatMap { generatedScenarioReturnValue, originalScenario, reasoning ->
+            if (generatedScenarioReturnValue !is HasValue) {
+                return@flatMap Decision.Execute(generatedScenarioReturnValue, originalScenario, reasoning)
+            }
+
+            val responseContentType = originalScenario.responseContentType
+            val generatedHeaders = generatedScenarioReturnValue.value.generateHttpRequest().headers
+            val isCompatible = isAcceptHeaderCompatibleWithResponse(requestHeaders = generatedHeaders, responseContentType = responseContentType)
+            if (isCompatible) {
+                return@flatMap Decision.Execute(generatedScenarioReturnValue, originalScenario, reasoning)
+            }
+
+            Decision.Skip(context = originalScenario, reasoning = Reasoning(mainReason = TestRuleViolations.ACCEPT_MISMATCH))
+        }
+    }
 
     fun generateContractTests(
         suggestions: List<Scenario>,
         originalScenarios: List<Scenario> = scenarios,
         fn: (Scenario, Row) -> Scenario = { s, _ -> s }
     ): Sequence<ContractTest> {
+        val scenarioDecisions = originalScenarios.asSequence().map { Decision.Execute(it, it) }
+        return generateContractTestsWithDecision(suggestions, originalScenarios, scenarioDecisions, fn).mapNotNull { decision ->
+            if (decision !is Decision.Execute) return@mapNotNull null
+            return@mapNotNull decision.value
+        }
+    }
+
+    fun generateContractTestsWithDecision(
+        suggestions: List<Scenario>,
+        originalScenarios: List<Scenario>,
+        scenarios: Sequence<Decision<Scenario, Scenario>>,
+        fn: (Scenario, Row) -> Scenario = { s, _ -> s },
+    ): Sequence<Decision<ContractTest, Scenario>> {
         val workflow = Workflow(specmaticConfig.getWorkflowDetails() ?: WorkflowDetails.default)
-
-        return generateContractTestScenarios(
-            suggestions,
-            fn,
-            originalScenarios
-        ).map { generatedScenarioPair ->
-            val (originalScenario, generatedScenarioReturnValue) = generatedScenarioPair
-
-            when (generatedScenarioReturnValue) {
-                is HasValue -> {
-                    val normalisedScenario = normaliseAcceptHeaderForContractTest(
-                        generatedScenario = generatedScenarioReturnValue.value,
-                        originalScenario = originalScenario
-                    )
-                    Pair(originalScenario, HasValue(normalisedScenario, generatedScenarioReturnValue.valueDetails))
-                }
-
-                else -> generatedScenarioPair
+        return generateContractTestScenariosWithDecision(suggestions, originalScenarios, scenarios, fn).map { decision ->
+            decision.normalizeAcceptHeader().checkAcceptCompatibility()
+        }.map { decision ->
+            decision.flatMap { returnValue, originalScenario, reasoning ->
+                returnValue.realise(
+                    hasValue = { concreteTestScenario, comment ->
+                        val scenarioAsTest = scenarioAsTest(concreteTestScenario, comment, workflow, originalScenario, originalScenarios)
+                        Decision.Execute(scenarioAsTest, originalScenario, reasoning)
+                    },
+                    orFailure = {
+                        val testGenerationFailure = ScenarioTestGenerationFailure(originalScenario, it.failure, it.message, originalScenario.protocol, originalScenario.specType)
+                        Decision.Execute(testGenerationFailure, originalScenario, reasoning)
+                    },
+                    orException = {
+                        val testGenerationException = ScenarioTestGenerationException(originalScenario, it.t, it.message, it.breadCrumb, originalScenario.protocol, originalScenario.specType)
+                        Decision.Execute(testGenerationException, originalScenario, reasoning)
+                    }
+                )
             }
-        }.filter { generatedScenarioPair ->
-            generatedScenarioPair.second.withDefault(true) { generatedScenario ->
-                val responseContentType = generatedScenario.responseContentType
-                val isCompatible = runCatching {
-                    isAcceptHeaderCompatibleWithResponse(
-                        requestHeaders = generatedScenario.generateHttpRequest().headers,
-                        responseContentType = responseContentType
-                    )
-                }.getOrDefault(true)
-
-                if (!isCompatible && generatedScenario.exampleRow?.isEmpty() == false) {
-                    val exampleName = generatedScenario.exampleRow.name.takeUnless { it.isBlank() } ?: "(unnamed example)"
-                    val responseContentTypeClause = responseContentType?.let {
-                        ". Response Content-Type: $it"
-                    }.orEmpty()
-                    logger.debug(
-                        "Dropping generated contract test scenario due to Accept mismatch for example named " +
-                            "\"$exampleName\" for API \"${generatedScenario.method} ${generatedScenario.path}\"" +
-                            responseContentTypeClause
-                    )
-                }
-
-                isCompatible
-            }
-        }.map { generatedScenarioPair ->
-            val (originalScenario, returnValue) = generatedScenarioPair
-            returnValue.realise(
-                hasValue = { concreteTestScenario, comment ->
-                    scenarioAsTest(concreteTestScenario, comment, workflow, originalScenario, originalScenarios)
-                },
-                orFailure = {
-                    ScenarioTestGenerationFailure(originalScenario, it.failure, it.message, originalScenario.protocol, originalScenario.specType)
-                },
-                orException = {
-                    ScenarioTestGenerationException(originalScenario, it.t, it.message, it.breadCrumb, originalScenario.protocol, originalScenario.specType)
-                }
-            )
         }
     }
 
@@ -999,73 +998,97 @@ data class Feature(
         fn: (Scenario, Row) -> Scenario = { s, _ -> s },
         originalScenarios: List<Scenario> = scenarios
     ): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        val positiveTestScenarios = positiveTestScenarios(suggestions, fn)
+        val scenarioDecisions = originalScenarios.asSequence().map { Decision.Execute(it, it) }
+        return generateContractTestScenariosWithDecision(suggestions, originalScenarios,scenarioDecisions, fn).mapNotNull { decision ->
+            if (decision !is Decision.Execute) return@mapNotNull null
+            return@mapNotNull Pair(decision.context, decision.value)
+        }
+    }
 
+    fun generateContractTestScenariosWithDecision(
+        suggestions: List<Scenario>,
+        originalScenarios: List<Scenario>,
+        scenarios: Sequence<Decision<Scenario, Scenario>>,
+        fn: (Scenario, Row) -> Scenario = { s, _ -> s },
+    ): Sequence<Decision<ReturnValue<Scenario>, Scenario>> {
+        val positiveTestScenarios = positiveTestScenariosWithDecision(suggestions, scenarios, fn)
         return if (!specmaticConfig.isResiliencyTestingEnabled() || specmaticConfig.isOnlyPositiveTestingEnabled())
             positiveTestScenarios
         else
-            positiveTestScenarios + negativeTestScenarios(originalScenarios)
+            positiveTestScenarios + negativeTestScenariosWithDecision(scenarios, originalScenarios)
     }
 
-    private fun positiveTestScenarios(
+    private fun positiveTestScenariosWithDecision(
         suggestions: List<Scenario>,
-        fn: (Scenario, Row) -> Scenario = { s, _ -> s }
-    ): Sequence<Pair<Scenario, ReturnValue<Scenario>>> =
-        scenarios.asSequence().filter {
-            it.isA2xxScenario() || it.examples.isNotEmpty() || it.isGherkinScenario
-        }.filter {
-            !strictMode || it.hasExampleRows()
-        }.map {
-            it.newBasedOn(suggestions)
-        }.flatMap { originalScenario ->
-            val resolverStrategies = if (originalScenario.isA2xxScenario())
-                flagsBased
-            else
-                flagsBased.withoutGenerativeTests()
+        scenarios: Sequence<Decision<Scenario, Scenario>>,
+        fn: (Scenario, Row) -> Scenario = { s, _ -> s },
+    ): Sequence<Decision<ReturnValue<Scenario>, Scenario>> {
+        val resiliencyTestSuite = specmaticConfig.getResiliencyTestsEnabled()
+        return scenarios.mapNotNull { scenarioDecision ->
+            if (scenarioDecision !is Decision.Execute) return@mapNotNull scenarioDecision
+            scenarioDecision.value.newBasedOnWithDecision(suggestions, strictMode, resiliencyTestSuite)
+        }.flatMap { scenarioDecision ->
+            scenarioDecision.flatMapSequence { scenario, _, reasoning ->
+                val resolverStrategies = if (scenario.isA2xxScenario()) {
+                    flagsBased
+                } else {
+                    flagsBased.withoutGenerativeTests()
+                }
 
-            originalScenario.generateTestScenarios(
-                resolverStrategies,
-                testVariables,
-                testBaseURLs,
-                fn
-            ).map {
-                getScenarioWithDescription(it)
-            }.map {
-                Pair(originalScenario.copy(generativePrefix = flagsBased.positivePrefix), it)
+                scenario.generateTestScenarios(
+                    fn = fn,
+                    variables = testVariables,
+                    testBaseURLs = testBaseURLs,
+                    flagsBased = resolverStrategies,
+                ).map { generatedScenario ->
+                    val scenarioWithPrefix = scenario.copy(generativePrefix = flagsBased.positivePrefix)
+                    val returnValueWithDescription = getScenarioWithDescription(generatedScenario)
+                    val updatedReasoning = updatePositiveGenerationReasoning(resolverStrategies, generatedScenario, reasoning)
+                    Decision.Execute(returnValueWithDescription, scenarioWithPrefix, updatedReasoning)
+                }
             }
         }
+    }
 
     fun negativeTestScenarios(originalScenarios: List<Scenario> = scenarios): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        return originalScenarios.asSequence().filter {
-            it.isA2xxScenario()
-        }.filter {
-            !strictMode || it.hasExampleRows()
-        }.flatMap { originalScenario ->
-            val badRequestOrDefault = getBadRequestsOrDefault(originalScenario)
-            if (badRequestOrDefaultWasFilteredOut(badRequestOrDefault, originalScenario, originalScenarios)) {
-                return@flatMap emptySequence()
+        val scenarioDecisions = originalScenarios.asSequence().map { Decision.Execute(it, it) }
+        return negativeTestScenariosWithDecision(scenarioDecisions, originalScenarios).mapNotNull { decision ->
+            if (decision !is Decision.Execute) return@mapNotNull null
+            return@mapNotNull Pair(decision.context, decision.value)
+        }
+    }
+
+    fun negativeTestScenariosWithDecision(scenarios: Sequence<Decision<Scenario, Scenario>>, originalScenarios: List<Scenario>): Sequence<Decision<ReturnValue<Scenario>, Scenario>> {
+        return scenarios.mapNotNull { scenarioDecision ->
+            if (scenarioDecision !is Decision.Execute) return@mapNotNull scenarioDecision
+            val badRequestOrDefault = getBadRequestsOrDefault(scenarioDecision.value)
+            if (badRequestOrDefaultWasFilteredOut(badRequestOrDefault, scenarioDecision.value, originalScenarios)) {
+                return@mapNotNull null
             }
 
-            val negativeScenario = originalScenario.negativeBasedOn(badRequestOrDefault)
-            val negativeTestScenarios =
-                negativeScenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs).map {
-                    getScenarioWithDescription(it)
+            scenarioDecision.value.negativeBasedOnWithDecision(badRequestOrDefault, strictMode)
+        }.flatMap { scenarioDecision ->
+            scenarioDecision.flatMapSequence { scenario, _, reasoning ->
+                scenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs).filterNot { negativeTestScenarioR ->
+                    negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
+                        val sampleRequest = negativeTestScenario.generateHttpRequest()
+                        scenario.httpRequestPattern.matches(sampleRequest, scenario.resolver).isSuccess()
+                    }
+                }.mapIndexed { index, negativeTestScenarioR ->
+                    val returnValueWithDescription = getScenarioWithDescription(negativeTestScenarioR)
+                    Decision.Execute(returnValueWithDescription.ifValue { negativeTestScenario ->
+                        negativeTestScenario.copy(generativePrefix = flagsBased.negativePrefix, disambiguate = { "[${(index + 1)}] " })
+                    }, scenario, reasoning)
                 }
-
-            negativeTestScenarios.filterNot { negativeTestScenarioR ->
-                negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
-                    val sampleRequest = negativeTestScenario.generateHttpRequest()
-                    originalScenario.httpRequestPattern.matches(sampleRequest, originalScenario.resolver).isSuccess()
-                }
-            }.mapIndexed { index, negativeTestScenarioR ->
-                Pair(negativeScenario, negativeTestScenarioR.ifValue { negativeTestScenario ->
-                    negativeTestScenario.copy(
-                        generativePrefix = flagsBased.negativePrefix,
-                        disambiguate = { "[${(index + 1)}] " }
-                    )
-                })
             }
         }
+    }
+
+    private fun updatePositiveGenerationReasoning(flagsBased: FlagsBased, scenario: ReturnValue<Scenario>, reasoning: Reasoning): Reasoning {
+        if (scenario !is HasValue || scenario.value.generatedFrom == GeneratedScenarioOrigin.EXAMPLE_ROW) return reasoning
+        if (flagsBased.generation !is GenerativeTestsEnabled) return reasoning
+        if (!specmaticConfig.isResiliencyTestingEnabled()) return reasoning
+        return reasoning.withMainReason(TestExecutionReason.executedPositiveGen())
     }
 
     private fun badRequestOrDefaultWasFilteredOut(
@@ -2380,6 +2403,18 @@ data class Feature(
     fun validateAndFilterExamples(): Pair<Feature, Result> {
         val result = scenarios.map { scenario -> scenario.validateAndFilterExamples(flagsBased) }
         return Pair(this.copy(scenarios = result.map { it.first }), Result.fromResults(result.map { it.second }))
+    }
+
+    fun validateAndFilterExamples(scenarioDecisions: Sequence<Decision<Scenario, Scenario>>): Pair<Sequence<Decision<Scenario, Scenario>>, Result> {
+        val validatedScenariosWithResult = scenarioDecisions.map { scenarioDecision ->
+            if (scenarioDecision !is Decision.Execute) return@map Pair(scenarioDecision, Success())
+            val (validatedScenario, result) = scenarioDecision.value.validateAndFilterExamples(flagsBased)
+            Decision.Execute(validatedScenario, scenarioDecision.context, scenarioDecision.reasoning) to result
+        }.toList()
+
+        val validatedScenarioDecisions = validatedScenariosWithResult.map { it.first }.asSequence()
+        val validationResult = Result.fromResults(validatedScenariosWithResult.map { it.second })
+        return validatedScenarioDecisions to validationResult
     }
 
     fun validateExamplesOrException(disallowExtraHeaders: Boolean = true) {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -843,7 +843,7 @@ data class Feature(
         originalScenarios: List<Scenario> = scenarios,
         fn: (Scenario, Row) -> Scenario = { s, _ -> s }
     ): Sequence<ContractTest> {
-        val scenarioDecisions = originalScenarios.asSequence().map { Decision.Execute(it, it) }
+        val scenarioDecisions = originalScenarios.asSequence().map { Decision.execute(it) }
         return generateContractTestsWithDecision(suggestions, originalScenarios, scenarioDecisions, fn).mapNotNull { decision ->
             if (decision !is Decision.Execute) return@mapNotNull null
             return@mapNotNull decision.value
@@ -998,7 +998,7 @@ data class Feature(
         fn: (Scenario, Row) -> Scenario = { s, _ -> s },
         originalScenarios: List<Scenario> = scenarios
     ): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        val scenarioDecisions = originalScenarios.asSequence().map { Decision.Execute(it, it) }
+        val scenarioDecisions = originalScenarios.asSequence().map { Decision.execute(it) }
         return generateContractTestScenariosWithDecision(suggestions, originalScenarios,scenarioDecisions, fn).mapNotNull { decision ->
             if (decision !is Decision.Execute) return@mapNotNull null
             return@mapNotNull Pair(decision.context, decision.value)
@@ -1006,9 +1006,9 @@ data class Feature(
     }
 
     fun generateContractTestScenariosWithDecision(
-        suggestions: List<Scenario>,
-        originalScenarios: List<Scenario>,
-        scenarios: Sequence<Decision<Scenario, Scenario>>,
+        suggestions: List<Scenario> = emptyList(),
+        originalScenarios: List<Scenario> = emptyList(),
+        scenarios: Sequence<Decision<Scenario, Scenario>> = emptySequence(),
         fn: (Scenario, Row) -> Scenario = { s, _ -> s },
     ): Sequence<Decision<ReturnValue<Scenario>, Scenario>> {
         val positiveTestScenarios = positiveTestScenariosWithDecision(suggestions, scenarios, fn)
@@ -1051,7 +1051,7 @@ data class Feature(
     }
 
     fun negativeTestScenarios(originalScenarios: List<Scenario> = scenarios): Sequence<Pair<Scenario, ReturnValue<Scenario>>> {
-        val scenarioDecisions = originalScenarios.asSequence().map { Decision.Execute(it, it) }
+        val scenarioDecisions = originalScenarios.asSequence().map { Decision.execute(it) }
         return negativeTestScenariosWithDecision(scenarioDecisions, originalScenarios).mapNotNull { decision ->
             if (decision !is Decision.Execute) return@mapNotNull null
             return@mapNotNull Pair(decision.context, decision.value)

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -987,12 +987,12 @@ data class Feature(
         val badRequestResponses = scenariosToLookInto.filter {
             it.httpRequestPattern.httpPathPattern!!.toInternalPath() == scenario.httpRequestPattern.httpPathPattern!!.toInternalPath()
                     && it.httpResponsePattern.status.toString().startsWith("4")
-        }.associate { it.httpResponsePattern.status to it.httpResponsePattern }
+        }.associate { it.httpResponsePattern.status to it }
 
-        val defaultResponse: HttpResponsePattern? = scenariosToLookInto.find {
+        val defaultResponse: Scenario? = scenariosToLookInto.find {
             it.httpRequestPattern.httpPathPattern!!.toInternalPath() == scenario.httpRequestPattern.httpPathPattern!!.toInternalPath()
                     && it.httpResponsePattern.status == DEFAULT_RESPONSE_CODE
-        }?.httpResponsePattern
+        }
 
         if (badRequestResponses.isEmpty() && defaultResponse == null)
             return null

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -211,6 +211,13 @@ data class Feature(
         return this.copy(scenarios = this.scenarios.map { scenario -> scenario.copy(dictionary = dictionary) })
     }
 
+    fun disableGenerativeTesting(): Feature {
+        return this.copy(
+            flagsBased = this.flagsBased.copy(generation = NonGenerativeTests, positivePrefix = "", negativePrefix = ""),
+            specmaticConfig = specmaticConfig.disableResiliencyTests()
+        )
+    }
+
     fun enableGenerativeTesting(onlyPositive: Boolean = false): Feature {
         return this.copy(
             flagsBased = this.flagsBased.copy(
@@ -834,7 +841,7 @@ data class Feature(
                 return@flatMap Decision.Execute(generatedScenarioReturnValue, originalScenario, reasoning)
             }
 
-            Decision.Skip(context = originalScenario, reasoning = Reasoning(mainReason = TestRuleViolations.ACCEPT_MISMATCH))
+            Decision.Skip(context = generatedScenarioReturnValue.value, reasoning = Reasoning(mainReason = TestRuleViolations.ACCEPT_MISMATCH))
         }
     }
 
@@ -851,9 +858,9 @@ data class Feature(
     }
 
     fun generateContractTestsWithDecision(
-        suggestions: List<Scenario>,
-        originalScenarios: List<Scenario>,
-        scenarios: Sequence<Decision<Scenario, Scenario>>,
+        suggestions: List<Scenario> = emptyList(),
+        originalScenarios: List<Scenario> = this.scenarios,
+        scenarios: Sequence<Decision<Scenario, Scenario>> = emptySequence(),
         fn: (Scenario, Row) -> Scenario = { s, _ -> s },
     ): Sequence<Decision<ContractTest, Scenario>> {
         val workflow = Workflow(specmaticConfig.getWorkflowDetails() ?: WorkflowDetails.default)
@@ -1043,7 +1050,7 @@ data class Feature(
                 ).map { generatedScenario ->
                     val scenarioWithPrefix = scenario.copy(generativePrefix = flagsBased.positivePrefix)
                     val returnValueWithDescription = getScenarioWithDescription(generatedScenario)
-                    val updatedReasoning = updatePositiveGenerationReasoning(resolverStrategies, generatedScenario, reasoning)
+                    val updatedReasoning = updatePositiveGenerationReasoning(generatedScenario, reasoning)
                     Decision.Execute(returnValueWithDescription, scenarioWithPrefix, updatedReasoning)
                 }
             }
@@ -1084,10 +1091,9 @@ data class Feature(
         }
     }
 
-    private fun updatePositiveGenerationReasoning(flagsBased: FlagsBased, scenario: ReturnValue<Scenario>, reasoning: Reasoning): Reasoning {
+    private fun updatePositiveGenerationReasoning(scenario: ReturnValue<Scenario>, reasoning: Reasoning): Reasoning {
         if (scenario !is HasValue || scenario.value.generatedFrom == GeneratedScenarioOrigin.EXAMPLE_ROW) return reasoning
-        if (flagsBased.generation !is GenerativeTestsEnabled) return reasoning
-        if (!specmaticConfig.isResiliencyTestingEnabled()) return reasoning
+        if (specmaticConfig.getResiliencyTestsEnabled() == ResiliencyTestSuite.none) return reasoning
         return reasoning.withMainReason(TestExecutionReason.executedPositiveGen())
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -872,15 +872,15 @@ data class Feature(
             decision.flatMap { returnValue, originalScenario, reasoning ->
                 returnValue.realise(
                     hasValue = { concreteTestScenario, comment ->
-                        val scenarioAsTest = scenarioAsTest(concreteTestScenario, comment, workflow, originalScenario, originalScenarios)
+                        val scenarioAsTest = scenarioAsTest(concreteTestScenario, comment, workflow, originalScenario, originalScenarios, reasoning)
                         Decision.Execute(scenarioAsTest, originalScenario, reasoning)
                     },
                     orFailure = {
-                        val testGenerationFailure = ScenarioTestGenerationFailure(originalScenario, it.failure, it.message, originalScenario.protocol, originalScenario.specType)
+                        val testGenerationFailure = ScenarioTestGenerationFailure(originalScenario, it.failure, it.message, originalScenario.protocol, originalScenario.specType, reasoning)
                         Decision.Execute(testGenerationFailure, originalScenario, reasoning)
                     },
                     orException = {
-                        val testGenerationException = ScenarioTestGenerationException(originalScenario, it.t, it.message, it.breadCrumb, originalScenario.protocol, originalScenario.specType)
+                        val testGenerationException = ScenarioTestGenerationException(originalScenario, it.t, it.message, it.breadCrumb, originalScenario.protocol, originalScenario.specType, reasoning)
                         Decision.Execute(testGenerationException, originalScenario, reasoning)
                     }
                 )
@@ -945,7 +945,8 @@ data class Feature(
         comment: String?,
         workflow: Workflow,
         originalScenario: Scenario,
-        originalScenarios: List<Scenario> = emptyList()
+        originalScenarios: List<Scenario> = emptyList(),
+        reasoning: Reasoning = Reasoning()
     ): ContractTest = ScenarioAsTest(
         scenario = adjustTestDescription(concreteTestScenario, originalScenarios),
         feature = this.copy(scenarios = originalScenarios),
@@ -959,7 +960,8 @@ data class Feature(
         comment,
         validators = listOf(ExamplePostValidator),
         workflow = workflow,
-        originalScenario = originalScenario
+        originalScenario = originalScenario,
+        reasoning = reasoning
     )
 
     fun adjustTestDescription(scenario: Scenario, scenarios: List<Scenario> = this.scenarios): Scenario {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -835,7 +835,7 @@ data class Feature(
             }
 
             val responseContentType = originalScenario.responseContentType
-            val generatedHeaders = generatedScenarioReturnValue.value.generateHttpRequest().headers
+            val generatedHeaders = generatedScenarioReturnValue.value.generateHeaders(flagsBased)
             val isCompatible = isAcceptHeaderCompatibleWithResponse(requestHeaders = generatedHeaders, responseContentType = responseContentType)
             if (isCompatible) {
                 return@flatMap Decision.Execute(generatedScenarioReturnValue, originalScenario, reasoning)

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -18,6 +18,7 @@ import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.*
 import io.specmatic.core.pattern.Examples.Companion.examplesFrom
+import io.specmatic.core.pattern.Row.Companion.isNullOrEmpty
 import io.specmatic.core.utilities.*
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.value.*
@@ -828,7 +829,7 @@ data class Feature(
         }
     }
 
-    private fun Decision<ReturnValue<Scenario>, Scenario>.checkAcceptCompatibility(): Decision<ReturnValue<Scenario>, Scenario> {
+    private fun Decision<ReturnValue<Scenario>, Scenario>.checkAcceptCompatibility(): Decision<ReturnValue<Scenario>, Scenario>? {
         return this.flatMap { generatedScenarioReturnValue, originalScenario, reasoning ->
             if (generatedScenarioReturnValue !is HasValue) {
                 return@flatMap Decision.Execute(generatedScenarioReturnValue, originalScenario, reasoning)
@@ -841,6 +842,7 @@ data class Feature(
                 return@flatMap Decision.Execute(generatedScenarioReturnValue, originalScenario, reasoning)
             }
 
+            if (generatedScenarioReturnValue.value.exampleRow.isNullOrEmpty()) return null
             Decision.Skip(context = generatedScenarioReturnValue.value, reasoning = Reasoning(mainReason = TestSkipReason.ACCEPT_MISMATCH))
         }
     }
@@ -864,7 +866,7 @@ data class Feature(
         fn: (Scenario, Row) -> Scenario = { s, _ -> s },
     ): Sequence<Decision<ContractTest, Scenario>> {
         val workflow = Workflow(specmaticConfig.getWorkflowDetails() ?: WorkflowDetails.default)
-        return generateContractTestScenariosWithDecision(suggestions, originalScenarios, scenarios, fn).map { decision ->
+        return generateContractTestScenariosWithDecision(suggestions, originalScenarios, scenarios, fn).mapNotNull { decision ->
             decision.normalizeAcceptHeader().checkAcceptCompatibility()
         }.map { decision ->
             decision.flatMap { returnValue, originalScenario, reasoning ->
@@ -1065,13 +1067,13 @@ data class Feature(
 
     fun negativeTestScenariosWithDecision(scenarios: Sequence<Decision<Scenario, Scenario>>, originalScenarios: List<Scenario>): Sequence<Decision<ReturnValue<Scenario>, Scenario>> {
         return scenarios.mapNotNull { scenarioDecision ->
-            if (scenarioDecision !is Decision.Execute) return@mapNotNull scenarioDecision
-            val badRequestOrDefault = getBadRequestsOrDefault(scenarioDecision.value)
-            if (badRequestOrDefaultWasFilteredOut(badRequestOrDefault, scenarioDecision.value, originalScenarios)) {
+            val scenario = if (scenarioDecision is Decision.Execute) scenarioDecision.value else scenarioDecision.context
+            val badRequestOrDefault = getBadRequestsOrDefault(scenario)
+            if (badRequestOrDefaultWasFilteredOut(badRequestOrDefault, scenario, originalScenarios)) {
                 return@mapNotNull null
             }
 
-            scenarioDecision.value.negativeBasedOnWithDecision(badRequestOrDefault, strictMode)
+            scenario.negativeBasedOnWithDecision(badRequestOrDefault, strictMode)
         }.flatMapSequence { scenario, _, reasoning ->
             scenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs).filterNot { negativeTestScenarioR ->
                 negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
@@ -1090,7 +1092,8 @@ data class Feature(
     private fun updatePositiveGenerationReasoning(scenario: ReturnValue<Scenario>, reasoning: Reasoning): Reasoning {
         if (scenario !is HasValue || scenario.value.generatedFrom == GeneratedScenarioOrigin.EXAMPLE_ROW) return reasoning
         if (specmaticConfig.getResiliencyTestsEnabled() == ResiliencyTestSuite.none) return reasoning
-        return reasoning.withMainReason(TestExecutionReason.executedPositiveGen())
+        val otherReasons = reasoning.reasonsMatching { it != TestExecutionReason.NO_EXAMPLE }.orEmpty()
+        return Reasoning(mainReason = TestExecutionReason.executedPositiveGen(), otherReasons = otherReasons)
     }
 
     private fun badRequestOrDefaultWasFilteredOut(

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -1034,25 +1034,23 @@ data class Feature(
         return scenarios.mapNotNull { scenarioDecision ->
             if (scenarioDecision !is Decision.Execute) return@mapNotNull scenarioDecision
             scenarioDecision.value.newBasedOnWithDecision(suggestions, strictMode, resiliencyTestSuite)
-        }.flatMap { scenarioDecision ->
-            scenarioDecision.flatMapSequence { scenario, _, reasoning ->
-                val resolverStrategies = if (scenario.isA2xxScenario()) {
-                    flagsBased
-                } else {
-                    flagsBased.withoutGenerativeTests()
-                }
+        }.flatMapSequence { scenario, _, reasoning ->
+            val resolverStrategies = if (scenario.isA2xxScenario()) {
+                flagsBased
+            } else {
+                flagsBased.withoutGenerativeTests()
+            }
 
-                scenario.generateTestScenarios(
-                    fn = fn,
-                    variables = testVariables,
-                    testBaseURLs = testBaseURLs,
-                    flagsBased = resolverStrategies,
-                ).map { generatedScenario ->
-                    val scenarioWithPrefix = scenario.copy(generativePrefix = flagsBased.positivePrefix)
-                    val returnValueWithDescription = getScenarioWithDescription(generatedScenario)
-                    val updatedReasoning = updatePositiveGenerationReasoning(generatedScenario, reasoning)
-                    Decision.Execute(returnValueWithDescription, scenarioWithPrefix, updatedReasoning)
-                }
+            scenario.generateTestScenarios(
+                fn = fn,
+                variables = testVariables,
+                testBaseURLs = testBaseURLs,
+                flagsBased = resolverStrategies,
+            ).map { generatedScenario ->
+                val scenarioWithPrefix = scenario.copy(generativePrefix = flagsBased.positivePrefix)
+                val returnValueWithDescription = getScenarioWithDescription(generatedScenario)
+                val updatedReasoning = updatePositiveGenerationReasoning(generatedScenario, reasoning)
+                Decision.Execute(returnValueWithDescription, scenarioWithPrefix, updatedReasoning)
             }
         }
     }
@@ -1074,19 +1072,17 @@ data class Feature(
             }
 
             scenarioDecision.value.negativeBasedOnWithDecision(badRequestOrDefault, strictMode)
-        }.flatMap { scenarioDecision ->
-            scenarioDecision.flatMapSequence { scenario, _, reasoning ->
-                scenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs).filterNot { negativeTestScenarioR ->
-                    negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
-                        val sampleRequest = negativeTestScenario.generateHttpRequest()
-                        scenario.httpRequestPattern.matches(sampleRequest, scenario.resolver).isSuccess()
-                    }
-                }.mapIndexed { index, negativeTestScenarioR ->
-                    val returnValueWithDescription = getScenarioWithDescription(negativeTestScenarioR)
-                    Decision.Execute(returnValueWithDescription.ifValue { negativeTestScenario ->
-                        negativeTestScenario.copy(generativePrefix = flagsBased.negativePrefix, disambiguate = { "[${(index + 1)}] " })
-                    }, scenario, reasoning)
+        }.flatMapSequence { scenario, _, reasoning ->
+            scenario.generateTestScenarios(flagsBased, testVariables, testBaseURLs).filterNot { negativeTestScenarioR ->
+                negativeTestScenarioR.withDefault(false) { negativeTestScenario ->
+                    val sampleRequest = negativeTestScenario.generateHttpRequest()
+                    scenario.httpRequestPattern.matches(sampleRequest, scenario.resolver).isSuccess()
                 }
+            }.mapIndexed { index, negativeTestScenarioR ->
+                val returnValueWithDescription = getScenarioWithDescription(negativeTestScenarioR)
+                Decision.Execute(returnValueWithDescription.ifValue { negativeTestScenario ->
+                    negativeTestScenario.copy(generativePrefix = flagsBased.negativePrefix, disambiguate = { "[${(index + 1)}] " })
+                }, scenario, reasoning)
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -841,7 +841,7 @@ data class Feature(
                 return@flatMap Decision.Execute(generatedScenarioReturnValue, originalScenario, reasoning)
             }
 
-            Decision.Skip(context = generatedScenarioReturnValue.value, reasoning = Reasoning(mainReason = TestRuleViolations.ACCEPT_MISMATCH))
+            Decision.Skip(context = generatedScenarioReturnValue.value, reasoning = Reasoning(mainReason = TestSkipReason.ACCEPT_MISMATCH))
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpResponsePattern.kt
@@ -261,6 +261,12 @@ data class HttpResponsePattern(
         val newBodyPattern: Pattern = bodyPattern.addToFirstString(errorReport, resolver)
         return this.copy(body = newBodyPattern)
     }
+
+    fun matchesStatusAndContentType(httpResponse: HttpResponse, resolver: Resolver): Result {
+        val contentTypeMatches = headersPattern.matchContentType(httpResponse.headers to resolver)
+        if (contentTypeMatches is MatchFailure<*>) return contentTypeMatches.error.breadCrumb(BreadCrumb.RESPONSE.plus(BreadCrumb.HEADER).value)
+        return matchStatus(Pair(httpResponse, resolver)).toResult { it }
+    }
 }
 
 private val valueMismatchMessages = object : MismatchMessages {

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -317,6 +317,14 @@ data class Scenario(
         }
     }
 
+    fun generateHeaders(flagsBased: FlagsBased = DefaultStrategies): Map<String, String> {
+        return scenarioBreadCrumb(this) {
+            httpRequestPattern.headersPattern.generate(
+                flagsBased.update(resolver.copy(factStore = CheckFacts(expectedFacts), isNegative = this.isNegative))
+            )
+        }
+    }
+
     fun generateHttpRequest(flagsBased: FlagsBased = DefaultStrategies): HttpRequest =
         scenarioBreadCrumb(this) {
             httpRequestPattern.generate(
@@ -759,9 +767,10 @@ data class Scenario(
         }
     }
 
-    private fun contentDescription(): String {
+    private fun contentDescription(): String? {
         val contentTypes = listOfNotNull(requestContentType?.let { "accepts $it" }, responseContentType?.let { "returns $it" })
-        return contentTypes.takeIf { it.isNotEmpty() }?.joinToString(prefix = "(", separator = ", ", postfix = ")").orEmpty()
+        if (contentTypes.isEmpty()) return null
+        return contentTypes.joinToString(prefix = "(", separator = ", ", postfix = ")")
     }
 
     val defaultAPIDescription: String get() {
@@ -770,9 +779,17 @@ data class Scenario(
     }
 
     val fullApiDescription: String get() {
-        if (customAPIDescription != null) return "$customAPIDescription ${disambiguate()}".trimEnd()
-        val content = contentDescription()
-        return if (content.isBlank()) baseApiDescription() else listOf(baseApiDescription(), content).joinToString(separator = " ")
+        val baseDescription = customAPIDescription ?: baseApiDescription()
+        return buildList {
+            add(baseDescription)
+            contentDescription()?.takeIf(String::isNotBlank)?.let(::add)
+            disambiguate().takeIf(String::isNotBlank)?.let(::add)
+        }.joinToString(separator = " ")
+    }
+
+    fun fullApiTestDescription(): String {
+        val apiDescription = this.fullApiDescription
+        return testDescription(generativePrefix, apiDescription, exampleName, requestChangeSummary)
     }
 
     override fun testDescription(): String {
@@ -1053,7 +1070,7 @@ fun testDescription(
             "$generativePrefix Scenario: $apiDescription with a request where $requestChangeSummary"
 
         else -> "$generativePrefix Scenario: $apiDescription"
-    }
+    }.trim()
 }
 
 fun newExpectedServerStateBasedOn(

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -26,7 +26,7 @@ import io.specmatic.stub.NamedExampleMismatchMessages
 import io.specmatic.stub.RequestContext
 import io.specmatic.test.ExampleProcessor
 import io.specmatic.test.TestExecutionReason
-import io.specmatic.test.TestRuleViolations
+import io.specmatic.test.TestSkipReason
 
 interface ScenarioDetailsForResult {
     val status: Int
@@ -796,18 +796,18 @@ data class Scenario(
         if (badRequestHasNoExample && resiliencyTestSuite == ResiliencyTestSuite.all) return null
 
         if (badRequestHasNoExample) {
-            val otherReasons = listOf(TestRuleViolations.noExamples2xxAnd400(strictMode))
-            val reason = Reasoning(mainReason = TestRuleViolations.GENERATIVE_DISABLED, otherReasons = otherReasons)
+            val otherReasons = listOf(TestSkipReason.noExamples2xxAnd400(strictMode))
+            val reason = Reasoning(mainReason = TestSkipReason.GENERATIVE_DISABLED, otherReasons = otherReasons)
             return Decision.Skip(context = this, reasoning = reason)
         }
 
         if (!isGherkinScenario && !isA2xxScenario() && !hasExamples) {
-            val ruleViolation = TestRuleViolations.noExamplesNon2xxAndNon400()
+            val ruleViolation = TestSkipReason.noExamplesNon2xxAndNon400()
             return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
         }
 
         if (strictMode && !hasExamples) {
-            val ruleViolation = TestRuleViolations.noExamples2xxAnd400(true)
+            val ruleViolation = TestSkipReason.noExamples2xxAnd400(true)
             return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
         }
 
@@ -818,7 +818,7 @@ data class Scenario(
     fun negativeBasedOnWithDecision(badRequestOrDefault: BadRequestOrDefault?, strictMode: Boolean): Decision<Scenario, Scenario>? {
         if (!this.isA2xxScenario()) return null
         if (strictMode && !hasExamples()) {
-            val ruleViolation = TestRuleViolations.noExamples2xxAnd400(true)
+            val ruleViolation = TestSkipReason.noExamples2xxAnd400(true)
             val updatedContext = badRequestOrDefault.updateScenarioWithBadRequestPattern(this)
             return Decision.Skip(context = updatedContext, reasoning = Reasoning(mainReason = ruleViolation))
         }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -3,7 +3,6 @@ package io.specmatic.core
 import io.ktor.http.HttpStatusCode
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.OperationMetadata
-import io.specmatic.core.BadRequestOrDefault.Companion.updateScenarioWithBadRequestPattern
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
 import io.specmatic.core.examples.server.ExampleMismatchMessages
 import io.specmatic.core.filters.HasScenarioMetadata
@@ -768,7 +767,7 @@ data class Scenario(
     }
 
     private fun contentDescription(): String? {
-        val contentTypes = listOfNotNull(requestContentType?.let { "accepts $it" }, responseContentType?.let { "returns $it" })
+        val contentTypes = listOfNotNull(requestContentType?.let { "requestContentType $it" }, responseContentType?.let { "responseContentType $it" })
         if (contentTypes.isEmpty()) return null
         return contentTypes.joinToString(prefix = "(", separator = ", ", postfix = ")")
     }
@@ -809,8 +808,14 @@ data class Scenario(
 
     fun newBasedOnWithDecision(suggestions: List<Scenario> = emptyList(), strictMode: Boolean, resiliencyTestSuite: ResiliencyTestSuite): Decision<Scenario, Scenario>? {
         val hasExamples = hasExamples()
+        val negativeGenerationEnabled = resiliencyTestSuite == ResiliencyTestSuite.all
         val badRequestHasNoExample = !isGherkinScenario && status == HttpStatusCode.BadRequest.value && !hasExamples
-        if (badRequestHasNoExample && resiliencyTestSuite == ResiliencyTestSuite.all) return null
+
+        if (badRequestHasNoExample && negativeGenerationEnabled) {
+            if (!strictMode) return null
+            val ruleViolation = TestSkipReason.noExamples2xxAnd400(true)
+            return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
+        }
 
         if (badRequestHasNoExample) {
             val otherReasons = listOf(TestSkipReason.noExamples2xxAnd400(strictMode))
@@ -834,12 +839,7 @@ data class Scenario(
 
     fun negativeBasedOnWithDecision(badRequestOrDefault: BadRequestOrDefault?, strictMode: Boolean): Decision<Scenario, Scenario>? {
         if (!this.isA2xxScenario()) return null
-        if (strictMode && !hasExamples()) {
-            val ruleViolation = TestSkipReason.noExamples2xxAnd400(true)
-            val updatedContext = badRequestOrDefault.updateScenarioWithBadRequestPattern(this)
-            return Decision.Skip(context = updatedContext, reasoning = Reasoning(mainReason = ruleViolation))
-        }
-
+        if (strictMode && !hasExamples()) return null
         val reason = Reasoning(TestExecutionReason.executedNegativeGen())
         return Decision.Execute(value = negativeBasedOn(badRequestOrDefault), context = this, reasoning = reason)
     }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -3,6 +3,7 @@ package io.specmatic.core
 import io.ktor.http.HttpStatusCode
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.OperationMetadata
+import io.specmatic.core.BadRequestOrDefault.Companion.updateScenarioWithBadRequestPattern
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
 import io.specmatic.core.examples.server.ExampleMismatchMessages
 import io.specmatic.core.filters.HasScenarioMetadata
@@ -816,7 +817,12 @@ data class Scenario(
 
     fun negativeBasedOnWithDecision(badRequestOrDefault: BadRequestOrDefault?, strictMode: Boolean): Decision<Scenario, Scenario>? {
         if (!this.isA2xxScenario()) return null
-        if (strictMode && !hasExamples()) return null
+        if (strictMode && !hasExamples()) {
+            val ruleViolation = TestRuleViolations.noExamples2xxAnd400(true)
+            val updatedContext = badRequestOrDefault.updateScenarioWithBadRequestPattern(this)
+            return Decision.Skip(context = updatedContext, reasoning = Reasoning(mainReason = ruleViolation))
+        }
+
         val reason = Reasoning(TestExecutionReason.executedNegativeGen())
         return Decision.Execute(value = negativeBasedOn(badRequestOrDefault), context = this, reasoning = reason)
     }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -469,7 +469,7 @@ data class Scenario(
                 }
 
                 newRequestPatterns.mapIndexed { index, newHttpRequestPattern ->
-                    val generatedFrom = if (index == 0) GeneratedScenarioOrigin.EXAMPLE_ROW else GeneratedScenarioOrigin.MUTATION
+                    val generatedFrom = if (index == 0 && !row.isEmpty()) GeneratedScenarioOrigin.EXAMPLE_ROW else GeneratedScenarioOrigin.MUTATION
                     newHttpRequestPattern.realise(
                         hasValue = { it, _ ->
                             HasValue(
@@ -777,9 +777,10 @@ data class Scenario(
 
     fun newBasedOnWithDecision(suggestions: List<Scenario> = emptyList(), strictMode: Boolean, resiliencyTestSuite: ResiliencyTestSuite): Decision<Scenario, Scenario>? {
         val hasExamples = hasExamples()
-        val isBadRequest = status == HttpStatusCode.BadRequest.value
+        val badRequestHasNoExample = !isGherkinScenario && status == HttpStatusCode.BadRequest.value && !hasExamples
+        if (badRequestHasNoExample && resiliencyTestSuite == ResiliencyTestSuite.all) return null
 
-        if (!isGherkinScenario && isBadRequest && !hasExamples && resiliencyTestSuite != ResiliencyTestSuite.all) {
+        if (badRequestHasNoExample) {
             val otherReasons = listOf(TestRuleViolations.noExamples2xxAnd400(strictMode))
             val reason = Reasoning(mainReason = TestRuleViolations.GENERATIVE_DISABLED, otherReasons = otherReasons)
             return Decision.Skip(context = this, reasoning = reason)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -775,7 +775,7 @@ data class Scenario(
     fun newBasedOn(suggestions: List<Scenario>) =
         this.newBasedOn(suggestions.find { it.name == this.name } ?: this)
 
-    fun newBasedOnWithDecision(suggestions: List<Scenario>, strictMode: Boolean, resiliencyTestSuite: ResiliencyTestSuite): Decision<Scenario, Scenario>? {
+    fun newBasedOnWithDecision(suggestions: List<Scenario> = emptyList(), strictMode: Boolean, resiliencyTestSuite: ResiliencyTestSuite): Decision<Scenario, Scenario>? {
         val hasExamples = hasExamples()
         val isBadRequest = status == HttpStatusCode.BadRequest.value
 
@@ -801,13 +801,7 @@ data class Scenario(
 
     fun negativeBasedOnWithDecision(badRequestOrDefault: BadRequestOrDefault?, strictMode: Boolean): Decision<Scenario, Scenario>? {
         if (!this.isA2xxScenario()) return null
-        if (strictMode && !hasExamples()) {
-            val newStatus = badRequestOrDefault?.getBadRequestStatus() ?: HttpStatusCode.BadRequest.value
-            val modifiedScenario = this.copy(httpResponsePattern = httpResponsePattern.copy(status = newStatus))
-            val reason = Reasoning(TestRuleViolations.noExamples2xxAnd400(true))
-            return Decision.Skip(context = modifiedScenario, reasoning = reason)
-        }
-
+        if (strictMode && !hasExamples()) return null
         val reason = Reasoning(TestExecutionReason.executedNegativeGen())
         return Decision.Execute(value = negativeBasedOn(badRequestOrDefault), context = this, reasoning = reason)
     }

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core
 
+import io.ktor.http.HttpStatusCode
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.OperationMetadata
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
@@ -8,6 +9,8 @@ import io.specmatic.core.filters.HasScenarioMetadata
 import io.specmatic.core.filters.ExpressionContextPopulator
 import io.specmatic.core.filters.ScenarioFilterVariablePopulator
 import io.specmatic.core.pattern.*
+import io.specmatic.core.utilities.Decision
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.utilities.mapZip
 import io.specmatic.core.utilities.nullOrExceptionString
@@ -21,6 +24,8 @@ import io.specmatic.reporter.model.SpecType
 import io.specmatic.stub.NamedExampleMismatchMessages
 import io.specmatic.stub.RequestContext
 import io.specmatic.test.ExampleProcessor
+import io.specmatic.test.TestExecutionReason
+import io.specmatic.test.TestRuleViolations
 
 interface ScenarioDetailsForResult {
     val status: Int
@@ -38,6 +43,7 @@ interface ScenarioDetailsForResult {
 const val ATTRIBUTE_SELECTION_DEFAULT_FIELDS = "ATTRIBUTE_SELECTION_DEFAULT_FIELDS"
 const val ATTRIBUTE_SELECTION_QUERY_PARAM_KEY = "ATTRIBUTE_SELECTION_QUERY_PARAM_KEY"
 
+enum class GeneratedScenarioOrigin { EXAMPLE_ROW, MUTATION }
 data class Scenario(
     override val name: String,
     val httpRequestPattern: HttpRequestPattern,
@@ -68,7 +74,8 @@ data class Scenario(
     val attributeSelectionPattern: AttributeSelectionPatternDetails = AttributeSelectionPatternDetails.default,
     val exampleRow: Row? = null,
     val operationMetadata: OperationMetadata? = null,
-    val requestChangeSummary: String? = null
+    val requestChangeSummary: String? = null,
+    val generatedFrom: GeneratedScenarioOrigin? = null
 ): ScenarioDetailsForResult, HasScenarioMetadata {
     data class RequestDetails(
         private val method: String,
@@ -461,7 +468,8 @@ data class Scenario(
                     else -> Pair(httpRequestPattern.negativeBasedOn(rowValue, resolver.copy(isNegative = isNegative)), flagsBased.negativePrefix)
                 }
 
-                newRequestPatterns.map { newHttpRequestPattern ->
+                newRequestPatterns.mapIndexed { index, newHttpRequestPattern ->
+                    val generatedFrom = if (index == 0) GeneratedScenarioOrigin.EXAMPLE_ROW else GeneratedScenarioOrigin.MUTATION
                     newHttpRequestPattern.realise(
                         hasValue = { it, _ ->
                             HasValue(
@@ -472,6 +480,7 @@ data class Scenario(
                                     ignoreFailure = ignoreFailure,
                                     exampleName = row.name,
                                     exampleRow = row,
+                                    generatedFrom = generatedFrom,
                                     generativePrefix = generativePrefix,
                                 ), (newHttpRequestPattern as HasValue<HttpRequestPattern>).valueDetails
                             )
@@ -766,6 +775,43 @@ data class Scenario(
     fun newBasedOn(suggestions: List<Scenario>) =
         this.newBasedOn(suggestions.find { it.name == this.name } ?: this)
 
+    fun newBasedOnWithDecision(suggestions: List<Scenario>, strictMode: Boolean, resiliencyTestSuite: ResiliencyTestSuite): Decision<Scenario, Scenario>? {
+        val hasExamples = hasExamples()
+        val isBadRequest = status == HttpStatusCode.BadRequest.value
+
+        if (!isGherkinScenario && isBadRequest && !hasExamples && resiliencyTestSuite != ResiliencyTestSuite.all) {
+            val otherReasons = listOf(TestRuleViolations.noExamples2xxAnd400(strictMode))
+            val reason = Reasoning(mainReason = TestRuleViolations.GENERATIVE_DISABLED, otherReasons = otherReasons)
+            return Decision.Skip(context = this, reasoning = reason)
+        }
+
+        if (!isGherkinScenario && !isA2xxScenario() && !hasExamples) {
+            val ruleViolation = TestRuleViolations.noExamplesNon2xxAndNon400()
+            return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
+        }
+
+        if (strictMode && !hasExamples) {
+            val ruleViolation = TestRuleViolations.noExamples2xxAnd400(true)
+            return Decision.Skip(context = this, reasoning = Reasoning(mainReason = ruleViolation))
+        }
+
+        val reason = Reasoning(TestExecutionReason.executed(hasExamples))
+        return Decision.Execute(value = newBasedOn(suggestions), context = this, reasoning = reason)
+    }
+
+    fun negativeBasedOnWithDecision(badRequestOrDefault: BadRequestOrDefault?, strictMode: Boolean): Decision<Scenario, Scenario>? {
+        if (!this.isA2xxScenario()) return null
+        if (strictMode && !hasExamples()) {
+            val newStatus = badRequestOrDefault?.getBadRequestStatus() ?: HttpStatusCode.BadRequest.value
+            val modifiedScenario = this.copy(httpResponsePattern = httpResponsePattern.copy(status = newStatus))
+            val reason = Reasoning(TestRuleViolations.noExamples2xxAnd400(true))
+            return Decision.Skip(context = modifiedScenario, reasoning = reason)
+        }
+
+        val reason = Reasoning(TestExecutionReason.executedNegativeGen())
+        return Decision.Execute(value = negativeBasedOn(badRequestOrDefault), context = this, reasoning = reason)
+    }
+
     fun newBasedOnAttributeSelectionFields(queryParams: QueryParameters?): Scenario {
         val fieldsToBeMadeMandatory = fieldsToBeMadeMandatoryBasedOnAttributeSelection(queryParams)
         if (fieldsToBeMadeMandatory.isEmpty()) return this
@@ -789,6 +835,8 @@ data class Scenario(
     fun isA4xxScenario(): Boolean = this.httpResponsePattern.status in 400..499
 
     fun hasExampleRows(): Boolean = examples.any { it.rows.isNotEmpty() }
+
+    fun hasExamples(): Boolean = examples.isNotEmpty() && hasExampleRows()
 
     fun calculatePath(httpRequest: HttpRequest): Set<String> {
         val bodyPattern = resolvedHop(this.httpRequestPattern.body, this.resolver)

--- a/core/src/main/kotlin/io/specmatic/core/Scenario.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Scenario.kt
@@ -749,16 +749,30 @@ data class Scenario(
             }
         }
 
-    val defaultAPIDescription: String
-        get() {
-            if(customAPIDescription != null) return "$customAPIDescription ${disambiguate()}"
-            val soapActionInfo = httpRequestPattern.getSOAPAction()
-            return if (soapActionInfo != null) {
-                "$method $path SOAPAction $soapActionInfo ${disambiguate()}-> $statusInDescription"
-            } else {
-                "$method $path ${disambiguate()}-> $statusInDescription"
-            }
+    private fun baseApiDescription(): String {
+        val soapActionInfo = httpRequestPattern.getSOAPAction()
+        return if (soapActionInfo != null) {
+            "$method $path SOAPAction $soapActionInfo ${disambiguate()}-> $statusInDescription"
+        } else {
+            "$method $path ${disambiguate()}-> $statusInDescription"
         }
+    }
+
+    private fun contentDescription(): String {
+        val contentTypes = listOfNotNull(requestContentType?.let { "accepts $it" }, responseContentType?.let { "returns $it" })
+        return contentTypes.takeIf { it.isNotEmpty() }?.joinToString(prefix = "(", separator = ", ", postfix = ")").orEmpty()
+    }
+
+    val defaultAPIDescription: String get() {
+        if (customAPIDescription != null) return "$customAPIDescription ${disambiguate()}"
+        return baseApiDescription()
+    }
+
+    val fullApiDescription: String get() {
+        if (customAPIDescription != null) return "$customAPIDescription ${disambiguate()}".trimEnd()
+        val content = contentDescription()
+        return if (content.isBlank()) baseApiDescription() else listOf(baseApiDescription(), content).joinToString(separator = " ")
+    }
 
     override fun testDescription(): String {
         val apiDescription = customAPIDescription ?: this.defaultAPIDescription

--- a/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
+++ b/core/src/main/kotlin/io/specmatic/core/examples/module/ExampleModule.kt
@@ -30,6 +30,7 @@ class ExampleModule(private val specmaticConfig: SpecmaticConfig) {
                                 || breadCrumb.contains(METHOD_BREAD_CRUMB)
                                 || breadCrumb.contains(BreadCrumb.REQUEST.plus(BreadCrumb.PARAM_HEADER).with(CONTENT_TYPE))
                                 || breadCrumb.contains("STATUS")
+                                || breadCrumb.contains(BreadCrumb.RESPONSE.plus(BreadCrumb.HEADER).with(CONTENT_TYPE))
                     } || matchResult.hasReason(FailureReason.URLPathParamMismatchButSameStructure)
                     if (isFailureRelatedToScenario) { example to example.breadCrumbIfPartial(matchResult) } else null
                 }

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.filters
 import com.ezylang.evalex.Expression
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Reasoning
-import io.specmatic.test.TestRuleViolations
+import io.specmatic.test.TestSkipReason
 
 data class ScenarioMetadataFilter(
     val expression: Expression? = null
@@ -47,7 +47,7 @@ data class ScenarioMetadataFilter(
             return items.map { item ->
                 if (item !is Decision.Execute) return@map item
                 if (scenarioMetadataFilter.isSatisfiedBy(item.value.toScenarioMetadata())) return@map item
-                Decision.Skip(item.context, Reasoning(TestRuleViolations.EXCLUDED))
+                Decision.Skip(item.context, Reasoning(TestSkipReason.EXCLUDED))
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -1,6 +1,9 @@
 package io.specmatic.core.filters
 
 import com.ezylang.evalex.Expression
+import io.specmatic.core.utilities.Decision
+import io.specmatic.core.utilities.Reasoning
+import io.specmatic.test.TestRuleViolations
 
 data class ScenarioMetadataFilter(
     val expression: Expression? = null
@@ -34,6 +37,17 @@ data class ScenarioMetadataFilter(
         ): Sequence<T> {
             return items.filter { item ->
                 scenarioMetadataFilter.isSatisfiedBy(item.toScenarioMetadata())
+            }
+        }
+
+        fun <T : HasScenarioMetadata, U> filterUsingDecisions(
+            items: Sequence<Decision<T, U>>,
+            scenarioMetadataFilter: ScenarioMetadataFilter
+        ): Sequence<Decision<T, U>> {
+            return items.map { item ->
+                if (item !is Decision.Execute) return@map item
+                if (scenarioMetadataFilter.isSatisfiedBy(item.value.toScenarioMetadata())) return@map item
+                Decision.Skip(item.context, Reasoning(TestRuleViolations.EXCLUDED))
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/ScenarioMetadataFilter.kt
@@ -42,12 +42,13 @@ data class ScenarioMetadataFilter(
 
         fun <T : HasScenarioMetadata, U> filterUsingDecisions(
             items: Sequence<Decision<T, U>>,
-            scenarioMetadataFilter: ScenarioMetadataFilter
+            scenarioMetadataFilter: ScenarioMetadataFilter,
+            getSkipContext: (T) -> U
         ): Sequence<Decision<T, U>> {
             return items.map { item ->
                 if (item !is Decision.Execute) return@map item
                 if (scenarioMetadataFilter.isSatisfiedBy(item.value.toScenarioMetadata())) return@map item
-                Decision.Skip(item.context, Reasoning(TestSkipReason.EXCLUDED))
+                Decision.Skip(getSkipContext(item.value), Reasoning(TestSkipReason.EXCLUDED))
             }
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/Row.kt
@@ -180,4 +180,11 @@ data class Row(
 
         return this.copy(columnNames = emptyList(), values = emptyList()).addFields(path + headers + queryParams + bodyEntry).copy(requestExample = request)
     }
+
+    companion object {
+        fun Row?.isNullOrEmpty(): Boolean {
+            if (this == null) return true
+            return this.isEmpty()
+        }
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
@@ -1,0 +1,29 @@
+package io.specmatic.core.utilities
+
+sealed interface Decision<out Item, out Ctx> {
+    val context: Ctx
+    val reasoning: Reasoning
+
+    data class Execute<Item, Ctx>(val value: Item, override val context: Ctx, override val reasoning: Reasoning = Reasoning()) : Decision<Item, Ctx>
+    data class Skip<Ctx>(override val context: Ctx, override val reasoning: Reasoning) : Decision<Nothing, Ctx>
+}
+
+inline fun <Item, Ctx, NewItem> Decision<Item, Ctx>.flatMap(fn: (Item, Ctx, Reasoning) -> Decision<NewItem, Ctx>): Decision<NewItem, Ctx> = when (this) {
+    is Decision.Execute -> fn(value, context, reasoning)
+    is Decision.Skip -> Decision.Skip(context, reasoning)
+}
+
+inline fun <Item, Ctx, NewItem> Decision<Item, Ctx>.mapValue(fn: (Item) -> NewItem): Decision<NewItem, Ctx> = when (this) {
+    is Decision.Execute -> Decision.Execute(fn(value), context, reasoning)
+    is Decision.Skip -> Decision.Skip(context, reasoning)
+}
+
+inline fun <Item, Ctx, NewItem> Decision<Item, Ctx>.map(fn: (Item, Ctx) -> NewItem): Decision<NewItem, Ctx> = when (this) {
+    is Decision.Execute -> Decision.Execute(fn(value, context), context, reasoning)
+    is Decision.Skip -> Decision.Skip(context, reasoning)
+}
+
+inline fun <Item, Ctx, NewItem> Decision<Item, Ctx>.flatMapSequence(fn: (Item, Ctx, Reasoning) -> Sequence<Decision<NewItem, Ctx>>): Sequence<Decision<NewItem, Ctx>> = when (this) {
+    is Decision.Execute -> fn(value, context, reasoning)
+    is Decision.Skip -> sequenceOf(Decision.Skip(context, reasoning))
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
@@ -6,6 +6,10 @@ sealed interface Decision<out Item, out Ctx> {
 
     data class Execute<Item, Ctx>(val value: Item, override val context: Ctx, override val reasoning: Reasoning = Reasoning()) : Decision<Item, Ctx>
     data class Skip<Ctx>(override val context: Ctx, override val reasoning: Reasoning) : Decision<Nothing, Ctx>
+
+    companion object {
+        fun <Item> execute(item: Item): Execute<Item, Item> = Execute(item, item)
+    }
 }
 
 inline fun <Item, Ctx, NewItem> Decision<Item, Ctx>.flatMap(fn: (Item, Ctx, Reasoning) -> Decision<NewItem, Ctx>): Decision<NewItem, Ctx> = when (this) {

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Decision.kt
@@ -31,3 +31,11 @@ inline fun <Item, Ctx, NewItem> Decision<Item, Ctx>.flatMapSequence(fn: (Item, C
     is Decision.Execute -> fn(value, context, reasoning)
     is Decision.Skip -> sequenceOf(Decision.Skip(context, reasoning))
 }
+
+inline fun <Item, Ctx, NewItem> Sequence<Decision<Item, Ctx>>.mapSequence(crossinline fn: (Item) -> NewItem): Sequence<Decision<NewItem, Ctx>> {
+    return this.map { it.mapValue(fn) }
+}
+
+inline fun <Item, Ctx, NewItem> Sequence<Decision<Item, Ctx>>.flatMapSequence(crossinline fn: (Item, Ctx, Reasoning) -> Sequence<Decision<NewItem, Ctx>>): Sequence<Decision<NewItem, Ctx>> {
+    return flatMap { it.flatMapSequence(fn) }
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
@@ -5,8 +5,9 @@ import io.specmatic.core.RuleViolationReport
 
 data class Reasoning(val mainReason: RuleViolation? = null, val otherReasons: List<RuleViolation> = emptyList()) {
     fun withMainReason(reason: RuleViolation): Reasoning = copy(mainReason = reason, otherReasons = listOfNotNull(mainReason).plus(otherReasons))
-    fun toRuleViolationText(): String {
+    fun toRuleViolationText(): String = toRuleViolationReport().toText().orEmpty()
+    fun toRuleViolationReport(): RuleViolationReport {
         val violations = linkedSetOf<RuleViolation>().apply { mainReason?.let(::add); addAll(otherReasons) }
-        return RuleViolationReport(violations).toText().orEmpty()
+        return RuleViolationReport(violations)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
@@ -5,8 +5,6 @@ import io.specmatic.core.RuleViolationReport
 
 data class Reasoning(val mainReason: RuleViolation? = null, val otherReasons: List<RuleViolation> = emptyList()) {
     fun withMainReason(reason: RuleViolation): Reasoning = copy(mainReason = reason, otherReasons = listOfNotNull(mainReason).plus(otherReasons))
-    fun hasReason(reason: RuleViolation): Boolean = mainReason == reason || otherReasons.contains(reason)
-
     fun toRuleViolationText(): String {
         val violations = linkedSetOf<RuleViolation>().apply { mainReason?.let(::add); addAll(otherReasons) }
         return RuleViolationReport(violations).toText().orEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
@@ -1,0 +1,12 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.RuleViolation
+import io.specmatic.core.RuleViolationReport
+
+data class Reasoning(val mainReason: RuleViolation? = null, val otherReasons: List<RuleViolation> = emptyList()) {
+    fun withMainReason(reason: RuleViolation): Reasoning = copy(mainReason = reason, otherReasons = listOfNotNull(mainReason).plus(otherReasons))
+    fun toRuleViolationText(): String {
+        val violations = linkedSetOf<RuleViolation>().apply { mainReason?.let(::add); addAll(otherReasons) }
+        return RuleViolationReport(violations).toText().orEmpty()
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
@@ -10,4 +10,10 @@ data class Reasoning(val mainReason: RuleViolation? = null, val otherReasons: Li
         val violations = linkedSetOf<RuleViolation>().apply { mainReason?.let(::add); addAll(otherReasons) }
         return RuleViolationReport(violations)
     }
+
+    fun reasonsMatching(predicate: (RuleViolation) -> Boolean): List<RuleViolation>? {
+        val reasons = listOfNotNull(mainReason).plus(otherReasons).filter(predicate)
+        if (reasons.isEmpty()) return null
+        return reasons
+    }
 }

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Reasoning.kt
@@ -5,6 +5,8 @@ import io.specmatic.core.RuleViolationReport
 
 data class Reasoning(val mainReason: RuleViolation? = null, val otherReasons: List<RuleViolation> = emptyList()) {
     fun withMainReason(reason: RuleViolation): Reasoning = copy(mainReason = reason, otherReasons = listOfNotNull(mainReason).plus(otherReasons))
+    fun hasReason(reason: RuleViolation): Boolean = mainReason == reason || otherReasons.contains(reason)
+
     fun toRuleViolationText(): String {
         val violations = linkedSetOf<RuleViolation>().apply { mainReason?.let(::add); addAll(otherReasons) }
         return RuleViolationReport(violations).toText().orEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/Utilities.kt
@@ -485,28 +485,27 @@ fun nullOrExceptionString(fn: () -> Result): String? {
 }
 
 private fun sanitizeFilename(input: String): String = input.replace(Regex("""[\\/:*?"'<>| ]"""), "_")
+private fun mediaTypeSuffix(contentType: String?): String = contentType?.substringBefore(";")?.takeUnless(String::isBlank)?.let { "_$it" }.orEmpty()
+private fun buildOperationFileName(baseName: String, httpRequest: HttpRequest, httpResponse: HttpResponse, prefix: String, suffix: String): String {
+    val reqContentType = mediaTypeSuffix(httpRequest.contentType())
+    val resContentType = mediaTypeSuffix(httpResponse.contentType())
+    return "$prefix$baseName${reqContentType}_${httpResponse.status}$resContentType$suffix"
+}
 
-fun uniqueNameForApiOperation(httpRequest: HttpRequest, scenario: Scenario, baseDir: File, prefix: String = ""): String {
-    val operationId = scenario.operationMetadata?.operationId?.takeUnless { it.isNullOrBlank() }
+fun uniqueNameForApiOperation(httpRequest: HttpRequest, httpResponse: HttpResponse, scenario: Scenario, baseDir: File, prefix: String = "", suffix: String = ""): String {
+    val operationId = scenario.operationMetadata?.operationId?.takeUnless { it.isBlank() }
     if (operationId != null) {
-        val fileName = "$prefix${operationId}_${scenario.status}"
+        val fileName = buildOperationFileName(operationId, httpRequest, httpResponse, prefix, suffix)
         return sanitizeAndFitOsPathBudget(baseDir, fileName)
     }
 
-    return uniqueNameForApiOperation(httpRequest, "", scenario.status, baseDir, prefix)
+    return uniqueNameForApiOperation(httpRequest, httpResponse, "", baseDir, prefix, suffix)
 }
 
-fun uniqueNameForApiOperation(httpRequest: HttpRequest, baseURL: String, responseStatus: Int, baseDir: File, prefix: String = ""): String {
-    val (method, path, headers) = httpRequest
-    val contentType = headers[CONTENT_TYPE]?.substringBefore(";")?.takeUnless { it.isBlank() }?.let { "_$it" }.orEmpty()
-
-    val formattedPath = path?.removePrefix(baseURL)?.removePrefix("/").orEmpty()
-    val fileName = if (formattedPath.isEmpty()) {
-        "$prefix${method}_$responseStatus$contentType"
-    } else {
-        "$prefix${formattedPath}_${method}_${responseStatus}$contentType"
-    }
-
+fun uniqueNameForApiOperation(httpRequest: HttpRequest, httpResponse: HttpResponse, baseURL: String, baseDir: File, prefix: String = "", suffix: String = ""): String {
+    val formattedPath = httpRequest.path?.removePrefix(baseURL)?.removePrefix("/").orEmpty()
+    val baseName = if (formattedPath.isEmpty()) { httpRequest.method } else { "${formattedPath}_${httpRequest.method}" }.orEmpty()
+    val fileName = buildOperationFileName(baseName, httpRequest, httpResponse, prefix, suffix)
     return sanitizeAndFitOsPathBudget(baseDir, fileName)
 }
 

--- a/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
+++ b/core/src/main/kotlin/io/specmatic/proxy/Proxy.kt
@@ -270,7 +270,7 @@ class Proxy(
                                     if (isRecordingEnabled) stubs.add(
                                         NamedStub(
                                             name,
-                                            uniqueNameForApiOperation(recordedRequest, baseURL, recordedResponse.status, defaultExamplesBaseDir),
+                                            uniqueNameForApiOperation(recordedRequest, recordedResponse, baseURL, defaultExamplesBaseDir),
                                             exampleTransformer.applyTo(
                                                 scenarioStub = ScenarioStub(
                                                 recordedRequest.dropIrrelevantHeaders(),

--- a/core/src/main/kotlin/io/specmatic/stub/FoundStubbedResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/FoundStubbedResponse.kt
@@ -18,7 +18,8 @@ class FoundStubbedResponse(override val response: HttpStubResponse) : StubbedRes
                 response.feature?.sourceRepositoryBranch,
                 response.feature?.specification,
                 response.scenario?.protocol ?: SpecmaticProtocol.HTTP,
-                response.scenario?.specType ?: SpecType.OPENAPI
+                response.scenario?.specType ?: SpecType.OPENAPI,
+                response.scenario?.responseContentType ?: response.response.contentType(),
             )
         )
     }

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -530,8 +530,8 @@ class HttpStub(
     ) {
         val path = convertPathParameterStyle(httpLogMessage.scenario?.path ?: httpRequest.path.orEmpty())
         val method = httpLogMessage.scenario?.method ?: httpRequest.method.orEmpty()
-        val requestContentType = httpLogMessage.scenario?.requestContentType
-            ?: httpRequest.headers["Content-Type"]
+        val requestContentType = httpLogMessage.scenario?.requestContentType ?: httpRequest.contentType()
+        val responseContentType = httpLogMessage.scenario?.responseContentType ?: httpResponse.contentType()
         val responseStatus = httpLogMessage.scenario?.status ?: 0
         val protocol = httpLogMessage.scenario?.protocol ?: SpecmaticProtocol.HTTP
         val ctrfTestResultRecord = TestResultRecord(
@@ -544,12 +544,11 @@ class HttpStub(
             scenarioResult = (httpLogMessage.result ?: Result.Success()).updateScenario(httpLogMessage.scenario),
             specType = httpLogMessage.scenario?.specType ?: SpecType.OPENAPI,
             requestContentType = requestContentType,
+            responseContentType = responseContentType,
             specification = httpStubResponse.scenario?.specification,
             testType = STUB_TEST_TYPE,
             actualResponseStatus = httpResponse.status,
-            operations = setOf(
-                OpenAPIOperation(path, method, requestContentType, responseStatus, protocol)
-            ),
+            operations = setOf(OpenAPIOperation(path, method, requestContentType, responseStatus, protocol, responseContentType)),
             exampleId = httpStubResponse.mock?.scenarioStub?.id
         )
         synchronized(ctrfTestResultRecords) { ctrfTestResultRecords.add(ctrfTestResultRecord) }
@@ -1189,6 +1188,7 @@ class HttpStub(
                         method = endpoint.method.orEmpty(),
                         contentType = endpoint.requestContentType,
                         responseCode = endpoint.responseCode,
+                        responseContentType = endpoint.responseContentType,
                         protocol = endpoint.protocol
                     )
                 )
@@ -1230,7 +1230,8 @@ class HttpStub(
                 scenario.sourceRepositoryBranch,
                 scenario.specification,
                 scenario.protocol,
-                scenario.specType
+                scenario.specType,
+                scenario.responseContentType,
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/stub/report/StubEndpoint.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/report/StubEndpoint.kt
@@ -15,7 +15,8 @@ data class StubEndpoint(
     val sourceRepositoryBranch: String? = null,
     val specification: String? = null,
     val protocol: SpecmaticProtocol,
-    val specType: SpecType
+    val specType: SpecType,
+    val responseContentType: String? = null,
 ) {
     fun isEqualTo(testResultRecord: TestResultRecord): Boolean {
         return convertPathParameterStyle(path.orEmpty()) == testResultRecord.path

--- a/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
@@ -27,6 +27,7 @@ interface ContractTest : HasScenarioMetadata {
     fun plusValidator(validator: ResponseValidator): ContractTest
     val protocol: SpecmaticProtocol?
     val specType: SpecType
+    val scenario: Scenario
 }
 
 data class ContractTestExecutionResult(

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -23,7 +23,7 @@ private const val BEFORE_FIXTURE_DISCRIMINATOR_KEY = "before"
 private const val AFTER_FIXTURE_DISCRIMINATOR_KEY = "after"
 
 data class ScenarioAsTest(
-    val scenario: Scenario,
+    override val scenario: Scenario,
     private val feature: Feature,
     private val flagsBased: FlagsBased,
     private val sourceProvider: String? = null,
@@ -221,6 +221,7 @@ data class ScenarioAsTest(
     }
 
     private fun fixtureExecutionResult(fixtureDiscriminatorKey: String): Result {
+        if (scenario.isNegative) return Result.Success()
         val row = scenario.exampleRow ?: return Result.Success()
         val scenarioStub = row.scenarioStub ?: return Result.Success()
         val id = scenarioStub.id.orEmpty()
@@ -228,6 +229,7 @@ data class ScenarioAsTest(
             BEFORE_FIXTURE_DISCRIMINATOR_KEY -> scenarioStub.beforeFixtures
             else -> scenarioStub.afterFixtures
         }
+
         return ServiceLoader.load(OpenAPIFixtureExecutor::class.java)
             .firstOrNull()?.execute(id, fixtures, fixtureDiscriminatorKey) ?: Result.Success()
     }

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.logger
 import io.specmatic.core.matchers.MatcherEngine
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.core.value.Value
 import io.specmatic.license.core.SpecmaticProtocol
@@ -37,6 +38,7 @@ data class ScenarioAsTest(
     private val originalScenario: Scenario,
     private val workflow: Workflow = Workflow(),
     private val responseHandlerRegistry: ResponseHandlerRegistry = ResponseHandlerRegistry(feature, originalScenario),
+    val reasoning: Reasoning = Reasoning()
 ) : ContractTest {
     companion object {
         private var id: Value? = null
@@ -57,6 +59,7 @@ data class ScenarioAsTest(
             path = path,
             method = scenario.method,
             requestContentType = scenario.requestContentType,
+            responseContentType = scenario.responseContentType,
             responseStatus = scenario.status,
             request = request,
             response = response,
@@ -72,9 +75,8 @@ data class ScenarioAsTest(
             isGherkin = scenario.isGherkinScenario,
             requestTime = startTime,
             responseTime = Instant.now(),
-            operations = setOf(
-                openAPIOperationFrom(scenario, path)
-            )
+            operations = setOf(openAPIOperationFrom(scenario, path)),
+            reasoning = reasoning
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.Scenario
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.OpenAPIOperation
@@ -18,7 +19,8 @@ class ScenarioTestGenerationException(
     val message: String,
     val breadCrumb: String?,
     override val protocol: SpecmaticProtocol?,
-    override val specType: SpecType
+    override val specType: SpecType,
+    val reasoning: Reasoning = Reasoning()
 ) : ContractTest {
     init {
         val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == message }
@@ -39,6 +41,7 @@ class ScenarioTestGenerationException(
             path = path,
             method = scenario.method,
             requestContentType = scenario.requestContentType,
+            responseContentType = scenario.responseContentType,
             responseStatus = scenario.status,
             request = request,
             response = response,
@@ -52,9 +55,8 @@ class ScenarioTestGenerationException(
             scenarioResult = result,
             soapAction = scenario.httpRequestPattern.getSOAPAction().takeIf { scenario.isGherkinScenario },
             isGherkin = scenario.isGherkinScenario,
-            operations = setOf(
-                openAPIOperationFrom(scenario, path)
-            )
+            operations = setOf(openAPIOperationFrom(scenario, path)),
+            reasoning = reasoning
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationException.kt
@@ -13,7 +13,7 @@ import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 
 class ScenarioTestGenerationException(
-    var scenario: Scenario,
+    override var scenario: Scenario,
     val e: Throwable,
     val message: String,
     val breadCrumb: String?,

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -11,7 +11,7 @@ import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 
 class ScenarioTestGenerationFailure(
-    var scenario: Scenario,
+    override var scenario: Scenario,
     val failure: Result.Failure,
     val message: String,
     override val protocol: SpecmaticProtocol?,

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioTestGenerationFailure.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.logger
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
@@ -15,7 +16,8 @@ class ScenarioTestGenerationFailure(
     val failure: Result.Failure,
     val message: String,
     override val protocol: SpecmaticProtocol?,
-    override val specType: SpecType
+    override val specType: SpecType,
+    val reasoning: Reasoning = Reasoning()
 ) : ContractTest {
     init {
         val exampleRow = scenario.examples.flatMap { it.rows }.firstOrNull { it.name == message }
@@ -36,6 +38,7 @@ class ScenarioTestGenerationFailure(
             path = path,
             method = scenario.method,
             requestContentType = scenario.requestContentType,
+            responseContentType = scenario.responseContentType,
             responseStatus = scenario.status,
             request = request,
             response = response,
@@ -49,9 +52,8 @@ class ScenarioTestGenerationFailure(
             scenarioResult = result,
             soapAction = scenario.httpRequestPattern.getSOAPAction().takeIf { scenario.isGherkinScenario },
             isGherkin = scenario.isGherkinScenario,
-            operations = setOf(
-                openAPIOperationFrom(scenario, path)
-            )
+            operations = setOf(openAPIOperationFrom(scenario, path)),
+            reasoning = reasoning
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/TestExecutionReason.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestExecutionReason.kt
@@ -1,0 +1,32 @@
+package io.specmatic.test
+
+import io.specmatic.core.RuleViolation
+
+enum class TestExecutionReason(override val id: String, override val title: String, override val summary: String? = null) : RuleViolation {
+    HAS_EXAMPLE(
+        id = "T10001",
+        title = "Executed Using Example",
+        summary = "This operation was executed by using an available example"
+    ),
+    NO_EXAMPLE(
+        id = "T10002",
+        title = "Executed Using Generation",
+        summary = "This operation was executed by generating payloads, due to the absence of an example"
+    ),
+    POSITIVE_GENERATION_ENABLED(
+        id = "T10003",
+        title = "Executed Using Positive Generation",
+        summary = "This operation was executed by generating +ve payloads, due to positive generation being enabled"
+    ),
+    NEGATIVE_GENERATION_ENABLED(
+        id = "T10004",
+        title = "Executed Using Negative Generation",
+        summary = "This operation was executed by generating -ve payloads, due to negative generation being enabled"
+    );
+
+    companion object {
+        fun executed(hasExamples: Boolean): TestExecutionReason = if (hasExamples) HAS_EXAMPLE else NO_EXAMPLE
+        fun executedPositiveGen(): TestExecutionReason = POSITIVE_GENERATION_ENABLED
+        fun executedNegativeGen(): TestExecutionReason = NEGATIVE_GENERATION_ENABLED
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -3,9 +3,12 @@ package io.specmatic.test
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
+import io.specmatic.core.RuleViolationReport
 import io.specmatic.core.Scenario
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.ctrf.model.CtrfRuleSnapshot
 import io.specmatic.reporter.ctrf.model.CtrfTestMetadata
 import io.specmatic.reporter.ctrf.model.CtrfTestOutput
 import io.specmatic.reporter.ctrf.model.CtrfTestResultRecord
@@ -33,6 +36,7 @@ data class TestResultRecord(
     val scenarioResult: Result? = null,
     override val isWip: Boolean = false,
     val requestContentType: String? = null,
+    val responseContentType: String? = null,
     val soapAction: String? = null,
     val isGherkin: Boolean = false,
     val requestTime: Instant? = null,
@@ -46,10 +50,12 @@ data class TestResultRecord(
             method = method,
             contentType = requestContentType,
             responseCode = responseStatus,
+            responseContentType = responseContentType,
             protocol = SpecmaticProtocol.HTTP
         )
     ),
-    val exampleId: String? = null
+    val exampleId: String? = null,
+    val reasoning: Reasoning = Reasoning(),
 ): CtrfTestResultRecord {
     val isExercised = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
     val isCovered = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
@@ -72,7 +78,8 @@ data class TestResultRecord(
             wip = isWip,
             input = request?.toLogString().orEmpty(),
             outputs = outputs,
-            inputTime = requestTime?.toEpochMilli() ?: 0L
+            inputTime = requestTime?.toEpochMilli() ?: 0L,
+            decisions = reasoning.toRuleViolationReport().toCtrfSnapshots()
         )
     }
 
@@ -138,6 +145,12 @@ data class TestResultRecord(
                 "Cannot determine coverage status for API operation ${this.testName()} with unknown test result: ${this.result}"
             )
         }
+
+    private fun RuleViolationReport.toCtrfSnapshots(): List<CtrfRuleSnapshot> {
+        return this.toSnapShots().map { snapShot ->
+            CtrfRuleSnapshot(id = snapShot.id, title = snapShot.title, documentationUrl = snapShot.documentationUrl, summary = snapShot.summary)
+        }
+    }
 }
 
 fun CoverageStatus.isPresentInSpecForApiCoverage(): Boolean =
@@ -163,6 +176,7 @@ fun openAPIOperationFrom(scenario: Scenario, path: String): OpenAPIOperation {
         path = path,
         method = scenario.method,
         contentType = scenario.requestContentType,
+        responseContentType = scenario.responseContentType,
         responseCode = scenario.status,
         protocol = scenario.protocol
     )

--- a/core/src/main/kotlin/io/specmatic/test/TestRuleViolations.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestRuleViolations.kt
@@ -8,31 +8,26 @@ enum class TestRuleViolations(override val id: String, override val title: Strin
         title = "Excluded from Run",
         summary = "This operation was skipped because it did not match the selected filters"
     ),
-
     NO_EXAMPLES(
         id = "T00003",
         title = "No Examples Available",
         summary = "This operation requires examples to run, but none were provided"
     ),
-
     STRICT_MODE_NO_EXAMPLES(
         id = "T00002",
         title = "Examples Required in Strict Mode",
         summary = "Strict mode requires at least one example, but none were found for this operation"
     ),
-
     ACCEPT_MISMATCH(
         id = "T00004",
         title = "Content Type Mismatch",
         summary = "The request Accept header does not match the response content type of the operation"
     ),
-
     GENERATIVE_DISABLED(
         id = "T00005",
         title = "Generation Disabled",
         summary = "This operation was skipped because it required generation to be enabled"
     ),
-
     MAX_TEST_COUNT_EXCEEDED(
         id = "T00006",
         title = "Maximum Test Count Exceeded",

--- a/core/src/main/kotlin/io/specmatic/test/TestRuleViolations.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestRuleViolations.kt
@@ -8,19 +8,19 @@ enum class TestRuleViolations(override val id: String, override val title: Strin
         title = "Excluded from Run",
         summary = "This operation was skipped because it did not match the selected filters"
     ),
-    NO_EXAMPLES(
+    EXAMPLES_REQUIRED(
         id = "T00003",
-        title = "No Examples Available",
+        title = "Examples Required",
         summary = "This operation requires examples to run, but none were provided"
     ),
-    STRICT_MODE_NO_EXAMPLES(
+    EXAMPLES_REQUIRED_STRICT_MODE(
         id = "T00002",
         title = "Examples Required in Strict Mode",
         summary = "Strict mode requires at least one example, but none were found for this operation"
     ),
     ACCEPT_MISMATCH(
         id = "T00004",
-        title = "Content Type Mismatch",
+        title = "Accept Mismatch",
         summary = "The request Accept header does not match the response content type of the operation"
     ),
     GENERATIVE_DISABLED(
@@ -35,7 +35,7 @@ enum class TestRuleViolations(override val id: String, override val title: Strin
     );
 
     companion object {
-        fun noExamplesNon2xxAndNon400(): TestRuleViolations = NO_EXAMPLES
-        fun noExamples2xxAnd400(strictMode: Boolean): TestRuleViolations = if (strictMode) STRICT_MODE_NO_EXAMPLES else NO_EXAMPLES
+        fun noExamplesNon2xxAndNon400(): TestRuleViolations = EXAMPLES_REQUIRED
+        fun noExamples2xxAnd400(strictMode: Boolean): TestRuleViolations = if (strictMode) EXAMPLES_REQUIRED_STRICT_MODE else EXAMPLES_REQUIRED
     }
 }

--- a/core/src/main/kotlin/io/specmatic/test/TestRuleViolations.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestRuleViolations.kt
@@ -1,0 +1,46 @@
+package io.specmatic.test
+
+import io.specmatic.core.RuleViolation
+
+enum class TestRuleViolations(override val id: String, override val title: String, override val summary: String? = null): RuleViolation {
+    EXCLUDED(
+        id = "T00001",
+        title = "Excluded from Run",
+        summary = "This operation was skipped because it did not match the selected filters"
+    ),
+
+    NO_EXAMPLES(
+        id = "T00003",
+        title = "No Examples Available",
+        summary = "This operation requires examples to run, but none were provided"
+    ),
+
+    STRICT_MODE_NO_EXAMPLES(
+        id = "T00002",
+        title = "Examples Required in Strict Mode",
+        summary = "Strict mode requires at least one example, but none were found for this operation"
+    ),
+
+    ACCEPT_MISMATCH(
+        id = "T00004",
+        title = "Content Type Mismatch",
+        summary = "The request Accept header does not match the response content type of the operation"
+    ),
+
+    GENERATIVE_DISABLED(
+        id = "T00005",
+        title = "Generation Disabled",
+        summary = "This operation was skipped because it required generation to be enabled"
+    ),
+
+    MAX_TEST_COUNT_EXCEEDED(
+        id = "T00006",
+        title = "Maximum Test Count Exceeded",
+        summary = "This operation was skipped because it exceeded the maximum test count"
+    );
+
+    companion object {
+        fun noExamplesNon2xxAndNon400(): TestRuleViolations = NO_EXAMPLES
+        fun noExamples2xxAnd400(strictMode: Boolean): TestRuleViolations = if (strictMode) STRICT_MODE_NO_EXAMPLES else NO_EXAMPLES
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/test/TestSkipReason.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestSkipReason.kt
@@ -2,7 +2,7 @@ package io.specmatic.test
 
 import io.specmatic.core.RuleViolation
 
-enum class TestRuleViolations(override val id: String, override val title: String, override val summary: String? = null): RuleViolation {
+enum class TestSkipReason(override val id: String, override val title: String, override val summary: String? = null): RuleViolation {
     EXCLUDED(
         id = "T00001",
         title = "Excluded from Run",
@@ -35,7 +35,7 @@ enum class TestRuleViolations(override val id: String, override val title: Strin
     );
 
     companion object {
-        fun noExamplesNon2xxAndNon400(): TestRuleViolations = EXAMPLES_REQUIRED
-        fun noExamples2xxAnd400(strictMode: Boolean): TestRuleViolations = if (strictMode) EXAMPLES_REQUIRED_STRICT_MODE else EXAMPLES_REQUIRED
+        fun noExamplesNon2xxAndNon400(): TestSkipReason = EXAMPLES_REQUIRED
+        fun noExamples2xxAnd400(strictMode: Boolean): TestSkipReason = if (strictMode) EXAMPLES_REQUIRED_STRICT_MODE else EXAMPLES_REQUIRED
     }
 }

--- a/core/src/main/kotlin/io/specmatic/test/handlers/AcceptedResponseHandler.kt
+++ b/core/src/main/kotlin/io/specmatic/test/handlers/AcceptedResponseHandler.kt
@@ -135,7 +135,7 @@ class AcceptedResponseHandler(
             path = originalScenario.path,
             method = originalScenario.method,
             responseStatusCode = HttpStatusCode.Accepted.value,
-            contentType = originalScenario.requestContentType,
+            reqContentType = originalScenario.requestContentType,
         )
     }
 

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7253,9 +7253,9 @@ components:
 
         val testDescriptionList = tests.map { it.testDescription() }
         assertThat(testDescriptionList).containsExactlyInAnyOrder(
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'FIRST' from enum",
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'SECOND' from enum",
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'THIRD' from enum"
+            "Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'FIRST' from enum",
+            "Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'SECOND' from enum",
+            "Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'THIRD' from enum"
         )
     }
 
@@ -8904,8 +8904,8 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'name', 'age' AND id which is a mandatory query param, is not sent")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'id', 'name' AND age which is a mandatory query param, is not sent")
+            assertThat(firstScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'name', 'age' AND id which is a mandatory query param, is not sent")
+            assertThat(secondScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'id', 'name' AND age which is a mandatory query param, is not sent")
         }
 
         @Test
@@ -8960,7 +8960,7 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /items -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the param 'category' AND ids which is a mandatory query param, is not sent")
+            assertThat(firstScenario.testDescription()).isEqualTo("Scenario: GET /items -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the param 'category' AND ids which is a mandatory query param, is not sent")
         }
 
         @Test
@@ -9045,8 +9045,8 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with the request from the example 'EXAMPLE' where REQUEST.PARAMETERS.QUERY contains the params 'name', 'age' AND id which is a mandatory query param, is not sent")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with the request from the example 'EXAMPLE' where REQUEST.PARAMETERS.QUERY contains the params 'id', 'name' AND age which is a mandatory query param, is not sent")
+            assertThat(firstScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with the request from the example 'EXAMPLE' where REQUEST.PARAMETERS.QUERY contains the params 'name', 'age' AND id which is a mandatory query param, is not sent")
+            assertThat(secondScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with the request from the example 'EXAMPLE' where REQUEST.PARAMETERS.QUERY contains the params 'id', 'name' AND age which is a mandatory query param, is not sent")
         }
 
     }
@@ -9128,8 +9128,8 @@ paths:
                 }
             })
 
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Optional-Header', 'X-Another-Required-Header' AND X-Required-Header which is a mandatory header, is not sent")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Required-Header', 'X-Optional-Header' AND X-Another-Required-Header which is a mandatory header, is not sent")
+            assertThat(firstScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Optional-Header', 'X-Another-Required-Header' AND X-Required-Header which is a mandatory header, is not sent")
+            assertThat(secondScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Required-Header', 'X-Optional-Header' AND X-Another-Required-Header which is a mandatory header, is not sent")
         }
 
         @Test
@@ -9220,8 +9220,8 @@ paths:
                     return HttpResponse.OK
                 }
             })
-            assertThat(firstScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Optional-Header', 'X-Another-Required-Header' AND X-Required-Header which is a mandatory header, is not sent")
-            assertThat(secondScenario.testDescription()).isEqualTo(" Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Required-Header', 'X-Optional-Header' AND X-Another-Required-Header which is a mandatory header, is not sent")
+            assertThat(firstScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Optional-Header', 'X-Another-Required-Header' AND X-Required-Header which is a mandatory header, is not sent")
+            assertThat(secondScenario.testDescription()).isEqualTo("Scenario: GET /persons -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Required-Header', 'X-Optional-Header' AND X-Another-Required-Header which is a mandatory header, is not sent")
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
@@ -1,0 +1,80 @@
+package io.specmatic.core
+
+import io.ktor.http.HttpStatusCode
+import io.specmatic.core.BadRequestOrDefault.Companion.updateScenarioWithBadRequestPattern
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.model.SpecType
+
+class BadRequestOrDefaultTest {
+    @Test
+    fun `matches should use explicit bad request response when available`() {
+        val badRequestOrDefault = BadRequestOrDefault(
+            badRequestResponses = mapOf(401 to scenarioWithStatus(401)),
+            defaultResponse = scenarioWithStatus(DEFAULT_RESPONSE_CODE)
+        )
+
+        assertThat(badRequestOrDefault.supports(401)).isTrue()
+        assertThat(badRequestOrDefault.matches(HttpResponse(401), Resolver())).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `matches should fall back to default response when no explicit bad request exists`() {
+        val badRequestOrDefault = BadRequestOrDefault(badRequestResponses = emptyMap(), defaultResponse = scenarioWithStatus(DEFAULT_RESPONSE_CODE))
+        assertThat(badRequestOrDefault.supports(402)).isTrue()
+        assertThat(badRequestOrDefault.matches(HttpResponse(402), Resolver())).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `supports should be false when there is no bad request response or default response`() {
+        val badRequestOrDefault = BadRequestOrDefault(emptyMap(), null)
+        assertThat(badRequestOrDefault.supports(HttpStatusCode.BadRequest.value)).isFalse()
+    }
+
+    @Test
+    fun `updateScenarioWithBadRequestPattern should prefer explicit bad request status over default`() {
+        val badRequestOrDefault = BadRequestOrDefault(
+            badRequestResponses = mapOf(401 to scenarioWithStatus(401), 400 to scenarioWithStatus(400)),
+            defaultResponse = scenarioWithStatus(DEFAULT_RESPONSE_CODE)
+        )
+
+        val scenario = Scenario(
+            name = "success",
+            specType = SpecType.OPENAPI,
+            protocol = SpecmaticProtocol.HTTP,
+            httpRequestPattern = HttpRequestPattern(method = "GET"),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+        )
+
+        val updated = badRequestOrDefault.updateScenarioWithBadRequestPattern(scenario)
+        assertThat(updated.httpResponsePattern.status).isEqualTo(400)
+        assertThat(updated.statusInDescription).isEqualTo("400")
+    }
+
+    @Test
+    fun `updateScenarioWithBadRequestPattern should use default response status when no explicit bad request exists`() {
+        val badRequestOrDefault = BadRequestOrDefault(badRequestResponses = emptyMap(), defaultResponse = scenarioWithStatus(DEFAULT_RESPONSE_CODE))
+        val scenario = Scenario(
+            name = "success",
+            specType = SpecType.OPENAPI,
+            protocol = SpecmaticProtocol.HTTP,
+            httpRequestPattern = HttpRequestPattern(method = "GET"),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+        )
+
+        val updated = badRequestOrDefault.updateScenarioWithBadRequestPattern(scenario)
+        assertThat(updated.httpResponsePattern.status).isEqualTo(DEFAULT_RESPONSE_CODE)
+        assertThat(updated.statusInDescription).isEqualTo(DEFAULT_RESPONSE_CODE.toString())
+    }
+
+    private fun scenarioWithStatus(status: Int): Scenario {
+        return Scenario(
+            name = "scenario-$status",
+            httpRequestPattern = HttpRequestPattern(method = "GET"),
+            httpResponsePattern = HttpResponsePattern(status = status),
+            protocol = SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
@@ -343,7 +343,10 @@ class FeatureDecisionMatrixTest {
                 originalScenarios = listOf(scenario)
             ).toList()
 
-            assertThat(generated).isEmpty()
+            assertThat(generated).hasSize(1)
+            val decision = generated.filterIsInstance<Decision.Skip<Scenario>>().single()
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamples2xxAnd400(true))
+            assertThat(decision.reasoning.otherReasons).isEmpty()
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
@@ -107,7 +107,7 @@ class FeatureDecisionMatrixTest {
             assertThat(successRequest).hasSize(2).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Execute::class.java)
                 assertThat(it.reasoning.mainReason).isEqualTo(TestExecutionReason.POSITIVE_GENERATION_ENABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestExecutionReason.NO_EXAMPLE)
+                assertThat(it.reasoning.otherReasons).isEmpty()
             }
         }
 
@@ -133,7 +133,7 @@ class FeatureDecisionMatrixTest {
             assertThat(successRequest).hasSize(2).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Execute::class.java)
                 assertThat(it.reasoning.mainReason).isEqualTo(TestExecutionReason.POSITIVE_GENERATION_ENABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestExecutionReason.NO_EXAMPLE)
+                assertThat(it.reasoning.otherReasons).isEmpty()
             }
         }
 
@@ -363,6 +363,53 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generatedWithBadRequestFilteredOut).isEmpty()
         }
+
+        @Test
+        fun `negative generation should still execute when 2xx is filtered but matching 400 is available`() {
+            val fullFeature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val successScenario = fullFeature.scenarios.first { it.httpResponsePattern.status == 200 }
+            val badRequestScenario = fullFeature.scenarios.first { it.matchesOperationId(successScenario) && it.status == 400 }
+
+            val feature = fullFeature.copy(scenarios = listOf(badRequestScenario))
+            val generated = feature.negativeTestScenariosWithDecision(
+                originalScenarios = listOf(successScenario, badRequestScenario),
+                scenarios = sequenceOf(
+                    Decision.Skip(context = successScenario, reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd400(true))),
+                    Decision.execute(badRequestScenario)
+                ),
+            ).toList()
+
+            assertThat(generated).isNotEmpty()
+            assertThat(generated).allSatisfy { decision ->
+                assertThat(decision).isInstanceOf(Decision.Execute::class.java)
+                assertThat(decision.context.isNegative).isTrue()
+                assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.NEGATIVE_GENERATION_ENABLED)
+            }
+        }
+
+        @Test
+        fun `negative generation should not execute when matching 400 is filtered out`() {
+            val fullFeature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val successScenario = fullFeature.scenarios.first { it.httpResponsePattern.status == 200 }
+            val badRequestScenario = fullFeature.scenarios.first { it.matchesOperationId(successScenario) && it.status == 400 }
+
+            val feature = fullFeature.copy(scenarios = listOf(successScenario))
+            val generated = feature.negativeTestScenariosWithDecision(
+                originalScenarios = listOf(successScenario, badRequestScenario),
+                scenarios = sequenceOf(
+                    Decision.Skip(
+                        context = successScenario,
+                        reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd400(true))
+                    ),
+                    Decision.Skip(
+                        context = badRequestScenario,
+                        reasoning = Reasoning(mainReason = TestSkipReason.noExamples2xxAnd400(true))
+                    )
+                ),
+            ).toList()
+
+            assertThat(generated).isEmpty()
+        }
     }
 
     @Nested
@@ -428,7 +475,7 @@ class FeatureDecisionMatrixTest {
         }
 
         @Test
-        fun `incompatible exact accept without examples should be skipped with accept mismatch`() {
+        fun `incompatible exact accept without examples should be skipped without any trace`() {
             val scenario = Scenario(
                 specType = SpecType.OPENAPI,
                 protocol = SpecmaticProtocol.HTTP,
@@ -447,10 +494,7 @@ class FeatureDecisionMatrixTest {
                 scenarios = sequenceOf(Decision.execute(scenario))
             ).toList()
 
-            assertThat(generated).hasSize(1)
-            val skip = generated.single() as Decision.Skip
-            assertThat(skip.reasoning.mainReason).isEqualTo(TestSkipReason.ACCEPT_MISMATCH)
-            assertThat(skip.reasoning.otherReasons).isEmpty()
+            assertThat(generated).isEmpty()
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
@@ -1,0 +1,524 @@
+package io.specmatic.core
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.pattern.*
+import io.specmatic.core.utilities.Decision
+import io.specmatic.core.utilities.Reasoning
+import io.specmatic.core.value.EmptyString
+import io.specmatic.core.value.StringValue
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.model.SpecType
+import io.specmatic.test.ContractTest
+import io.specmatic.test.ScenarioAsTest
+import io.specmatic.test.TestExecutionReason
+import io.specmatic.test.TestExecutor
+import io.specmatic.test.TestRuleViolations
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class FeatureDecisionMatrixTest {
+    private fun featureFromResourceOpenapi(resource: String): Feature {
+        return OpenApiSpecification.fromFile("openapi/$resource").toFeature()
+    }
+
+    private fun Scenario.matchesOperationId(other: Scenario): Boolean = this.operationMetadata?.operationId == other.operationMetadata?.operationId
+    private fun firstScenario(feature: Feature, status: Int, operationId: String? = null, hasExamples: Boolean? = null): Scenario {
+        return feature.scenarios.first {
+            it.httpResponsePattern.status == status &&
+            (operationId == null || it.operationMetadata?.operationId == operationId) &&
+            (hasExamples == null || it.hasExamples() == hasExamples)
+        }
+    }
+
+    @Nested
+    inner class ResiliencyModeTests {
+        @Test
+        fun `resiliency null should not generate negative scenarios and generative positive scenarios when no examples exist`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val scenario200 = firstScenario(feature, 200, hasExamples = false)
+            val scenario400 = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario200, scenario400),
+                scenarios = sequenceOf(Decision.execute(scenario200), Decision.execute(scenario400))
+            ).toList()
+
+            assertThat(generated).hasSize(3)
+            val badRequest = generated.filter { it.context.isA4xxScenario() }
+            assertThat(badRequest).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+            }
+
+            val successRequest = generated.filter { it.context.isA2xxScenario() }
+            assertThat(successRequest).hasSize(2).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Execute::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestExecutionReason.NO_EXAMPLE)
+                assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+        }
+
+        @Test
+        fun `resiliency none should not generate negative scenarios and not generative positive scenarios when examples exist`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").disableGenerativeTesting()
+            val scenario200 = firstScenario(feature, 200, hasExamples = true)
+            val scenario400 = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario200, scenario400),
+                scenarios = sequenceOf(Decision.execute(scenario200), Decision.execute(scenario400))
+            ).toList()
+
+            assertThat(generated).hasSize(2)
+            val badRequest = generated.filter { it.context.isA4xxScenario() }
+            assertThat(badRequest).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+            }
+
+            val successRequest = generated.filter { it.context.isA2xxScenario() }
+            assertThat(successRequest).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Execute::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestExecutionReason.HAS_EXAMPLE)
+                assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+        }
+
+        @Test
+        fun `resiliency all should generate negative scenarios and positive scenarios`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").enableGenerativeTesting()
+            val scenario200 = firstScenario(feature, 200, hasExamples = false)
+            val scenario400 = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario200, scenario400),
+                scenarios = sequenceOf(Decision.execute(scenario200), Decision.execute(scenario400))
+            ).toList()
+
+            assertThat(generated).hasSize(6)
+            val badRequest = generated.filter { it.context.isNegative }
+            assertThat(badRequest).hasSize(4).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Execute::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestExecutionReason.NEGATIVE_GENERATION_ENABLED)
+                assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+
+            val successRequest = generated.filter { !it.context.isNegative }
+            assertThat(successRequest).hasSize(2).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Execute::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestExecutionReason.POSITIVE_GENERATION_ENABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestExecutionReason.NO_EXAMPLE)
+            }
+        }
+
+        @Test
+        fun `resiliency positive only should generate positive scenarios when no examples exist`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").enableGenerativeTesting(onlyPositive = true)
+            val scenario200 = firstScenario(feature, 200, hasExamples = false)
+            val scenario400 = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario200, scenario400),
+                scenarios = sequenceOf(Decision.execute(scenario200), Decision.execute(scenario400))
+            ).toList()
+
+            assertThat(generated).hasSize(3)
+            val badRequest = generated.filter { it.context.isA4xxScenario() }
+            assertThat(badRequest).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+            }
+
+            val successRequest = generated.filter { it.context.isA2xxScenario() }
+            assertThat(successRequest).hasSize(2).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Execute::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestExecutionReason.POSITIVE_GENERATION_ENABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestExecutionReason.NO_EXAMPLE)
+            }
+        }
+
+        @Test
+        fun `resiliency positive only should generate positive scenarios when examples exist marking them appropriately`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").enableGenerativeTesting(onlyPositive = true)
+            val scenario200 = firstScenario(feature, 200, hasExamples = true)
+            val scenario400 = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario200, scenario400),
+                scenarios = sequenceOf(Decision.execute(scenario200), Decision.execute(scenario400))
+            ).toList()
+
+            assertThat(generated).hasSize(3)
+            val badRequest = generated.filter { it.context.isA4xxScenario() }
+            assertThat(badRequest).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+            }
+
+            val successRequest = generated.filter { it.context.isA2xxScenario() }
+            val (example, positiveGeneration) = successRequest
+            assertThat(successRequest).hasSize(2)
+            assertThat(example).isInstanceOf(Decision.Execute::class.java)
+            assertThat(example.reasoning.mainReason).isEqualTo(TestExecutionReason.HAS_EXAMPLE)
+            assertThat(example.reasoning.otherReasons).isEmpty()
+
+            assertThat(positiveGeneration).isInstanceOf(Decision.Execute::class.java)
+            assertThat(positiveGeneration.reasoning.mainReason).isEqualTo(TestExecutionReason.POSITIVE_GENERATION_ENABLED)
+            assertThat(positiveGeneration.reasoning.otherReasons).containsExactly(TestExecutionReason.HAS_EXAMPLE)
+        }
+    }
+
+    @Nested
+    inner class StrictModeTests {
+        @Test
+        fun `strict mode should skip 2xx scenarios without examples with strict violation`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").copy(strictMode = true)
+            val scenario = firstScenario(feature, 200, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val skip = generated.single() as Decision.Skip
+            assertThat(skip.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamples2xxAnd400(true))
+            assertThat(skip.reasoning.otherReasons).isEmpty()
+        }
+
+        @Test
+        fun `strict mode with resiliency none should mark 400 without examples as generative disabled with strict detail`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").copy(strictMode = true).disableGenerativeTesting()
+            val scenario = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val skip = generated.single() as Decision.Skip<*>
+            assertThat(skip.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
+            assertThat(skip.reasoning.otherReasons).containsExactly(TestRuleViolations.noExamples2xxAnd400(true))
+        }
+
+        @Test
+        fun `strict mode should keep non-2xx non-400 no-example skips as no-examples violation`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").copy(strictMode = true)
+            val scenario = firstScenario(feature, 500, hasExamples = false)
+            val secondScenario = firstScenario(feature, 404, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario, secondScenario),
+                scenarios = sequenceOf(Decision.execute(scenario), Decision.execute(secondScenario))
+            ).toList()
+
+            assertThat(generated).hasSize(2).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
+                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamplesNon2xxAndNon400())
+                assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+        }
+    }
+
+    @Nested
+    inner class PositiveScenarioTests {
+        @Test
+        fun `example-backed and schema-backed 2xx scenarios should execute with explicit reasoning`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").disableGenerativeTesting()
+            val exampleScenario = firstScenario(feature, 200, hasExamples = true)
+            val schemaScenario = firstScenario(feature, 200, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(exampleScenario, schemaScenario),
+                scenarios = sequenceOf(Decision.execute(exampleScenario), Decision.execute(schemaScenario))
+            ).toList()
+
+            assertThat(generated).hasSize(3).allSatisfy { decision ->
+                assertThat(decision).isInstanceOf(Decision.Execute::class.java)
+                assertThat(decision.context.isNegative).isFalse()
+            }
+
+            val exampleDecision = generated.single { it.context.matchesOperationId(exampleScenario) }
+            assertThat(exampleDecision).isInstanceOf(Decision.Execute::class.java); exampleDecision as Decision.Execute
+            assertThat(exampleDecision.value.value.generatedFrom).isEqualTo(GeneratedScenarioOrigin.EXAMPLE_ROW)
+            assertThat(exampleDecision.reasoning.mainReason).isEqualTo(TestExecutionReason.HAS_EXAMPLE)
+            assertThat(exampleDecision.reasoning.otherReasons).isEmpty()
+
+            val schemaDecisions = generated.filter { it.context.matchesOperationId(schemaScenario) }
+            assertThat(schemaDecisions).hasSize(2).allSatisfy { schemaDecision ->
+                assertThat(schemaDecision).isInstanceOf(Decision.Execute::class.java); schemaDecision as Decision.Execute
+                assertThat(schemaDecision.value.value.generatedFrom).isEqualTo(GeneratedScenarioOrigin.MUTATION)
+                assertThat(schemaDecision.reasoning.mainReason).isEqualTo(TestExecutionReason.NO_EXAMPLE)
+                assertThat(schemaDecision.reasoning.otherReasons).isEmpty()
+            }
+        }
+
+        @Test
+        fun `example-backed 400 scenarios should execute with has-example reasoning`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val scenario = firstScenario(feature, 400, hasExamples = true)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val decision = generated.single() as Decision.Execute
+            assertThat(decision.value.value.generatedFrom).isEqualTo(GeneratedScenarioOrigin.EXAMPLE_ROW)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.HAS_EXAMPLE)
+            assertThat(decision.reasoning.otherReasons).isEmpty()
+        }
+
+        @Test
+        fun `example-backed 404 scenarios should execute with has-example reasoning`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val scenario = firstScenario(feature, 404, hasExamples = true)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val decision = generated.single() as Decision.Execute
+            assertThat(decision.value.value.generatedFrom).isEqualTo(GeneratedScenarioOrigin.EXAMPLE_ROW)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.HAS_EXAMPLE)
+            assertThat(decision.reasoning.otherReasons).isEmpty()
+        }
+
+        @Test
+        fun `example-backed 500 scenarios should execute with has-example reasoning`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val scenario = firstScenario(feature, 500, hasExamples = true)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val decision = generated.filterIsInstance<Decision.Execute<ReturnValue<Scenario>, Scenario>>().first()
+            assertThat(decision.value.value.generatedFrom).isEqualTo(GeneratedScenarioOrigin.EXAMPLE_ROW)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.HAS_EXAMPLE)
+            assertThat(decision.reasoning.otherReasons).isEmpty()
+        }
+
+        @Test
+        fun `non-2xx non-400 scenarios without examples should be skipped with no-examples violation`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val scenario = firstScenario(feature, 500, hasExamples = false)
+            val secondScenario = firstScenario(feature, 404, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario, secondScenario),
+                scenarios = sequenceOf(Decision.execute(scenario), Decision.execute(secondScenario))
+            ).toList()
+
+            assertThat(generated).hasSize(2).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
+                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamplesNon2xxAndNon400())
+                assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+        }
+    }
+
+    @Nested
+    inner class NegativeGenerationTests {
+        @Test
+        fun `negative generation should only execute scenarios with explicit negative reasoning`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val generated = feature.negativeTestScenariosWithDecision(
+                scenarios = feature.scenarios.asSequence().map { Decision.execute(it) },
+                originalScenarios = feature.scenarios
+            ).toList()
+
+            assertThat(generated).hasSize(8).allSatisfy { decision ->
+                assertThat(decision).isInstanceOf(Decision.Execute::class.java)
+                assertThat(decision.context.isNegative).isTrue()
+                assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.NEGATIVE_GENERATION_ENABLED)
+                assertThat(decision.reasoning.otherReasons).isEmpty()
+            }
+        }
+
+        @Test
+        fun `negative generation should skip scenarios without examples in strict mode`() {
+            val feature = featureFromResourceOpenapi("has_400_example_for_stub.yaml").copy(strictMode = true)
+            val scenario = feature.scenarios.first { it.httpResponsePattern.status == 200 }
+            val generated = feature.negativeTestScenariosWithDecision(
+                scenarios = sequenceOf(Decision.execute(scenario)),
+                originalScenarios = listOf(scenario)
+            ).toList()
+
+            assertThat(generated).isEmpty()
+        }
+
+        @Test
+        fun `negative generation should stop when bad request or default scenarios are filtered out of the original scenario list`() {
+            val fullFeature = featureFromResourceOpenapi("feature_decision_matrix.yaml")
+            val successScenario = fullFeature.scenarios.first { it.httpResponsePattern.status == 200 }
+            val badRequestScenario = fullFeature.scenarios.first { it.matchesOperationId(successScenario) && it.status == 400 }
+
+            val feature = fullFeature.copy(scenarios = listOf(successScenario))
+            val generatedWithBadRequestFilteredOut = feature.negativeTestScenariosWithDecision(
+                scenarios = sequenceOf(Decision.execute(successScenario)),
+                originalScenarios = listOf(successScenario, badRequestScenario)
+            ).toList()
+
+            assertThat(generatedWithBadRequestFilteredOut).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class AcceptCompatibilityTests {
+        @Test
+        fun `compatible accept should stay executable with original reasoning`() {
+            val scenario = Scenario(
+                name = "compatible accept",
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                httpRequestPattern = HttpRequestPattern(
+                    method = "GET",
+                    httpPathPattern = buildHttpPathPattern("/products"),
+                    headersPattern = HttpHeadersPattern(mapOf(ACCEPT to ExactValuePattern(StringValue("application/json"))))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json")),
+            )
+
+            val feature = Feature(scenarios = listOf(scenario), name = "accept-compatible", protocol = SpecmaticProtocol.HTTP)
+            val generated = feature.generateContractTestsWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val decision = generated.single()
+            assertThat(decision).isInstanceOf(Decision.Execute::class.java)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.NO_EXAMPLE)
+            assertThat(decision.reasoning.otherReasons).isEmpty()
+        }
+
+        @Test
+        fun `incompatible accept enum with examples should produce one execute and one accept mismatch skip`() {
+            val scenario = Scenario(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                name = "example-backed accept mismatch",
+                httpRequestPattern = HttpRequestPattern(
+                    method = "GET",
+                    httpPathPattern = buildHttpPathPattern("/products"),
+                    headersPattern = HttpHeadersPattern(mapOf(ACCEPT to EnumPattern(values = listOf(StringValue("application/json"), StringValue("application/xml")))))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json")),
+                examples = listOf(Examples(columnNames = listOf("id"), rows = listOf(Row(columnNames = listOf("id"), values = listOf("123"))))),
+            )
+
+            val feature = Feature(scenarios = listOf(scenario), name = "accept-mismatch", protocol = SpecmaticProtocol.HTTP)
+            val generated = feature.generateContractTestsWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(2)
+            val execute = generated.filterIsInstance<Decision.Execute<ContractTest, Scenario>>().single()
+            val executeTestScenario = (execute.value as ScenarioAsTest).scenario
+            assertThat(executeTestScenario.httpRequestPattern.headersPattern.pattern.getValue(ACCEPT)).isEqualTo(ExactValuePattern(StringValue("application/json")))
+            assertThat(execute.reasoning.mainReason).isEqualTo(TestExecutionReason.HAS_EXAMPLE)
+            assertThat(execute.reasoning.otherReasons).isEmpty()
+
+            val skip = generated.filterIsInstance<Decision.Skip<Scenario>>().single()
+            assertThat(skip.context.httpRequestPattern.headersPattern.pattern.getValue(ACCEPT)).isEqualTo(ExactValuePattern(StringValue("application/xml")))
+            assertThat(skip.reasoning).isEqualTo(Reasoning(mainReason = TestRuleViolations.ACCEPT_MISMATCH))
+        }
+
+        @Test
+        fun `incompatible exact accept without examples should be skipped with accept mismatch`() {
+            val scenario = Scenario(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                name = "no-example accept mismatch",
+                httpRequestPattern = HttpRequestPattern(
+                    method = "GET",
+                    httpPathPattern = buildHttpPathPattern("/products"),
+                    headersPattern = HttpHeadersPattern(mapOf(ACCEPT to ExactValuePattern(StringValue("application/xml"))))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json")),
+            )
+
+            val feature = Feature(scenarios = listOf(scenario), name = "accept-mismatch-no-example", protocol = SpecmaticProtocol.HTTP)
+            val generated = feature.generateContractTestsWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val skip = generated.single() as Decision.Skip
+            assertThat(skip.reasoning.mainReason).isEqualTo(TestRuleViolations.ACCEPT_MISMATCH)
+            assertThat(skip.reasoning.otherReasons).isEmpty()
+        }
+
+        @Test
+        fun `string accept should normalize to response content type during execution`() {
+            val scenario = Scenario(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                name = "normalize accept to content type",
+                httpRequestPattern = HttpRequestPattern(
+                    method = "GET",
+                    httpPathPattern = buildHttpPathPattern("/products"),
+                    headersPattern = HttpHeadersPattern(mapOf(ACCEPT to StringPattern()))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json")),
+            )
+
+            val feature = Feature(scenarios = listOf(scenario), name = "accept-normalization", protocol = SpecmaticProtocol.HTTP)
+            val generated = feature.generateContractTestsWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val decision = generated.single() as Decision.Execute
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.NO_EXAMPLE)
+            assertThat(decision.reasoning.otherReasons).isEmpty()
+
+            val result = decision.value.runTest(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    assertThat(request.headers.getCaseInsensitive(ACCEPT)?.value).isEqualTo("application/json")
+                    return HttpResponse(200, body = EmptyString, headers = mapOf(CONTENT_TYPE to "application/json"))
+                }
+            })
+            assertThat(result.result).isInstanceOf(Result.Success::class.java)
+        }
+
+        @Test
+        fun `string accept should normalize to wildcard when response content type is unknown`() {
+            val scenario = Scenario(
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                name = "wildcard accept normalization",
+                httpRequestPattern = HttpRequestPattern(
+                    method = "GET",
+                    httpPathPattern = buildHttpPathPattern("/products"),
+                    headersPattern = HttpHeadersPattern(mapOf(ACCEPT to StringPattern()))
+                ),
+                httpResponsePattern = HttpResponsePattern(status = 200),
+            )
+
+            val feature = Feature(scenarios = listOf(scenario), name = "accept-wildcard", protocol = SpecmaticProtocol.HTTP)
+            val generated = feature.generateContractTestsWithDecision(
+                originalScenarios = listOf(scenario),
+                scenarios = sequenceOf(Decision.execute(scenario))
+            ).toList()
+
+            assertThat(generated).hasSize(1)
+            val decision = generated.single() as Decision.Execute
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestExecutionReason.NO_EXAMPLE)
+            assertThat(decision.reasoning.otherReasons).isEmpty()
+
+            val sentAcceptValues = mutableListOf<String?>()
+            val result = decision.value.runTest(object : TestExecutor {
+                override fun execute(request: HttpRequest): HttpResponse {
+                    sentAcceptValues.add(request.headers.getCaseInsensitive(ACCEPT)?.value)
+                    return HttpResponse(200)
+                }
+            })
+
+            assertThat(result.result).isInstanceOf(Result.Success::class.java)
+            assertThat(sentAcceptValues).contains("*/*")
+        }
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
@@ -48,7 +48,7 @@ class FeatureDecisionMatrixTest {
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
                 assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }
@@ -74,7 +74,7 @@ class FeatureDecisionMatrixTest {
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
                 assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }
@@ -126,7 +126,7 @@ class FeatureDecisionMatrixTest {
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
                 assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }
@@ -152,7 +152,7 @@ class FeatureDecisionMatrixTest {
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
                 assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.NO_EXAMPLES)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
@@ -12,7 +12,7 @@ import io.specmatic.test.ContractTest
 import io.specmatic.test.ScenarioAsTest
 import io.specmatic.test.TestExecutionReason
 import io.specmatic.test.TestExecutor
-import io.specmatic.test.TestRuleViolations
+import io.specmatic.test.TestSkipReason
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -47,8 +47,8 @@ class FeatureDecisionMatrixTest {
             val badRequest = generated.filter { it.context.isA4xxScenario() }
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
-                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestSkipReason.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }
@@ -73,8 +73,8 @@ class FeatureDecisionMatrixTest {
             val badRequest = generated.filter { it.context.isA4xxScenario() }
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
-                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestSkipReason.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }
@@ -125,8 +125,8 @@ class FeatureDecisionMatrixTest {
             val badRequest = generated.filter { it.context.isA4xxScenario() }
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
-                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestSkipReason.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }
@@ -151,8 +151,8 @@ class FeatureDecisionMatrixTest {
             val badRequest = generated.filter { it.context.isA4xxScenario() }
             assertThat(badRequest).hasSize(1).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java)
-                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-                assertThat(it.reasoning.otherReasons).containsExactly(TestRuleViolations.EXAMPLES_REQUIRED)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestSkipReason.EXAMPLES_REQUIRED)
             }
 
             val successRequest = generated.filter { it.context.isA2xxScenario() }
@@ -181,7 +181,7 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generated).hasSize(1)
             val skip = generated.single() as Decision.Skip
-            assertThat(skip.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamples2xxAnd400(true))
+            assertThat(skip.reasoning.mainReason).isEqualTo(TestSkipReason.noExamples2xxAnd400(true))
             assertThat(skip.reasoning.otherReasons).isEmpty()
         }
 
@@ -196,8 +196,8 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generated).hasSize(1)
             val skip = generated.single() as Decision.Skip<*>
-            assertThat(skip.reasoning.mainReason).isEqualTo(TestRuleViolations.GENERATIVE_DISABLED)
-            assertThat(skip.reasoning.otherReasons).containsExactly(TestRuleViolations.noExamples2xxAnd400(true))
+            assertThat(skip.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+            assertThat(skip.reasoning.otherReasons).containsExactly(TestSkipReason.noExamples2xxAnd400(true))
         }
 
         @Test
@@ -212,7 +212,7 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generated).hasSize(2).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
-                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamplesNon2xxAndNon400())
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.noExamplesNon2xxAndNon400())
                 assertThat(it.reasoning.otherReasons).isEmpty()
             }
         }
@@ -310,7 +310,7 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generated).hasSize(2).allSatisfy {
                 assertThat(it).isInstanceOf(Decision.Skip::class.java); it as Decision.Skip
-                assertThat(it.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamplesNon2xxAndNon400())
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.noExamplesNon2xxAndNon400())
                 assertThat(it.reasoning.otherReasons).isEmpty()
             }
         }
@@ -345,7 +345,7 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generated).hasSize(1)
             val decision = generated.filterIsInstance<Decision.Skip<Scenario>>().single()
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamples2xxAnd400(true))
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.noExamples2xxAnd400(true))
             assertThat(decision.reasoning.otherReasons).isEmpty()
         }
 
@@ -424,7 +424,7 @@ class FeatureDecisionMatrixTest {
 
             val skip = generated.filterIsInstance<Decision.Skip<Scenario>>().single()
             assertThat(skip.context.httpRequestPattern.headersPattern.pattern.getValue(ACCEPT)).isEqualTo(ExactValuePattern(StringValue("application/xml")))
-            assertThat(skip.reasoning).isEqualTo(Reasoning(mainReason = TestRuleViolations.ACCEPT_MISMATCH))
+            assertThat(skip.reasoning).isEqualTo(Reasoning(mainReason = TestSkipReason.ACCEPT_MISMATCH))
         }
 
         @Test
@@ -449,7 +449,7 @@ class FeatureDecisionMatrixTest {
 
             assertThat(generated).hasSize(1)
             val skip = generated.single() as Decision.Skip
-            assertThat(skip.reasoning.mainReason).isEqualTo(TestRuleViolations.ACCEPT_MISMATCH)
+            assertThat(skip.reasoning.mainReason).isEqualTo(TestSkipReason.ACCEPT_MISMATCH)
             assertThat(skip.reasoning.otherReasons).isEmpty()
         }
 

--- a/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureDecisionMatrixTest.kt
@@ -166,6 +166,44 @@ class FeatureDecisionMatrixTest {
             assertThat(positiveGeneration.reasoning.mainReason).isEqualTo(TestExecutionReason.POSITIVE_GENERATION_ENABLED)
             assertThat(positiveGeneration.reasoning.otherReasons).containsExactly(TestExecutionReason.HAS_EXAMPLE)
         }
+
+        @Test
+        fun `should not duplicate 4xx strict mode example required with the amount of 2xx scenarios`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").copy(strictMode = true)
+            val scenario200 = firstScenario(feature, 200, hasExamples = false)
+            val scenario400 = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario200, scenario200, scenario400),
+                scenarios = sequenceOf(Decision.execute(scenario200), Decision.execute(scenario200), Decision.execute(scenario400))
+            ).toList()
+
+            assertThat(generated).hasSize(3)
+            val badRequest = generated.filter { it.context.isA4xxScenario() }
+            assertThat(badRequest).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+                assertThat(it.reasoning.otherReasons).containsExactly(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
+            }
+        }
+
+        @Test
+        fun `should not duplicate 4xx strict mode example required with the amount of 2xx scenarios with resiliency`() {
+            val feature = featureFromResourceOpenapi("feature_decision_matrix.yaml").copy(strictMode = true).enableGenerativeTesting()
+            val scenario200 = firstScenario(feature, 200, hasExamples = false)
+            val scenario400 = firstScenario(feature, 400, hasExamples = false)
+            val generated = feature.generateContractTestScenariosWithDecision(
+                originalScenarios = listOf(scenario200, scenario200, scenario400),
+                scenarios = sequenceOf(Decision.execute(scenario200), Decision.execute(scenario200), Decision.execute(scenario400))
+            ).toList()
+
+            assertThat(generated).hasSize(3)
+            val badRequest = generated.filter { it.context.isA4xxScenario() }
+            assertThat(badRequest).hasSize(1).allSatisfy {
+                assertThat(it).isInstanceOf(Decision.Skip::class.java)
+                assertThat(it.reasoning.mainReason).isEqualTo(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
+                assertThat(it.reasoning.otherReasons).isEmpty()
+            }
+        }
     }
 
     @Nested
@@ -343,10 +381,7 @@ class FeatureDecisionMatrixTest {
                 originalScenarios = listOf(scenario)
             ).toList()
 
-            assertThat(generated).hasSize(1)
-            val decision = generated.filterIsInstance<Decision.Skip<Scenario>>().single()
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.noExamples2xxAnd400(true))
-            assertThat(decision.reasoning.otherReasons).isEmpty()
+            assertThat(generated).hasSize(0)
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -4433,4 +4433,99 @@ paths:
             }
         }
     }
+
+    @Test
+    fun `scenarioAssociatedTo should choose scenario by response content type`() {
+        val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/products"))
+        val jsonScenario = Scenario(
+            name = "json response",
+            httpRequestPattern = requestPattern,
+            httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json")),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val xmlScenario = Scenario(
+            name = "xml response",
+            httpRequestPattern = requestPattern,
+            httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/xml")),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val feature = Feature(scenarios = listOf(jsonScenario, xmlScenario), name = "content type lookup", protocol = SpecmaticProtocol.HTTP)
+        val matchingScenario = feature.scenarioAssociatedTo(method = "GET", path = "/products", responseStatusCode = 200, resContentType = "application/xml")
+        assertThat(matchingScenario).isEqualTo(xmlScenario)
+    }
+
+    @Test
+    fun `scenarioAssociatedTo should not match null response content type when response content type is provided`() {
+        val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/products"))
+        val noResponseContentTypeScenario = Scenario(
+            name = "no response content type",
+            httpRequestPattern = requestPattern,
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val xmlScenario = Scenario(
+            name = "xml response",
+            httpRequestPattern = requestPattern,
+            httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/xml")),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val feature = Feature(scenarios = listOf(noResponseContentTypeScenario, xmlScenario), name = "response content type lookup", protocol = SpecmaticProtocol.HTTP)
+        val matchingScenario = feature.scenarioAssociatedTo(method = "GET", path = "/products", responseStatusCode = 200, resContentType = "application/xml")
+        assertThat(matchingScenario).isEqualTo(xmlScenario)
+    }
+
+    @Test
+    fun `scenarioAssociatedTo should not match null request content type when request content type is provided`() {
+        val noRequestContentTypeScenario = Scenario(
+            name = "no request content type",
+            httpRequestPattern = HttpRequestPattern(method = "POST", httpPathPattern = buildHttpPathPattern("/products")),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val jsonRequestScenario = Scenario(
+            name = "json request content type",
+            httpRequestPattern = HttpRequestPattern(
+                method = "POST",
+                httpPathPattern = buildHttpPathPattern("/products"),
+                headersPattern = HttpHeadersPattern(contentType = "application/json")
+            ),
+            httpResponsePattern = HttpResponsePattern(status = 200),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val feature = Feature(scenarios = listOf(noRequestContentTypeScenario, jsonRequestScenario), name = "request content type lookup", protocol = SpecmaticProtocol.HTTP)
+        val matchingScenario = feature.scenarioAssociatedTo(method = "POST", path = "/products", responseStatusCode = 200, reqContentType = "application/json")
+        assertThat(matchingScenario).isEqualTo(jsonRequestScenario)
+    }
+
+    @Test
+    fun `identifierMatchingScenario with request and response should choose scenario by response status and content type`() {
+        val requestPattern = HttpRequestPattern(method = "GET", httpPathPattern = buildHttpPathPattern("/products"))
+        val createdScenario = Scenario(
+            name = "created",
+            httpRequestPattern = requestPattern,
+            httpResponsePattern = HttpResponsePattern(status = 201, headersPattern = HttpHeadersPattern(contentType = "application/json")),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val okScenario = Scenario(
+            name = "ok",
+            httpRequestPattern = requestPattern,
+            httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/xml")),
+            protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI
+        )
+
+        val feature = Feature(scenarios = listOf(createdScenario, okScenario), name = "identifier with response", protocol = SpecmaticProtocol.HTTP)
+        val matchedScenario = feature.identifierMatchingScenario(
+            httpRequest = HttpRequest(method = "GET", path = "/products"),
+            httpResponse = HttpResponse(status = 200, headers = mapOf("Content-Type" to "application/xml"))
+        )
+
+        assertThat(matchedScenario).isEqualTo(okScenario)
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpResponsePatternTest.kt
@@ -129,6 +129,52 @@ internal class HttpResponsePatternTest {
         assertThat(response.body).isEqualTo(NoBodyValue)
     }
 
+    @Test
+    fun `matchesStatusAndContentType should succeed when status and content type both match`() {
+        val pattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json"))
+        val result = pattern.matchesStatusAndContentType(
+            httpResponse = HttpResponse(status = 200, headers = mapOf("Content-Type" to "application/json")),
+            resolver = Resolver()
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `matchesStatusAndContentType should succeed when status and simplified content type both match`() {
+        val pattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json"))
+        val result = pattern.matchesStatusAndContentType(
+            httpResponse = HttpResponse(status = 200, headers = mapOf("Content-Type" to "application/json; charset=utf-8")),
+            resolver = Resolver()
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `matchesStatusAndContentType should fail with response breadcrumb when content type mismatches`() {
+        val pattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json"))
+        val result = pattern.matchesStatusAndContentType(
+            httpResponse = HttpResponse(status = 200, headers = mapOf("Content-Type" to "application/xml")),
+            resolver = Resolver()
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains(">> RESPONSE.HEADER.Content-Type")
+    }
+
+    @Test
+    fun `matchesStatusAndContentType should fail with status breadcrumb when status mismatches`() {
+        val pattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = "application/json"))
+        val result = pattern.matchesStatusAndContentType(
+            httpResponse = HttpResponse(status = 201, headers = mapOf("Content-Type" to "application/json")),
+            resolver = Resolver()
+        )
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains(">> RESPONSE.STATUS")
+    }
+
     @Nested
     inner class GenerateResponseV2Tests {
 

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioSOAPActionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioSOAPActionTest.kt
@@ -156,6 +156,6 @@ class ScenarioSOAPActionTest {
         
         // Test that the test description includes SOAPAction
         val testDescription = scenario.testDescription()
-        assertThat(testDescription).isEqualTo(" Scenario: POST /soap/service SOAPAction http://example.com/soap/action -> 200")
+        assertThat(testDescription).isEqualTo("Scenario: POST /soap/service SOAPAction http://example.com/soap/action -> 200")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.function.Consumer
 import java.util.stream.Stream
 import io.specmatic.test.TestExecutionReason
-import io.specmatic.test.TestRuleViolations
+import io.specmatic.test.TestSkipReason
 
 class ScenarioTest {
 
@@ -1114,7 +1114,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = original,
-                    reasoning = Reasoning(mainReason = TestRuleViolations.GENERATIVE_DISABLED, otherReasons = listOf(TestRuleViolations.EXAMPLES_REQUIRED))
+                    reasoning = Reasoning(mainReason = TestSkipReason.GENERATIVE_DISABLED, otherReasons = listOf(TestSkipReason.EXAMPLES_REQUIRED))
                 )
             )
         }
@@ -1133,7 +1133,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = original,
-                    reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)
+                    reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED)
                 )
             )
         }
@@ -1171,7 +1171,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = original,
-                    reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
+                    reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
                 )
             )
         }
@@ -1253,7 +1253,7 @@ class ScenarioTest {
             val original = scenarioForNegativeBasedOnWithDecision(status = 200)
             val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = null, strictMode = true)
             assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamples2xxAnd400(true))
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.noExamples2xxAnd400(true))
             assertThat(decision.reasoning.otherReasons).isEmpty()
         }
 
@@ -1278,7 +1278,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = scenarioForNegativeBasedOnWithDecision(status = 400),
-                    reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
+                    reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
                 )
             )
         }
@@ -1292,7 +1292,7 @@ class ScenarioTest {
             assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
             assertThat(decision.context.httpResponsePattern.status).isEqualTo(401)
             assertThat(decision.context.statusInDescription).isEqualTo("401")
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
         }
 
         @Test
@@ -1304,7 +1304,7 @@ class ScenarioTest {
             assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
             assertThat(decision.context.httpResponsePattern.status).isEqualTo(DEFAULT_RESPONSE_CODE)
             assertThat(decision.context.statusInDescription).isEqualTo(DEFAULT_RESPONSE_CODE.toString())
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -1121,15 +1121,10 @@ class ScenarioTest {
         }
 
         @Test
-        fun `newBasedOnWithDecision should skip bad request scenarios without examples when resiliency suite is all`() {
+        fun `newBasedOnWithDecision should return null for bad request scenarios without examples when resiliency suite is all`() {
             val original = scenarioForNewBasedOnWithDecision(status = 400)
             val decision = original.newBasedOnWithDecision(strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.all)
-            assertThat(decision).isEqualTo(
-                Decision.Skip(
-                    context = original,
-                    reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
-                )
-            )
+            assertThat(decision).isEqualTo(null)
         }
 
         @Test
@@ -1199,6 +1194,50 @@ class ScenarioTest {
             status = status,
             examples = listOf(Examples(listOf("id"), listOf(Row(mapOf("id" to "123")))))
         )
+    }
+
+    @Nested
+    inner class FullApiDescriptionTests {
+        @Test
+        fun `fullApiDescription should return base description when no content types are declared`() {
+            val scenario = scenarioForFullApiDescription()
+            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201")
+        }
+
+        @Test
+        fun `fullApiDescription should include request content type only`() {
+            val scenario = scenarioForFullApiDescription(requestContentType = "application/json")
+            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (accepts application/json)")
+        }
+
+        @Test
+        fun `fullApiDescription should include response content type only`() {
+            val scenario = scenarioForFullApiDescription(responseContentType = "application/xml")
+            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (returns application/xml)")
+        }
+
+        @Test
+        fun `fullApiDescription should include request and response content types`() {
+            val scenario = scenarioForFullApiDescription(requestContentType = "application/json", responseContentType = "application/xml")
+            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (accepts application/json, returns application/xml)")
+        }
+
+        @Test
+        fun `fullApiDescription should prefer custom api description`() {
+            val scenario = scenarioForFullApiDescription(requestContentType = "application/json", responseContentType = "application/xml", customAPIDescription = "Create product")
+            assertThat(scenario.fullApiDescription).startsWith("Create product")
+        }
+
+        private fun scenarioForFullApiDescription(requestContentType: String? = null, responseContentType: String? = null, customAPIDescription: String? = null, ): Scenario {
+            return Scenario(
+                name = "content-types",
+                specType = SpecType.OPENAPI,
+                protocol = SpecmaticProtocol.HTTP,
+                customAPIDescription = customAPIDescription,
+                httpRequestPattern = HttpRequestPattern(method = "POST", httpPathPattern = buildHttpPathPattern("/products"), headersPattern = HttpHeadersPattern(contentType = requestContentType)),
+                httpResponsePattern = HttpResponsePattern(status = 201, headersPattern = HttpHeadersPattern(contentType = responseContentType)),
+            )
+        }
     }
 
     @Nested

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -1222,9 +1222,9 @@ class ScenarioTest {
         }
 
         @Test
-        fun `fullApiDescription should prefer custom api description`() {
+        fun `fullApiDescription should prefer custom api description but include contentDescription`() {
             val scenario = scenarioForFullApiDescription(requestContentType = "application/json", responseContentType = "application/xml", customAPIDescription = "Create product")
-            assertThat(scenario.fullApiDescription).startsWith("Create product")
+            assertThat(scenario.fullApiDescription).startsWith("Create product").contains("accepts application/json").contains("returns application/xml")
         }
 
         private fun scenarioForFullApiDescription(requestContentType: String? = null, responseContentType: String? = null, customAPIDescription: String? = null, ): Scenario {

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -31,6 +31,7 @@ import java.util.function.Consumer
 import java.util.stream.Stream
 import io.specmatic.test.TestExecutionReason
 import io.specmatic.test.TestSkipReason
+import org.assertj.core.api.Assertions.assertThat
 
 class ScenarioTest {
 
@@ -1176,6 +1177,26 @@ class ScenarioTest {
             )
         }
 
+        @Test
+        fun `negativeBasedOnWithDecision should return examples required in strict mode for 400 response when resiliency is enabled`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 400)
+            val decision = original.newBasedOnWithDecision(strictMode = true, resiliencyTestSuite = ResiliencyTestSuite.all)
+
+            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
+            assertThat(decision.reasoning.otherReasons).isEmpty()
+        }
+
+        @Test
+        fun `negativeBasedOnWithDecision should return examples required in strict mode and resiliency disabled for 400 response`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 400)
+            val decision = original.newBasedOnWithDecision(strictMode = true, resiliencyTestSuite = ResiliencyTestSuite.none)
+
+            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.GENERATIVE_DISABLED)
+            assertThat(decision.reasoning.otherReasons).containsExactlyInAnyOrder(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
+        }
+
         private fun scenarioForNewBasedOnWithDecision(name: String = "scenario-name", method: String = "GET", status: Int = 200, examples: List<Examples> = emptyList(), isGherkinScenario: Boolean = false): Scenario {
             return Scenario(
                 name = name,
@@ -1206,25 +1227,25 @@ class ScenarioTest {
         @Test
         fun `fullApiDescription should include request content type only`() {
             val scenario = scenarioForFullApiDescription(requestContentType = "application/json")
-            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (accepts application/json)")
+            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (requestContentType application/json)")
         }
 
         @Test
         fun `fullApiDescription should include response content type only`() {
             val scenario = scenarioForFullApiDescription(responseContentType = "application/xml")
-            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (returns application/xml)")
+            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (responseContentType application/xml)")
         }
 
         @Test
         fun `fullApiDescription should include request and response content types`() {
             val scenario = scenarioForFullApiDescription(requestContentType = "application/json", responseContentType = "application/xml")
-            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (accepts application/json, returns application/xml)")
+            assertThat(scenario.fullApiDescription).isEqualTo("POST /products -> 201 (requestContentType application/json, responseContentType application/xml)")
         }
 
         @Test
         fun `fullApiDescription should prefer custom api description but include contentDescription`() {
             val scenario = scenarioForFullApiDescription(requestContentType = "application/json", responseContentType = "application/xml", customAPIDescription = "Create product")
-            assertThat(scenario.fullApiDescription).startsWith("Create product").contains("accepts application/json").contains("returns application/xml")
+            assertThat(scenario.fullApiDescription).startsWith("Create product").contains("requestContentType application/json").contains("responseContentType application/xml")
         }
 
         private fun scenarioForFullApiDescription(requestContentType: String? = null, responseContentType: String? = null, customAPIDescription: String? = null, ): Scenario {
@@ -1249,12 +1270,10 @@ class ScenarioTest {
         }
 
         @Test
-        fun `negativeBasedOnWithDecision should return modified skip 400 for 2xx scenarios without examples in strict mode`() {
+        fun `negativeBasedOnWithDecision should return null for 2xx scenarios without examples in strict mode`() {
             val original = scenarioForNegativeBasedOnWithDecision(status = 200)
             val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = null, strictMode = true)
-            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.noExamples2xxAnd400(true))
-            assertThat(decision.reasoning.otherReasons).isEmpty()
+            assertThat(decision).isNull()
         }
 
         @Test
@@ -1268,43 +1287,6 @@ class ScenarioTest {
                     reasoning = Reasoning(mainReason = TestExecutionReason.NEGATIVE_GENERATION_ENABLED)
                 )
             )
-        }
-
-        @Test
-        fun `negativeBasedOnWithDecision should return skip for 2xx scenarios that have no examples`() {
-            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
-            val badRequestOrDefault = BadRequestOrDefault(mapOf(400 to scenarioForNegativeBasedOnWithDecision(status = 400)), null)
-            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = badRequestOrDefault, strictMode = true)
-            assertThat(decision).isEqualTo(
-                Decision.Skip(
-                    context = scenarioForNegativeBasedOnWithDecision(status = 400),
-                    reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
-                )
-            )
-        }
-
-        @Test
-        fun `negativeBasedOnWithDecision should use the explicit bad request status in the skip context`() {
-            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
-            val badRequestOrDefault = BadRequestOrDefault(mapOf(401 to scenarioForNegativeBasedOnWithDecision(status = 401)), null)
-            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = badRequestOrDefault, strictMode = true)
-
-            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
-            assertThat(decision.context.httpResponsePattern.status).isEqualTo(401)
-            assertThat(decision.context.statusInDescription).isEqualTo("401")
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
-        }
-
-        @Test
-        fun `negativeBasedOnWithDecision should use the default bad request status in the skip context`() {
-            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
-            val badRequestOrDefault = BadRequestOrDefault(emptyMap(), scenarioForNegativeBasedOnWithDecision(status = DEFAULT_RESPONSE_CODE))
-            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = badRequestOrDefault, strictMode = true)
-
-            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
-            assertThat(decision.context.httpResponsePattern.status).isEqualTo(DEFAULT_RESPONSE_CODE)
-            assertThat(decision.context.statusInDescription).isEqualTo(DEFAULT_RESPONSE_CODE.toString())
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestSkipReason.EXAMPLES_REQUIRED_STRICT_MODE)
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.core
 
 import com.ezylang.evalex.Expression
 import com.ezylang.evalex.config.ExpressionConfiguration
+import io.ktor.http.HttpStatusCode
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.conversions.*
@@ -9,6 +10,8 @@ import io.specmatic.core.filters.HttpFilterContext
 import io.specmatic.core.filters.ScenarioFilterVariablePopulator
 import io.specmatic.core.pattern.*
 import io.specmatic.core.utilities.Flags
+import io.specmatic.core.utilities.Decision
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.core.value.JSONArrayValue
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.core.value.NumberValue
@@ -27,6 +30,8 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.function.Consumer
 import java.util.stream.Stream
+import io.specmatic.test.TestExecutionReason
+import io.specmatic.test.TestRuleViolations
 
 class ScenarioTest {
 
@@ -1048,6 +1053,206 @@ class ScenarioTest {
             val paths = scenario.calculatePath(httpRequest)
 
             assertThat(paths).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class NewBasedOnWithDecisionTests {
+        @Test
+        fun `newBasedOnWithDecision should execute using matching suggestion and keep original context`() {
+            val original = exampleScenarioForNewBasedOnWithDecision(name = "original")
+            val suggested = exampleScenarioForNewBasedOnWithDecision(name = "original").copy(
+                examples = listOf(Examples(listOf("id"), listOf(Row(mapOf("id" to "456"))))),
+                references = emptyMap()
+            )
+
+            val decision = original.newBasedOnWithDecision(suggestions = listOf(suggested), strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.all)
+            assertThat(decision).isEqualTo(
+                Decision.Execute(
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestExecutionReason.HAS_EXAMPLE),
+                    value = original.copy(examples = suggested.examples, references = suggested.references),
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should execute using self when no matching suggestion exists`() {
+            val original = exampleScenarioForNewBasedOnWithDecision(name = "original")
+            val unrelatedSuggestion = exampleScenarioForNewBasedOnWithDecision(name = "other")
+            val decision = original.newBasedOnWithDecision(
+                strictMode = false,
+                suggestions = listOf(unrelatedSuggestion),
+                resiliencyTestSuite = ResiliencyTestSuite.all
+            )
+
+            assertThat(decision).isEqualTo(
+                Decision.Execute(
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestExecutionReason.HAS_EXAMPLE),
+                    value = original.copy(examples = original.examples, references = original.references),
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should execute with no example reasoning when scenario has no examples`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 200)
+            val decision = original.newBasedOnWithDecision(strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.all)
+            assertThat(decision).isEqualTo(
+                Decision.Execute(
+                    value = original,
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestExecutionReason.NO_EXAMPLE)
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should skip bad request scenarios without examples when resiliency suite is not all`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 400)
+            val decision = original.newBasedOnWithDecision(strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.positiveOnly)
+            assertThat(decision).isEqualTo(
+                Decision.Skip(
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestRuleViolations.GENERATIVE_DISABLED, otherReasons = listOf(TestRuleViolations.NO_EXAMPLES))
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should skip bad request scenarios without examples when resiliency suite is all`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 400)
+            val decision = original.newBasedOnWithDecision(strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.all)
+            assertThat(decision).isEqualTo(
+                Decision.Skip(
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should skip non 2xx and non 400 scenarios without examples with no examples reasoning`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 500)
+            val decision = original.newBasedOnWithDecision(strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.all)
+            assertThat(decision).isEqualTo(
+                Decision.Skip(
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should execute bad request scenarios with examples`() {
+            val original = exampleScenarioForNewBasedOnWithDecision(status = 400)
+            val decision = original.newBasedOnWithDecision(strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.positiveOnly)
+            assertThat(decision).isEqualTo(
+                Decision.Execute(
+                    value = original,
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestExecutionReason.HAS_EXAMPLE)
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should execute gherkin scenarios without examples even when status is non 2xx`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 500, isGherkinScenario = true)
+            val decision = original.newBasedOnWithDecision(strictMode = false, resiliencyTestSuite = ResiliencyTestSuite.all)
+            assertThat(decision).isEqualTo(
+                Decision.Execute(
+                    value = original,
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestExecutionReason.NO_EXAMPLE)
+                )
+            )
+        }
+
+        @Test
+        fun `newBasedOnWithDecision should skip 2xx scenarios without examples in strict mode`() {
+            val original = scenarioForNewBasedOnWithDecision(status = 200)
+            val decision = original.newBasedOnWithDecision(strictMode = true, resiliencyTestSuite = ResiliencyTestSuite.all)
+            assertThat(decision).isEqualTo(
+                Decision.Skip(
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
+                )
+            )
+        }
+
+        private fun scenarioForNewBasedOnWithDecision(name: String = "scenario-name", method: String = "GET", status: Int = 200, examples: List<Examples> = emptyList(), isGherkinScenario: Boolean = false): Scenario {
+            return Scenario(
+                name = name,
+                httpRequestPattern = HttpRequestPattern(method = method),
+                httpResponsePattern = HttpResponsePattern(status = status),
+                examples = examples,
+                protocol = SpecmaticProtocol.HTTP,
+                specType = SpecType.OPENAPI,
+                isGherkinScenario = isGherkinScenario
+            )
+        }
+
+        private fun exampleScenarioForNewBasedOnWithDecision(name: String = "scenario-name", status: Int = 200) = scenarioForNewBasedOnWithDecision(
+            name = name,
+            status = status,
+            examples = listOf(Examples(listOf("id"), listOf(Row(mapOf("id" to "123")))))
+        )
+    }
+
+    @Nested
+    inner class NegativeBasedOnWithDecisionTests {
+        @Test
+        fun `negativeBasedOnWithDecision should return null for non 2xx scenarios`() {
+            val original = scenarioForNegativeBasedOnWithDecision(status = 400)
+            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = null, strictMode = false)
+            assertThat(decision).isNull()
+        }
+
+        @Test
+        fun `negativeBasedOnWithDecision should return null for 2xx scenarios without examples in strict mode`() {
+            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
+            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = null, strictMode = true)
+            assertThat(decision).isEqualTo(null)
+        }
+
+        @Test
+        fun `negativeBasedOnWithDecision should execute negative generation for 2xx scenarios`() {
+            val original = scenarioForNegativeBasedOnWithDecision(status = 200, examples = listOf(Examples(listOf("id"), listOf(Row(mapOf("id" to "123"))))))
+            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = null, strictMode = false)
+            assertThat(decision).isEqualTo(
+                Decision.Execute(
+                    value = original.negativeBasedOn(null),
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestExecutionReason.NEGATIVE_GENERATION_ENABLED)
+                )
+            )
+        }
+
+        @Test
+        fun `negativeBasedOnWithDecision should execute negative generation even without examples when strict mode is false`() {
+            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
+            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = null, strictMode = false)
+            assertThat(decision).isEqualTo(
+                Decision.Execute(
+                    value = original.negativeBasedOn(null),
+                    context = original,
+                    reasoning = Reasoning(mainReason = TestExecutionReason.NEGATIVE_GENERATION_ENABLED)
+                )
+            )
+        }
+
+        private fun scenarioForNegativeBasedOnWithDecision(name: String = "scenario-name", method: String = "GET", status: Int = 200, examples: List<Examples> = emptyList(), isGherkinScenario: Boolean = false): Scenario {
+            return Scenario(
+                name = name,
+                httpRequestPattern = HttpRequestPattern(method = method),
+                httpResponsePattern = HttpResponsePattern(status = status),
+                examples = examples,
+                protocol = SpecmaticProtocol.HTTP,
+                specType = SpecType.OPENAPI,
+                isGherkinScenario = isGherkinScenario
+            )
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -1250,10 +1250,12 @@ class ScenarioTest {
         }
 
         @Test
-        fun `negativeBasedOnWithDecision should return null for 2xx scenarios without examples in strict mode`() {
+        fun `negativeBasedOnWithDecision should return modified skip 400 for 2xx scenarios without examples in strict mode`() {
             val original = scenarioForNegativeBasedOnWithDecision(status = 200)
             val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = null, strictMode = true)
-            assertThat(decision).isEqualTo(null)
+            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.noExamples2xxAnd400(true))
+            assertThat(decision.reasoning.otherReasons).isEmpty()
         }
 
         @Test
@@ -1267,6 +1269,43 @@ class ScenarioTest {
                     reasoning = Reasoning(mainReason = TestExecutionReason.NEGATIVE_GENERATION_ENABLED)
                 )
             )
+        }
+
+        @Test
+        fun `negativeBasedOnWithDecision should return skip for 2xx scenarios that have no examples`() {
+            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
+            val badRequestOrDefault = BadRequestOrDefault(mapOf(400 to scenarioForNegativeBasedOnWithDecision(status = 400)), null)
+            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = badRequestOrDefault, strictMode = true)
+            assertThat(decision).isEqualTo(
+                Decision.Skip(
+                    context = scenarioForNegativeBasedOnWithDecision(status = 400),
+                    reasoning = Reasoning(mainReason = TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
+                )
+            )
+        }
+
+        @Test
+        fun `negativeBasedOnWithDecision should use the explicit bad request status in the skip context`() {
+            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
+            val badRequestOrDefault = BadRequestOrDefault(mapOf(401 to scenarioForNegativeBasedOnWithDecision(status = 401)), null)
+            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = badRequestOrDefault, strictMode = true)
+
+            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
+            assertThat(decision.context.httpResponsePattern.status).isEqualTo(401)
+            assertThat(decision.context.statusInDescription).isEqualTo("401")
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
+        }
+
+        @Test
+        fun `negativeBasedOnWithDecision should use the default bad request status in the skip context`() {
+            val original = scenarioForNegativeBasedOnWithDecision(status = 200)
+            val badRequestOrDefault = BadRequestOrDefault(emptyMap(), scenarioForNegativeBasedOnWithDecision(status = DEFAULT_RESPONSE_CODE))
+            val decision = original.negativeBasedOnWithDecision(badRequestOrDefault = badRequestOrDefault, strictMode = true)
+
+            assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
+            assertThat(decision.context.httpResponsePattern.status).isEqualTo(DEFAULT_RESPONSE_CODE)
+            assertThat(decision.context.statusInDescription).isEqualTo(DEFAULT_RESPONSE_CODE.toString())
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioTest.kt
@@ -2,7 +2,6 @@ package io.specmatic.core
 
 import com.ezylang.evalex.Expression
 import com.ezylang.evalex.config.ExpressionConfiguration
-import io.ktor.http.HttpStatusCode
 import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.conversions.*
@@ -1115,7 +1114,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = original,
-                    reasoning = Reasoning(mainReason = TestRuleViolations.GENERATIVE_DISABLED, otherReasons = listOf(TestRuleViolations.NO_EXAMPLES))
+                    reasoning = Reasoning(mainReason = TestRuleViolations.GENERATIVE_DISABLED, otherReasons = listOf(TestRuleViolations.EXAMPLES_REQUIRED))
                 )
             )
         }
@@ -1134,7 +1133,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = original,
-                    reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
+                    reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)
                 )
             )
         }
@@ -1172,7 +1171,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = original,
-                    reasoning = Reasoning(mainReason = TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
+                    reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
                 )
             )
         }
@@ -1279,7 +1278,7 @@ class ScenarioTest {
             assertThat(decision).isEqualTo(
                 Decision.Skip(
                     context = scenarioForNegativeBasedOnWithDecision(status = 400),
-                    reasoning = Reasoning(mainReason = TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
+                    reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
                 )
             )
         }
@@ -1293,7 +1292,7 @@ class ScenarioTest {
             assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
             assertThat(decision.context.httpResponsePattern.status).isEqualTo(401)
             assertThat(decision.context.statusInDescription).isEqualTo("401")
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
         }
 
         @Test
@@ -1305,7 +1304,7 @@ class ScenarioTest {
             assertThat(decision).isInstanceOf(Decision.Skip::class.java); decision as Decision.Skip
             assertThat(decision.context.httpResponsePattern.status).isEqualTo(DEFAULT_RESPONSE_CODE)
             assertThat(decision.context.statusInDescription).isEqualTo(DEFAULT_RESPONSE_CODE.toString())
-            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.STRICT_MODE_NO_EXAMPLES)
+            assertThat(decision.reasoning.mainReason).isEqualTo(TestRuleViolations.EXAMPLES_REQUIRED_STRICT_MODE)
         }
 
         @Test

--- a/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/examples/module/ExampleModuleTest.kt
@@ -4,6 +4,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.config.SpecmaticConfigVersion
 import io.specmatic.core.config.v3.Data
 import io.specmatic.core.config.v3.RefOrValue
@@ -21,6 +22,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.specmatic.mock.ScenarioStub
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -131,6 +133,335 @@ class ExampleModuleTest {
 
         assertThat(badRequestScenarioExamples).hasSize(4)
         assertThat(badRequestScenarioExamples.map { it.first.file }).containsExactlyInAnyOrderElementsOf(badRequestExamples)
+    }
+
+    @Nested
+    inner class GetExistingExampleFilesDisambiguationTest {
+        @Test
+        fun `get existing examples should treat response content type as scenario-disambiguating`(@TempDir tempDir: File) {
+            val openApiSpec = """
+            openapi: 3.0.3
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: string
+                        text/plain:
+                          schema:
+                            type: string
+            """.trimIndent()
+            val feature = OpenApiSpecification.fromYAML(openApiSpec, "api.yaml").toFeature()
+            val examplesDir = File(tempDir, "api_examples").apply { mkdirs() }
+
+            val jsonExampleFile = examplesDir.resolve("json-response.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/hello"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "application/json"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val textExampleFile = examplesDir.resolve("text-response.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/hello"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val allExamples = exampleModule.getExamplesFromDir(examplesDir)
+            val jsonScenario = feature.scenarios.first { it.status == 200 && it.responseContentType == "application/json" }
+            val jsonScenarioExamples = exampleModule.getExistingExampleFiles(feature, jsonScenario, allExamples)
+            assertThat(jsonScenarioExamples.map { it.first.file }).containsExactly(jsonExampleFile)
+
+            val textScenario = feature.scenarios.first { it.status == 200 && it.responseContentType == "text/plain" }
+            val textScenarioExamples = exampleModule.getExistingExampleFiles(feature, textScenario, allExamples)
+            assertThat(textScenarioExamples.map { it.first.file }).containsExactly(textExampleFile)
+        }
+
+        @Test
+        fun `get existing examples should treat request content type as scenario-disambiguating`(@TempDir tempDir: File) {
+            val openApiSpec = """
+            openapi: 3.0.3
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /hello:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                      text/plain:
+                        schema:
+                          type: string
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            """.trimIndent()
+            val feature = OpenApiSpecification.fromYAML(openApiSpec, "api.yaml").toFeature()
+            val examplesDir = File(tempDir, "api_examples").apply { mkdirs() }
+
+            val jsonExampleFile = examplesDir.resolve("json-request.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("POST", "/hello", headers = mapOf(CONTENT_TYPE to "application/json")),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val textExampleFile = examplesDir.resolve("text-request.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("POST", "/hello", headers = mapOf(CONTENT_TYPE to "text/plain")),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val allExamples = exampleModule.getExamplesFromDir(examplesDir)
+            val jsonScenario = feature.scenarios.first { it.method == "POST" && it.path == "/hello" && it.requestContentType == "application/json" }
+            val jsonScenarioExamples = exampleModule.getExistingExampleFiles(feature, jsonScenario, allExamples)
+            assertThat(jsonScenarioExamples.map { it.first.file }).containsExactly(jsonExampleFile)
+
+            val textScenario = feature.scenarios.first { it.method == "POST" && it.path == "/hello" && it.requestContentType == "text/plain" }
+            val textScenarioExamples = exampleModule.getExistingExampleFiles(feature, textScenario, allExamples)
+            assertThat(textScenarioExamples.map { it.first.file }).containsExactly(textExampleFile)
+        }
+
+        @Test
+        fun `get existing examples should treat method as scenario-disambiguating`(@TempDir tempDir: File) {
+            val openApiSpec = """
+            openapi: 3.0.3
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                post:
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            """.trimIndent()
+            val feature = OpenApiSpecification.fromYAML(openApiSpec, "api.yaml").toFeature()
+            val examplesDir = File(tempDir, "api_examples").apply { mkdirs() }
+
+            val getExampleFile = examplesDir.resolve("get-example.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/hello"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val postExampleFile = examplesDir.resolve("post-example.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("POST", "/hello"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val allExamples = exampleModule.getExamplesFromDir(examplesDir)
+            val getScenario = feature.scenarios.first { it.method == "GET" && it.path == "/hello" && it.status == 200 }
+            val getScenarioExamples = exampleModule.getExistingExampleFiles(feature, getScenario, allExamples)
+            assertThat(getScenarioExamples.map { it.first.file }).containsExactly(getExampleFile)
+
+            val postScenario = feature.scenarios.first { it.method == "POST" && it.path == "/hello" && it.status == 200 }
+            val postScenarioExamples = exampleModule.getExistingExampleFiles(feature, postScenario, allExamples)
+            assertThat(postScenarioExamples.map { it.first.file }).containsExactly(postExampleFile)
+        }
+
+        @Test
+        fun `get existing examples should treat path as scenario-disambiguating`(@TempDir tempDir: File) {
+            val openApiSpec = """
+            openapi: 3.0.3
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+              /customers:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            """.trimIndent()
+            val feature = OpenApiSpecification.fromYAML(openApiSpec, "api.yaml").toFeature()
+            val examplesDir = File(tempDir, "api_examples").apply { mkdirs() }
+
+            val ordersExampleFile = examplesDir.resolve("orders-example.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/orders"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val customersExampleFile = examplesDir.resolve("customers-example.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/customers"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val allExamples = exampleModule.getExamplesFromDir(examplesDir)
+            val ordersScenario = feature.scenarios.first { it.method == "GET" && it.path == "/orders" && it.status == 200 }
+            val ordersScenarioExamples = exampleModule.getExistingExampleFiles(feature, ordersScenario, allExamples)
+            assertThat(ordersScenarioExamples.map { it.first.file }).containsExactly(ordersExampleFile)
+
+            val customersScenario = feature.scenarios.first { it.method == "GET" && it.path == "/customers" && it.status == 200 }
+            val customersScenarioExamples = exampleModule.getExistingExampleFiles(feature, customersScenario, allExamples)
+            assertThat(customersScenarioExamples.map { it.first.file }).containsExactly(customersExampleFile)
+        }
+
+        @Test
+        fun `get existing examples should treat status as scenario-disambiguating`(@TempDir tempDir: File) {
+            val openApiSpec = """
+            openapi: 3.0.3
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '400':
+                      description: bad request
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            """.trimIndent()
+            val feature = OpenApiSpecification.fromYAML(openApiSpec, "api.yaml").toFeature()
+            val examplesDir = File(tempDir, "api_examples").apply { mkdirs() }
+
+            val okExampleFile = examplesDir.resolve("ok-example.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/hello"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val badRequestExampleFile = examplesDir.resolve("bad-request-example.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/hello"),
+                        response = HttpResponse(status = 400, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val allExamples = exampleModule.getExamplesFromDir(examplesDir)
+            val okScenario = feature.scenarios.first { it.method == "GET" && it.path == "/hello" && it.status == 200 }
+            val okScenarioExamples = exampleModule.getExistingExampleFiles(feature, okScenario, allExamples)
+            assertThat(okScenarioExamples.map { it.first.file }).containsExactly(okExampleFile)
+
+            val badRequestScenario = feature.scenarios.first { it.method == "GET" && it.path == "/hello" && it.status == 400 }
+            val badRequestScenarioExamples = exampleModule.getExistingExampleFiles(feature, badRequestScenario, allExamples)
+            assertThat(badRequestScenarioExamples.map { it.first.file }).containsExactly(badRequestExampleFile)
+        }
+
+        @Test
+        fun `get existing examples should retain url path param mismatch when structure matches`(@TempDir tempDir: File) {
+            val openApiSpec = """
+            openapi: 3.0.3
+            info:
+              title: Sample API
+              version: 1.0.0
+            paths:
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        type: integer
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+            """.trimIndent()
+            val feature = OpenApiSpecification.fromYAML(openApiSpec, "api.yaml").toFeature()
+            val scenario = feature.scenarios.first { it.method == "GET" && it.status == 200 }
+            val examplesDir = File(tempDir, "api_examples").apply { mkdirs() }
+            val mismatchedExampleFile = examplesDir.resolve("path-param-type-mismatch.json").apply {
+                writeText(
+                    ScenarioStub(
+                        request = HttpRequest("GET", "/orders/abc"),
+                        response = HttpResponse(status = 200, headers = mapOf(CONTENT_TYPE to "text/plain"))
+                    ).toJSON().toStringLiteral()
+                )
+            }
+
+            val allExamples = exampleModule.getExamplesFromDir(examplesDir)
+            val matchedExamples = exampleModule.getExistingExampleFiles(feature, scenario, allExamples)
+            assertThat(matchedExamples.map { it.first.file }).containsExactly(mismatchedExampleFile)
+        }
     }
 
     private fun ScenarioStub.toExamples(examplesDir: File): List<File> {

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -1,0 +1,49 @@
+package io.specmatic.core.filters
+
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.core.Scenario
+import io.specmatic.core.utilities.Decision
+import io.specmatic.core.utilities.Reasoning
+import io.specmatic.test.TestRuleViolations
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScenarioMetadataFilterTest {
+    private data class FakeMetadata(private val scenario: Scenario) : HasScenarioMetadata {
+        override fun toScenarioMetadata(): ExpressionContextPopulator = ScenarioFilterVariablePopulator(scenario)
+    }
+
+    private fun scenario(method: String = "GET", path: String = "/pets", status: Int = 200): Scenario {
+        val scenario = mockk<Scenario>()
+        every { scenario.method } returns method
+        every { scenario.path } returns path
+        every { scenario.status } returns status
+        return scenario
+    }
+
+    @Test
+    fun `filterUsingDecisions should keep matching execute decisions unchanged`() {
+        val filter = ScenarioMetadataFilter.from("METHOD='GET'")
+        val scenario = scenario()
+        val decisions = sequenceOf(Decision.Execute(FakeMetadata(scenario), context = "kept"))
+        val filtered = ScenarioMetadataFilter.filterUsingDecisions(decisions, filter).toList()
+        assertThat(filtered).containsExactly(Decision.Execute(FakeMetadata(scenario), context = "kept"))
+    }
+
+    @Test
+    fun `filterUsingDecisions should convert non matching execute decisions to excluded skips`() {
+        val filter = ScenarioMetadataFilter.from("METHOD='POST'")
+        val decisions = sequenceOf(Decision.Execute(FakeMetadata(scenario()), context = "original-context"))
+        val filtered = ScenarioMetadataFilter.filterUsingDecisions(decisions, filter).toList()
+        assertThat(filtered).containsExactly(Decision.Skip(context = "original-context", reasoning = Reasoning(mainReason = TestRuleViolations.EXCLUDED)))
+    }
+
+    @Test
+    fun `filterUsingDecisions should preserve existing skip decisions`() {
+        val filter = ScenarioMetadataFilter.from("METHOD='POST'")
+        val originalSkip = Decision.Skip(context = "already-skipped", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val filtered = ScenarioMetadataFilter.filterUsingDecisions(sequenceOf(originalSkip), filter).toList()
+        assertThat(filtered).containsExactly(originalSkip)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -42,7 +42,7 @@ class ScenarioMetadataFilterTest {
     @Test
     fun `filterUsingDecisions should preserve existing skip decisions`() {
         val filter = ScenarioMetadataFilter.from("METHOD='POST'")
-        val originalSkip = Decision.Skip(context = "already-skipped", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val originalSkip = Decision.Skip(context = "already-skipped", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         val filtered = ScenarioMetadataFilter.filterUsingDecisions(sequenceOf(originalSkip), filter).toList()
         assertThat(filtered).containsExactly(originalSkip)
     }

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import io.specmatic.core.Scenario
 import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Reasoning
-import io.specmatic.test.TestRuleViolations
+import io.specmatic.test.TestSkipReason
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -36,13 +36,13 @@ class ScenarioMetadataFilterTest {
         val filter = ScenarioMetadataFilter.from("METHOD='POST'")
         val decisions = sequenceOf(Decision.Execute(FakeMetadata(scenario()), context = "original-context"))
         val filtered = ScenarioMetadataFilter.filterUsingDecisions(decisions, filter).toList()
-        assertThat(filtered).containsExactly(Decision.Skip(context = "original-context", reasoning = Reasoning(mainReason = TestRuleViolations.EXCLUDED)))
+        assertThat(filtered).containsExactly(Decision.Skip(context = "original-context", reasoning = Reasoning(mainReason = TestSkipReason.EXCLUDED)))
     }
 
     @Test
     fun `filterUsingDecisions should preserve existing skip decisions`() {
         val filter = ScenarioMetadataFilter.from("METHOD='POST'")
-        val originalSkip = Decision.Skip(context = "already-skipped", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+        val originalSkip = Decision.Skip(context = "already-skipped", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         val filtered = ScenarioMetadataFilter.filterUsingDecisions(sequenceOf(originalSkip), filter).toList()
         assertThat(filtered).containsExactly(originalSkip)
     }

--- a/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/ScenarioMetadataFilterTest.kt
@@ -27,23 +27,24 @@ class ScenarioMetadataFilterTest {
         val filter = ScenarioMetadataFilter.from("METHOD='GET'")
         val scenario = scenario()
         val decisions = sequenceOf(Decision.Execute(FakeMetadata(scenario), context = "kept"))
-        val filtered = ScenarioMetadataFilter.filterUsingDecisions(decisions, filter).toList()
+        val filtered = ScenarioMetadataFilter.filterUsingDecisions(decisions, filter) { it }.toList()
         assertThat(filtered).containsExactly(Decision.Execute(FakeMetadata(scenario), context = "kept"))
     }
 
     @Test
     fun `filterUsingDecisions should convert non matching execute decisions to excluded skips`() {
+        val metadata = FakeMetadata(scenario())
         val filter = ScenarioMetadataFilter.from("METHOD='POST'")
-        val decisions = sequenceOf(Decision.Execute(FakeMetadata(scenario()), context = "original-context"))
-        val filtered = ScenarioMetadataFilter.filterUsingDecisions(decisions, filter).toList()
-        assertThat(filtered).containsExactly(Decision.Skip(context = "original-context", reasoning = Reasoning(mainReason = TestSkipReason.EXCLUDED)))
+        val decisions = sequenceOf(Decision.Execute(metadata, context = "original-context"))
+        val filtered = ScenarioMetadataFilter.filterUsingDecisions(decisions, filter) { it }.toList()
+        assertThat(filtered).containsExactly(Decision.Skip(context = metadata, reasoning = Reasoning(mainReason = TestSkipReason.EXCLUDED)))
     }
 
     @Test
     fun `filterUsingDecisions should preserve existing skip decisions`() {
         val filter = ScenarioMetadataFilter.from("METHOD='POST'")
         val originalSkip = Decision.Skip(context = "already-skipped", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
-        val filtered = ScenarioMetadataFilter.filterUsingDecisions(sequenceOf(originalSkip), filter).toList()
+        val filtered = ScenarioMetadataFilter.filterUsingDecisions(sequenceOf(originalSkip), filter) { it }.toList()
         assertThat(filtered).containsExactly(originalSkip)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/DecisionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/DecisionTest.kt
@@ -7,40 +7,40 @@ import org.junit.jupiter.api.Test
 class DecisionTest {
     @Test
     fun `mapValue should transform execute values and preserve context and reasoning`() {
-        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         val mapped = decision.mapValue { it * 2 }
         assertThat(mapped).isEqualTo(
             Decision.Execute(
                 value = 20,
                 context = "ctx",
-                reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
+                reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)
             )
         )
     }
 
     @Test
     fun `mapValue should preserve skip decisions unchanged`() {
-        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         val mapped = decision.mapValue { it }
         assertThat(mapped).isEqualTo(decision)
     }
 
     @Test
     fun `map should transform execute values using item and context`() {
-        val decision = Decision.Execute(value = 10, context = 5, reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val decision = Decision.Execute(value = 10, context = 5, reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         val mapped = decision.map { value, context -> value + context }
         assertThat(mapped).isEqualTo(
             Decision.Execute(
                 value = 15,
                 context = 5,
-                reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
+                reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)
             )
         )
     }
 
     @Test
     fun `flatMap should allow replacing execute decisions`() {
-        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         val mapped = decision.flatMap { value, context, reasoning ->
             Decision.Execute(value + 1, "$context-updated", reasoning.withMainReason(TestRuleViolations.EXCLUDED))
         }
@@ -49,14 +49,14 @@ class DecisionTest {
             Decision.Execute(
                 value = 11,
                 context = "ctx-updated",
-                reasoning = Reasoning(mainReason = TestRuleViolations.EXCLUDED, otherReasons = listOf(TestRuleViolations.NO_EXAMPLES))
+                reasoning = Reasoning(mainReason = TestRuleViolations.EXCLUDED, otherReasons = listOf(TestRuleViolations.EXAMPLES_REQUIRED))
             )
         )
     }
 
     @Test
     fun `flatMap should preserve skip decisions unchanged`() {
-        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)) as Decision<*, *>
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)) as Decision<*, *>
         val mapped = decision.flatMap { value, context, reasoning ->
             Decision.Execute(value, context, reasoning)
         }
@@ -66,20 +66,20 @@ class DecisionTest {
 
     @Test
     fun `flatMapSequence should return mapped sequence for execute decisions`() {
-        val decision = Decision.Execute(value = 2, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val decision = Decision.Execute(value = 2, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         val mapped = decision.flatMapSequence { value, context, reasoning ->
             sequenceOf(Decision.Execute(value, context, reasoning), Decision.Execute(value + 1, "$context-next", reasoning))
         }
 
         assertThat(mapped.toList()).containsExactly(
-            Decision.Execute(2, "ctx", Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)),
-            Decision.Execute(3, "ctx-next", Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+            Decision.Execute(2, "ctx", Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)),
+            Decision.Execute(3, "ctx-next", Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         )
     }
 
     @Test
     fun `flatMapSequence should preserve skip decisions unchanged`() {
-        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
         val mapped = decision.flatMapSequence { _, _, _ ->
             sequenceOf(Decision.Execute(1, "other", Reasoning()))
         }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/DecisionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/DecisionTest.kt
@@ -1,0 +1,89 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.test.TestRuleViolations
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DecisionTest {
+    @Test
+    fun `mapValue should transform execute values and preserve context and reasoning`() {
+        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val mapped = decision.mapValue { it * 2 }
+        assertThat(mapped).isEqualTo(
+            Decision.Execute(
+                value = 20,
+                context = "ctx",
+                reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
+            )
+        )
+    }
+
+    @Test
+    fun `mapValue should preserve skip decisions unchanged`() {
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val mapped = decision.mapValue { it }
+        assertThat(mapped).isEqualTo(decision)
+    }
+
+    @Test
+    fun `map should transform execute values using item and context`() {
+        val decision = Decision.Execute(value = 10, context = 5, reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val mapped = decision.map { value, context -> value + context }
+        assertThat(mapped).isEqualTo(
+            Decision.Execute(
+                value = 15,
+                context = 5,
+                reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)
+            )
+        )
+    }
+
+    @Test
+    fun `flatMap should allow replacing execute decisions`() {
+        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val mapped = decision.flatMap { value, context, reasoning ->
+            Decision.Execute(value + 1, "$context-updated", reasoning.withMainReason(TestRuleViolations.EXCLUDED))
+        }
+
+        assertThat(mapped).isEqualTo(
+            Decision.Execute(
+                value = 11,
+                context = "ctx-updated",
+                reasoning = Reasoning(mainReason = TestRuleViolations.EXCLUDED, otherReasons = listOf(TestRuleViolations.NO_EXAMPLES))
+            )
+        )
+    }
+
+    @Test
+    fun `flatMap should preserve skip decisions unchanged`() {
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)) as Decision<*, *>
+        val mapped = decision.flatMap { value, context, reasoning ->
+            Decision.Execute(value, context, reasoning)
+        }
+
+        assertThat(mapped).isEqualTo(decision)
+    }
+
+    @Test
+    fun `flatMapSequence should return mapped sequence for execute decisions`() {
+        val decision = Decision.Execute(value = 2, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val mapped = decision.flatMapSequence { value, context, reasoning ->
+            sequenceOf(Decision.Execute(value, context, reasoning), Decision.Execute(value + 1, "$context-next", reasoning))
+        }
+
+        assertThat(mapped.toList()).containsExactly(
+            Decision.Execute(2, "ctx", Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES)),
+            Decision.Execute(3, "ctx-next", Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        )
+    }
+
+    @Test
+    fun `flatMapSequence should preserve skip decisions unchanged`() {
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES))
+        val mapped = decision.flatMapSequence { _, _, _ ->
+            sequenceOf(Decision.Execute(1, "other", Reasoning()))
+        }
+
+        assertThat(mapped.toList()).containsExactly(decision)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/utilities/DecisionTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/DecisionTest.kt
@@ -1,62 +1,62 @@
 package io.specmatic.core.utilities
 
-import io.specmatic.test.TestRuleViolations
+import io.specmatic.test.TestSkipReason
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class DecisionTest {
     @Test
     fun `mapValue should transform execute values and preserve context and reasoning`() {
-        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         val mapped = decision.mapValue { it * 2 }
         assertThat(mapped).isEqualTo(
             Decision.Execute(
                 value = 20,
                 context = "ctx",
-                reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)
+                reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED)
             )
         )
     }
 
     @Test
     fun `mapValue should preserve skip decisions unchanged`() {
-        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         val mapped = decision.mapValue { it }
         assertThat(mapped).isEqualTo(decision)
     }
 
     @Test
     fun `map should transform execute values using item and context`() {
-        val decision = Decision.Execute(value = 10, context = 5, reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+        val decision = Decision.Execute(value = 10, context = 5, reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         val mapped = decision.map { value, context -> value + context }
         assertThat(mapped).isEqualTo(
             Decision.Execute(
                 value = 15,
                 context = 5,
-                reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)
+                reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED)
             )
         )
     }
 
     @Test
     fun `flatMap should allow replacing execute decisions`() {
-        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+        val decision = Decision.Execute(value = 10, context = "ctx", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         val mapped = decision.flatMap { value, context, reasoning ->
-            Decision.Execute(value + 1, "$context-updated", reasoning.withMainReason(TestRuleViolations.EXCLUDED))
+            Decision.Execute(value + 1, "$context-updated", reasoning.withMainReason(TestSkipReason.EXCLUDED))
         }
 
         assertThat(mapped).isEqualTo(
             Decision.Execute(
                 value = 11,
                 context = "ctx-updated",
-                reasoning = Reasoning(mainReason = TestRuleViolations.EXCLUDED, otherReasons = listOf(TestRuleViolations.EXAMPLES_REQUIRED))
+                reasoning = Reasoning(mainReason = TestSkipReason.EXCLUDED, otherReasons = listOf(TestSkipReason.EXAMPLES_REQUIRED))
             )
         )
     }
 
     @Test
     fun `flatMap should preserve skip decisions unchanged`() {
-        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)) as Decision<*, *>
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED)) as Decision<*, *>
         val mapped = decision.flatMap { value, context, reasoning ->
             Decision.Execute(value, context, reasoning)
         }
@@ -66,20 +66,20 @@ class DecisionTest {
 
     @Test
     fun `flatMapSequence should return mapped sequence for execute decisions`() {
-        val decision = Decision.Execute(value = 2, context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+        val decision = Decision.Execute(value = 2, context = "ctx", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         val mapped = decision.flatMapSequence { value, context, reasoning ->
             sequenceOf(Decision.Execute(value, context, reasoning), Decision.Execute(value + 1, "$context-next", reasoning))
         }
 
         assertThat(mapped.toList()).containsExactly(
-            Decision.Execute(2, "ctx", Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED)),
-            Decision.Execute(3, "ctx-next", Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+            Decision.Execute(2, "ctx", Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED)),
+            Decision.Execute(3, "ctx-next", Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         )
     }
 
     @Test
     fun `flatMapSequence should preserve skip decisions unchanged`() {
-        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED))
+        val decision = Decision.Skip(context = "ctx", reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED))
         val mapped = decision.flatMapSequence { _, _, _ ->
             sequenceOf(Decision.Execute(1, "other", Reasoning()))
         }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/ReasoningTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/ReasoningTest.kt
@@ -1,0 +1,37 @@
+package io.specmatic.core.utilities
+
+import io.specmatic.core.RuleViolationReport
+import io.specmatic.test.TestRuleViolations
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ReasoningTest {
+    @Test
+    fun `withMainReason should promote the previous main reason into other reasons`() {
+        val reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES, otherReasons = listOf(TestRuleViolations.EXCLUDED))
+        val updated = reasoning.withMainReason(TestRuleViolations.ACCEPT_MISMATCH)
+        assertThat(updated).isEqualTo(
+            Reasoning(
+                mainReason = TestRuleViolations.ACCEPT_MISMATCH,
+                otherReasons = listOf(TestRuleViolations.NO_EXAMPLES, TestRuleViolations.EXCLUDED)
+            )
+        )
+    }
+
+    @Test
+    fun `withMainReason should set main reason on an empty reasoning`() {
+        val updated = Reasoning().withMainReason(TestRuleViolations.EXCLUDED)
+        assertThat(updated).isEqualTo(Reasoning(mainReason = TestRuleViolations.EXCLUDED, otherReasons = emptyList()))
+    }
+
+    @Test
+    fun `toRuleViolationText should render unique violations only once and preserve insertion order`() {
+        val text = Reasoning(
+            mainReason = TestRuleViolations.EXCLUDED,
+            otherReasons = listOf(TestRuleViolations.EXCLUDED, TestRuleViolations.NO_EXAMPLES)
+        ).toRuleViolationText()
+
+        assertThat(text).isEqualTo(RuleViolationReport(linkedSetOf(TestRuleViolations.EXCLUDED, TestRuleViolations.NO_EXAMPLES)).toText())
+        assertThat(text).containsSubsequence(TestRuleViolations.EXCLUDED.id, TestRuleViolations.NO_EXAMPLES.id)
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/utilities/ReasoningTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/ReasoningTest.kt
@@ -1,37 +1,37 @@
 package io.specmatic.core.utilities
 
 import io.specmatic.core.RuleViolationReport
-import io.specmatic.test.TestRuleViolations
+import io.specmatic.test.TestSkipReason
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ReasoningTest {
     @Test
     fun `withMainReason should promote the previous main reason into other reasons`() {
-        val reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED, otherReasons = listOf(TestRuleViolations.EXCLUDED))
-        val updated = reasoning.withMainReason(TestRuleViolations.ACCEPT_MISMATCH)
+        val reasoning = Reasoning(mainReason = TestSkipReason.EXAMPLES_REQUIRED, otherReasons = listOf(TestSkipReason.EXCLUDED))
+        val updated = reasoning.withMainReason(TestSkipReason.ACCEPT_MISMATCH)
         assertThat(updated).isEqualTo(
             Reasoning(
-                mainReason = TestRuleViolations.ACCEPT_MISMATCH,
-                otherReasons = listOf(TestRuleViolations.EXAMPLES_REQUIRED, TestRuleViolations.EXCLUDED)
+                mainReason = TestSkipReason.ACCEPT_MISMATCH,
+                otherReasons = listOf(TestSkipReason.EXAMPLES_REQUIRED, TestSkipReason.EXCLUDED)
             )
         )
     }
 
     @Test
     fun `withMainReason should set main reason on an empty reasoning`() {
-        val updated = Reasoning().withMainReason(TestRuleViolations.EXCLUDED)
-        assertThat(updated).isEqualTo(Reasoning(mainReason = TestRuleViolations.EXCLUDED, otherReasons = emptyList()))
+        val updated = Reasoning().withMainReason(TestSkipReason.EXCLUDED)
+        assertThat(updated).isEqualTo(Reasoning(mainReason = TestSkipReason.EXCLUDED, otherReasons = emptyList()))
     }
 
     @Test
     fun `toRuleViolationText should render unique violations only once and preserve insertion order`() {
         val text = Reasoning(
-            mainReason = TestRuleViolations.EXCLUDED,
-            otherReasons = listOf(TestRuleViolations.EXCLUDED, TestRuleViolations.EXAMPLES_REQUIRED)
+            mainReason = TestSkipReason.EXCLUDED,
+            otherReasons = listOf(TestSkipReason.EXCLUDED, TestSkipReason.EXAMPLES_REQUIRED)
         ).toRuleViolationText()
 
-        assertThat(text).isEqualTo(RuleViolationReport(linkedSetOf(TestRuleViolations.EXCLUDED, TestRuleViolations.EXAMPLES_REQUIRED)).toText())
-        assertThat(text).containsSubsequence(TestRuleViolations.EXCLUDED.id, TestRuleViolations.EXAMPLES_REQUIRED.id)
+        assertThat(text).isEqualTo(RuleViolationReport(linkedSetOf(TestSkipReason.EXCLUDED, TestSkipReason.EXAMPLES_REQUIRED)).toText())
+        assertThat(text).containsSubsequence(TestSkipReason.EXCLUDED.id, TestSkipReason.EXAMPLES_REQUIRED.id)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/ReasoningTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/ReasoningTest.kt
@@ -8,12 +8,12 @@ import org.junit.jupiter.api.Test
 class ReasoningTest {
     @Test
     fun `withMainReason should promote the previous main reason into other reasons`() {
-        val reasoning = Reasoning(mainReason = TestRuleViolations.NO_EXAMPLES, otherReasons = listOf(TestRuleViolations.EXCLUDED))
+        val reasoning = Reasoning(mainReason = TestRuleViolations.EXAMPLES_REQUIRED, otherReasons = listOf(TestRuleViolations.EXCLUDED))
         val updated = reasoning.withMainReason(TestRuleViolations.ACCEPT_MISMATCH)
         assertThat(updated).isEqualTo(
             Reasoning(
                 mainReason = TestRuleViolations.ACCEPT_MISMATCH,
-                otherReasons = listOf(TestRuleViolations.NO_EXAMPLES, TestRuleViolations.EXCLUDED)
+                otherReasons = listOf(TestRuleViolations.EXAMPLES_REQUIRED, TestRuleViolations.EXCLUDED)
             )
         )
     }
@@ -28,10 +28,10 @@ class ReasoningTest {
     fun `toRuleViolationText should render unique violations only once and preserve insertion order`() {
         val text = Reasoning(
             mainReason = TestRuleViolations.EXCLUDED,
-            otherReasons = listOf(TestRuleViolations.EXCLUDED, TestRuleViolations.NO_EXAMPLES)
+            otherReasons = listOf(TestRuleViolations.EXCLUDED, TestRuleViolations.EXAMPLES_REQUIRED)
         ).toRuleViolationText()
 
-        assertThat(text).isEqualTo(RuleViolationReport(linkedSetOf(TestRuleViolations.EXCLUDED, TestRuleViolations.NO_EXAMPLES)).toText())
-        assertThat(text).containsSubsequence(TestRuleViolations.EXCLUDED.id, TestRuleViolations.NO_EXAMPLES.id)
+        assertThat(text).isEqualTo(RuleViolationReport(linkedSetOf(TestRuleViolations.EXCLUDED, TestRuleViolations.EXAMPLES_REQUIRED)).toText())
+        assertThat(text).containsSubsequence(TestRuleViolations.EXCLUDED.id, TestRuleViolations.EXAMPLES_REQUIRED.id)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
+++ b/core/src/test/kotlin/io/specmatic/proxy/ProxyTest.kt
@@ -91,7 +91,7 @@ internal class ProxyTest {
         assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
         assertThat(fakeFileWriter.receivedPaths.toList()).containsExactlyInAnyOrder(
             "proxy_generated.yaml",
-            "POST_200_text_plain_1.json",
+            "POST_text_plain_200_text_plain_1.json",
         )
     }
 
@@ -120,7 +120,7 @@ internal class ProxyTest {
         assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
         assertThat(fakeFileWriter.receivedPaths.toList()).containsExactlyInAnyOrder(
             "proxy_generated.yaml",
-            "multiply_POST_200_text_plain_1.json",
+            "multiply_POST_text_plain_200_text_plain_1.json",
         )
     }
 
@@ -171,7 +171,7 @@ internal class ProxyTest {
             )
         }.doesNotThrowAnyException()
         assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
-        assertThat(fakeFileWriter.receivedPaths).containsExactlyInAnyOrder("proxy_generated.yaml", "POST_200_text_plain_1.json")
+        assertThat(fakeFileWriter.receivedPaths).containsExactlyInAnyOrder("proxy_generated.yaml", "POST_text_plain_200_text_plain_1.json")
     }
 
     @Test
@@ -484,7 +484,7 @@ internal class ProxyTest {
                 assertThatCode { parsedJSON(fakeFileWriter.receivedStub ?: "") }.doesNotThrowAnyException()
                 assertThat(fakeFileWriter.receivedPaths.toList()).contains(
                     "proxy_generated.yaml",
-                    "multiply_POST_200_text_plain_1.json",
+                    "multiply_POST_text_plain_200_text_plain_1.json",
                 )
             }
         }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubUsageReportTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubUsageReportTest.kt
@@ -99,10 +99,10 @@ paths:
 
         HttpStub(listOf(stubContract1, stubContract2)).use { stub ->
             assertThat(stub.allEndpoints).isEqualTo(listOf(
-                StubEndpoint("/data", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
-                StubEndpoint("/hello", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
-                StubEndpoint("/data2", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
-                StubEndpoint("/hello2", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI)
+                StubEndpoint("/data", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain"),
+                StubEndpoint("/hello", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain"),
+                StubEndpoint("/data2", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain"),
+                StubEndpoint("/hello2", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain")
             ))
         }
     }
@@ -207,8 +207,8 @@ paths:
             stub.client.execute(HttpRequest("GET", "/hello"))
 
             assertThat(stub.logs).isEqualTo(listOf(
-                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
-                StubEndpoint("/hello", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI)
+                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain"),
+                StubEndpoint("/hello", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain")
             ))
         }
     }
@@ -239,8 +239,8 @@ paths:
             stub.client.execute(HttpRequest("GET", "/unknown"))
 
             assertThat(stub.logs).isEqualTo(listOf(
-                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
-                StubEndpoint("/hello", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI)
+                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain"),
+                StubEndpoint("/hello", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain")
             ))
         }
     }
@@ -255,7 +255,7 @@ paths:
             stub.client.execute(HttpRequest("GET", "/unknown"))
 
             assertThat(stub.logs).isEqualTo(listOf(
-                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain"),
             ))
         }
     }
@@ -283,7 +283,7 @@ paths:
             stub.client.execute(HttpRequest("GET", "/hello"))
 
             assertThat(stub.logs).isEqualTo(listOf(
-                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI),
+                StubEndpoint("/data", "GET", 200, "text/plain", protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain"),
             ))
         }
     }
@@ -303,7 +303,7 @@ paths:
             threads.forEach { it.join() }
 
             assertThat(stub.logs.count()).isEqualTo(10)
-            assertThat(stub.logs.all { it == StubEndpoint("/hello", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI) }).isTrue
+            assertThat(stub.logs.all { it == StubEndpoint("/hello", "GET", 200, protocol = SpecmaticProtocol.HTTP, specType = SpecType.OPENAPI, responseContentType="text/plain") }).isTrue
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -52,6 +52,18 @@ class ScenarioAsTestTest {
         }
 
         @Test
+        fun `does not call fixture executor for negative scenario`() {
+            ServiceLoaderTestFixtureExecutor.reset()
+            val exampleRow = Row(scenarioStub = ScenarioStub(id = "fixture-id", beforeFixtures = listOf(StringValue("before")), afterFixtures = listOf(StringValue("after"))))
+            val scenario = scenario(status = 400, exampleRow = exampleRow,).copy(isNegative = true)
+            withServiceLoaderEntries(mapOf(OpenAPIFixtureExecutor::class.java to ServiceLoaderTestFixtureExecutor::class.java.name)) {
+                scenarioAsTest(scenario).runTest(fixedResponseExecutor("anything", 400))
+            }
+
+            assertThat(ServiceLoaderTestFixtureExecutor.calls).isEmpty()
+        }
+
+        @Test
         fun `does not call fixture executor when missing from service loader`() {
             ServiceLoaderTestFixtureExecutor.reset()
 
@@ -74,17 +86,11 @@ class ScenarioAsTestTest {
         }
     }
 
-    private fun scenario(exampleRow: Row? = null): Scenario {
+    private fun scenario(exampleRow: Row? = null, status: Int = 200): Scenario {
         return Scenario(
             ScenarioInfo(
-                httpRequestPattern = HttpRequestPattern(
-                    httpPathPattern = buildHttpPathPattern("/resource"),
-                    method = "GET"
-                ),
-                httpResponsePattern = HttpResponsePattern(
-                    status = 200,
-                    body = StringPattern()
-                ),
+                httpRequestPattern = HttpRequestPattern(httpPathPattern = buildHttpPathPattern("/resource"), method = "GET"),
+                httpResponsePattern = HttpResponsePattern(status = status, body = StringPattern()),
                 protocol = SpecmaticProtocol.HTTP,
                 specType = SpecType.OPENAPI
             )
@@ -103,10 +109,10 @@ class ScenarioAsTestTest {
         )
     }
 
-    private fun fixedResponseExecutor(body: String): TestExecutor {
+    private fun fixedResponseExecutor(body: String, status: Int = 200): TestExecutor {
         return object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
-                return HttpResponse(200, body)
+                return HttpResponse(status, body)
             }
         }
     }

--- a/core/src/test/kotlin/utilities/UtilitiesTest.kt
+++ b/core/src/test/kotlin/utilities/UtilitiesTest.kt
@@ -23,6 +23,7 @@ import io.ktor.server.netty.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.mockk.*
+import io.specmatic.core.HttpResponse
 import io.specmatic.core.readEnvVarOrProperty
 import io.specmatic.toContractSourceEntries
 import org.assertj.core.api.Assertions.assertThat
@@ -570,8 +571,7 @@ internal class UtilitiesTest {
     )
     fun `unique names from operation information names should be path valid`(path: String?, baseURL: String, method: String, status: Int, expected: String) {
         val request = HttpRequest(method, path, emptyMap())
-        val actual = uniqueNameForApiOperation(request, baseURL, status, File("."))
-
+        val actual = uniqueNameForApiOperation(request, HttpResponse(status = status), baseURL, File("."))
         assertThat(actual).isEqualTo(expected)
         assertDoesNotThrow { File(actual).canonicalPath }
     }
@@ -583,7 +583,7 @@ internal class UtilitiesTest {
         every { scenario.operationMetadata } returns OperationMetadata(operationId = "create-order")
         every { scenario.status } returns 201
 
-        val output = uniqueNameForApiOperation(request, scenario, File("."), "prefix_")
+        val output = uniqueNameForApiOperation(request, HttpResponse(status = scenario.status), scenario, File("."), "prefix_")
         assertThat(output).isEqualTo("prefix_create-order_201")
     }
 
@@ -594,7 +594,7 @@ internal class UtilitiesTest {
         every { scenario.operationMetadata } returns OperationMetadata(operationId = "")
         every { scenario.status } returns 201
 
-        val output = uniqueNameForApiOperation(request, scenario, File("."), "prefix_")
+        val output = uniqueNameForApiOperation(request, HttpResponse(status = scenario.status), scenario, File("."), "prefix_")
         assertThat(output).isEqualTo("prefix_path_that_should_be_used_GET_201")
     }
 
@@ -605,7 +605,7 @@ internal class UtilitiesTest {
         every { scenario.operationMetadata } returns OperationMetadata(operationId = "create-order")
         every { scenario.status } returns 201
 
-        val output = uniqueNameForApiOperation(request, scenario, File("."))
+        val output = uniqueNameForApiOperation(request, HttpResponse(status = scenario.status), scenario, File("."))
         assertThat(output).isEqualTo("create-order_201")
     }
 
@@ -616,19 +616,39 @@ internal class UtilitiesTest {
         every { scenario.operationMetadata } returns OperationMetadata(operationId = "A".repeat(300))
         every { scenario.status } returns 200
 
-        val output = uniqueNameForApiOperation(request, scenario, File("."))
+        val output = uniqueNameForApiOperation(request, HttpResponse(status = scenario.status), scenario, File("."))
         assertThat(output.length).isLessThan(300)
         assertThat(output.length).isLessThanOrEqualTo(255)
         assertThat(output).matches("A*_[0-9a-f]{12}$")
     }
 
     @Test
+    fun `uniqueNameForApiOperation with scenario should include request and response media types`() {
+        val request = HttpRequest(method = "POST", path = "/orders", headers = mapOf("Content-Type" to "application/json; charset=utf-8"))
+        val response = HttpResponse(status = 201, headers = mapOf("Content-Type" to "application/problem+json; charset=utf-8"))
+        val scenario = mockk<Scenario>()
+        every { scenario.operationMetadata } returns OperationMetadata(operationId = "create-order")
+        every { scenario.status } returns 201
+
+        val output = uniqueNameForApiOperation(request, response, scenario, File("."))
+        assertThat(output).isEqualTo("create-order_application_json_201_application_problem+json")
+    }
+
+    @Test
     fun `uniqueNameForApiOperation with request details should budget long generated name`() {
         val request = HttpRequest("GET", "http://example.com/" + "segment/".repeat(80), emptyMap())
-        val output = uniqueNameForApiOperation(request, "http://example.com", 200, File("."))
+        val output = uniqueNameForApiOperation(request, HttpResponse(status = 200), "http://example.com", File("."))
         assertThat(output.length).isLessThan(request.path!!.length)
         assertThat(output.length).isLessThanOrEqualTo(255)
         assertThat(output).matches(".*_[0-9a-f]{12}$")
+    }
+
+    @Test
+    fun `uniqueNameForApiOperation with request details should include request and response media types`() {
+        val request = HttpRequest(method = "POST", path = "http://example.com/orders", headers = mapOf("Content-Type" to "application/json; charset=utf-8"))
+        val response = HttpResponse(status = 200, headers = mapOf("Content-Type" to "text/plain; charset=utf-8"))
+        val output = uniqueNameForApiOperation(request, response, "http://example.com", File("."))
+        assertThat(output).isEqualTo("orders_POST_application_json_200_text_plain")
     }
 
     @Test

--- a/core/src/test/resources/openapi/feature_decision_matrix.yaml
+++ b/core/src/test/resources/openapi/feature_decision_matrix.yaml
@@ -1,0 +1,144 @@
+openapi: 3.0.3
+info:
+  title: Feature Decision Matrix API
+  version: 1.0.0
+paths:
+  /matrix:
+    get:
+      operationId: getMatrixWithExamples
+      parameters:
+        - in: query
+          name: type
+          required: true
+          schema:
+            type: string
+            enum:
+              - case1
+              - case2
+          examples:
+            success:
+              value: case1
+            badRequest:
+              value: case2
+            notFound:
+              value: case1
+            serverError:
+              value: case2
+      responses:
+        '200':
+          description: Example-backed success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+              examples:
+                success:
+                  value:
+                    message: success
+        '400':
+          description: Example-backed bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+              examples:
+                badRequest:
+                  value:
+                    message: bad request
+        '404':
+          description: Example-backed not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+              examples:
+                notFound:
+                  value:
+                    message: not found
+        '500':
+          description: Example-backed server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+              examples:
+                serverError:
+                  value:
+                    message: server error
+  /matrix/no-example:
+    get:
+      operationId: getMatrixWithoutExamples
+      parameters:
+        - in: query
+          name: type
+          required: true
+          schema:
+            type: string
+            enum:
+              - case1s
+              - case2
+      responses:
+        '200':
+          description: Schema-backed success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '400':
+          description: Schema-backed bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '404':
+          description: Schema-backed not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        '500':
+          description: Schema-backed other status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group=io.specmatic
 version=2.43.3-SNAPSHOT
 specmaticGradlePluginVersion=0.15.3
-specmaticReporterVersion=0.3.10
+specmaticReporterVersion=0.3.11-SNAPSHOT
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -530,10 +530,6 @@ open class SpecmaticJUnitSupport {
                 } catch (e: Throwable) {
                     throw e
                 } finally {
-                    logger.log(buildString {
-                        appendLine("Executed ${contractTestDecision.value.first.scenario.fullApiTestDescription()}")
-                        appendLine(contractTestDecision.reasoning.toRuleViolationText())
-                    }.prependIndent(LOG_INDENT))
                     if (testResult != null) {
                         contractTest.testResultRecord(testResult)?.let { testResultRecord ->
                             openApiCoverageReportInput.addTestReportRecords(testResultRecord)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -467,7 +467,7 @@ open class SpecmaticJUnitSupport {
                 logger.boundary()
                 logger.log(buildString {
                     appendLine("--------------------")
-                    this.appendLine("Skipping ${contractTestDecision.context.defaultAPIDescription}")
+                    this.appendLine("Skipping ${contractTestDecision.context.fullApiDescription}")
                     this.appendLine(contractTestDecision.reasoning.toRuleViolationText())
                 })
                 return@mapNotNull null
@@ -526,7 +526,7 @@ open class SpecmaticJUnitSupport {
                     throw e
                 } finally {
                     logger.log(buildString {
-                        appendLine("Execution reasons for ${contractTestDecision.context.defaultAPIDescription}")
+                        appendLine("Execution reasons for ${contractTestDecision.context.fullApiDescription}")
                         appendLine(contractTestDecision.reasoning.toRuleViolationText())
                     })
                     if (testResult != null) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -82,6 +82,8 @@ open class SpecmaticJUnitSupport {
         const val PROTOCOL = "protocol"
         const val TEST_BASE_URL = "testBaseURL"
         const val FILTER = "filter"
+        const val LOG_SEPARATOR = "--------------------"
+        const val LOG_INDENT = "  "
 
         val partialSuccesses: ConcurrentLinkedDeque<Result.Success> = ConcurrentLinkedDeque()
     }
@@ -465,11 +467,11 @@ open class SpecmaticJUnitSupport {
         return testScenarios.mapNotNull { contractTestDecision ->
             if (contractTestDecision !is Decision.Execute) {
                 logger.boundary()
+                logger.log(LOG_SEPARATOR)
                 logger.log(buildString {
-                    appendLine("--------------------")
                     this.appendLine("Skipping ${contractTestDecision.context.fullApiDescription}")
                     this.appendLine(contractTestDecision.reasoning.toRuleViolationText())
-                })
+                }.prependIndent(LOG_INDENT))
                 return@mapNotNull null
             }
 
@@ -526,9 +528,9 @@ open class SpecmaticJUnitSupport {
                     throw e
                 } finally {
                     logger.log(buildString {
-                        appendLine("Execution reasons for ${contractTestDecision.context.fullApiDescription}")
+                        appendLine("Executed ${contractTestDecision.context.fullApiDescription}")
                         appendLine(contractTestDecision.reasoning.toRuleViolationText())
-                    })
+                    }.prependIndent(LOG_INDENT))
                     if (testResult != null) {
                         contractTest.testResultRecord(testResult)?.let { testResultRecord ->
                             openApiCoverageReportInput.addTestReportRecords(testResultRecord)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -53,7 +53,6 @@ import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
-import kotlin.math.max
 
 @Serializable
 data class API(
@@ -320,7 +319,7 @@ open class SpecmaticJUnitSupport {
                     val filteredEndpoints: List<Endpoint> = loadedScenariosByContractPath.flatMap { (_, loaded) -> loaded.filteredEndpoints }
                     val exampleValidationResults = loadedScenariosByContractPath.associate { (contractPath, loaded) -> contractPath to loaded.exampleValidationResult }
                     val testsWithUrls = loadedScenariosByContractPath.asSequence().flatMap { (_, loaded) ->
-                        loaded.scenarios.map { test -> test.mapValue { Pair(it, defaultBaseURL) }  }
+                        loaded.scenarios.mapSequence { Pair(it, defaultBaseURL) }
                     }
 
                     TestData(testsWithUrls, endpoints, filteredEndpoints, setOf(defaultBaseURL), exampleValidationResults)
@@ -374,7 +373,7 @@ open class SpecmaticJUnitSupport {
                     val filteredEndpoints: List<Endpoint> = loadedScenariosWithBaseUrlsByContractPath.flatMap { (_, loaded, _) -> loaded.filteredEndpoints }
                     val exampleValidationResults = loadedScenariosWithBaseUrlsByContractPath.associate { (contractPath, loaded, _) -> contractPath to loaded.exampleValidationResult }
                     val testsWithUrls = loadedScenariosWithBaseUrlsByContractPath.asSequence().flatMap { (_, loaded, resolvedBaseURL) ->
-                        loaded.scenarios.map { test -> test.mapValue { Pair(it, resolvedBaseURL) } }
+                        loaded.scenarios.mapSequence {  Pair(it, resolvedBaseURL) }
                     }
 
                     TestData(testsWithUrls, endpoints, filteredEndpoints, baseUrls, exampleValidationResults)
@@ -695,12 +694,12 @@ open class SpecmaticJUnitSupport {
             it.testDescription()
         }
 
-        val filteredScenarioDecisionsBasedOnFilter = filterUsingDecisions(
+        val filteredScenarioDecisions = filterUsingDecisions(
             filteredScenarioDecisionsBasedOnName,
             filter
         )
 
-        val filteredEndpoints = filteredScenarioDecisionsBasedOnFilter.mapNotNull { decision ->
+        val filteredEndpoints = filteredScenarioDecisions.mapNotNull { decision ->
             if (decision !is Decision.Execute) return@mapNotNull null
             val scenario = decision.value
             Endpoint(
@@ -719,7 +718,7 @@ open class SpecmaticJUnitSupport {
             )
         }.toList()
 
-        val (validatedScenarioDecisions, result) = featureWithExternalizedExamples.validateAndFilterExamples(filteredScenarioDecisionsBasedOnFilter)
+        val (validatedScenarioDecisions, result) = featureWithExternalizedExamples.validateAndFilterExamples(filteredScenarioDecisions)
         if (specmaticConfig.getTestLenientMode() == false) result.throwOnFailure()
 
         val validatedScenarios = validatedScenarioDecisions.mapNotNull { (it as? Decision.Execute)?.value }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -465,6 +465,7 @@ open class SpecmaticJUnitSupport {
 
         startTime = Instant.now()
         return testScenarios.mapNotNull { contractTestDecision ->
+            openApiCoverageReportInput.onTestDecision(contractTestDecision)
             if (contractTestDecision !is Decision.Execute) {
                 logger.boundary()
                 logger.log(LOG_SEPARATOR)

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -375,7 +375,7 @@ open class SpecmaticJUnitSupport {
                     val filteredEndpoints: List<Endpoint> = loadedScenariosWithBaseUrlsByContractPath.flatMap { (_, loaded, _) -> loaded.filteredEndpoints }
                     val exampleValidationResults = loadedScenariosWithBaseUrlsByContractPath.associate { (contractPath, loaded, _) -> contractPath to loaded.exampleValidationResult }
                     val testsWithUrls = loadedScenariosWithBaseUrlsByContractPath.asSequence().flatMap { (_, loaded, resolvedBaseURL) ->
-                        loaded.scenarios.mapSequence {  Pair(it, resolvedBaseURL) }
+                        loaded.scenarios.mapSequence { Pair(it, resolvedBaseURL) }
                     }
 
                     TestData(testsWithUrls, endpoints, filteredEndpoints, baseUrls, exampleValidationResults)
@@ -403,13 +403,15 @@ open class SpecmaticJUnitSupport {
             val filteredPairsBasedOnName = selectTestsToRunWithDecision(
                 testScenarios = testBuildResult.scenarios,
                 filterName = filterName,
-                filterNotName = filterNotName
-            ) { it.first.testDescription() }
+                filterNotName = filterNotName,
+                getTestDescription = { it.first.testDescription() },
+                getSkipContext = { it.first.scenario }
+            )
 
             filteredPairsBasedOnName.map { decision ->
                 if (decision !is Decision.Execute) return@map decision
                 if (testFilter.isSatisfiedBy(decision.value.first.toScenarioMetadata())) return@map decision
-                Decision.Skip(decision.context, Reasoning(TestSkipReason.EXCLUDED))
+                Decision.Skip(decision.value.first.scenario, Reasoning(TestSkipReason.EXCLUDED))
             }
         } catch (e: ContractException) {
             return loadExceptionAsTestError(e)
@@ -438,9 +440,9 @@ open class SpecmaticJUnitSupport {
         var taken = 0
         val maxTestCount = specmaticConfig.getMaxTestCount() ?: return testScenarios
         return testScenarios.map { decision ->
-            if (decision is Decision.Skip) return@map decision
+            if (decision !is Decision.Execute) return@map decision
             if (taken++ < maxTestCount) return@map decision
-            Decision.Skip(decision.context, Reasoning(TestSkipReason.MAX_TEST_COUNT_EXCEEDED))
+            Decision.Skip(decision.value.first.scenario, Reasoning(TestSkipReason.MAX_TEST_COUNT_EXCEEDED))
         }
     }
 
@@ -470,7 +472,7 @@ open class SpecmaticJUnitSupport {
                 logger.boundary()
                 logger.log(LOG_SEPARATOR)
                 logger.log(buildString {
-                    this.appendLine("Skipping ${contractTestDecision.context.fullApiDescription}")
+                    this.appendLine("Skipping ${contractTestDecision.context.fullApiTestDescription()}")
                     this.appendLine(contractTestDecision.reasoning.toRuleViolationText())
                 }.prependIndent(LOG_INDENT))
                 return@mapNotNull null
@@ -529,7 +531,7 @@ open class SpecmaticJUnitSupport {
                     throw e
                 } finally {
                     logger.log(buildString {
-                        appendLine("Executed ${contractTestDecision.context.fullApiDescription}")
+                        appendLine("Executed ${contractTestDecision.value.first.scenario.fullApiTestDescription()}")
                         appendLine(contractTestDecision.reasoning.toRuleViolationText())
                     }.prependIndent(LOG_INDENT))
                     if (testResult != null) {
@@ -698,8 +700,9 @@ open class SpecmaticJUnitSupport {
         }
 
         val filteredScenarioDecisions = filterUsingDecisions(
-            filteredScenarioDecisionsBasedOnName,
-            filter
+            items = filteredScenarioDecisionsBasedOnName,
+            scenarioMetadataFilter = filter,
+            getSkipContext = { it }
         )
 
         val filteredEndpoints = filteredScenarioDecisions.mapNotNull { decision ->
@@ -841,23 +844,22 @@ fun <T> selectTestsToRun(
     getTestDescription: (T) -> String
 ): Sequence<Decision<T, T>> {
     val decisionSequence = testScenarios.map { Decision.execute(it) }
-    return selectTestsToRunWithDecision(decisionSequence, filterName, filterNotName) {
-        getTestDescription(it)
-    }
+    return selectTestsToRunWithDecision(decisionSequence, filterName, filterNotName, getTestDescription, getSkipContext = { it })
 }
 
 fun <T, U> selectTestsToRunWithDecision(
     testScenarios: Sequence<Decision<T, U>>,
     filterName: String? = null,
     filterNotName: String? = null,
-    getTestDescription: (T) -> String
+    getTestDescription: (T) -> String,
+    getSkipContext: (T) -> U
 ): Sequence<Decision<T, U>> {
     val filteredByName = if (!filterName.isNullOrBlank()) {
         val filterNames = filterName.split(",").map { it.trim() }
         testScenarios.map { test ->
             if (test !is Decision.Execute) return@map test
             if (filterNames.any { getTestDescription(test.value).contains(it) }) return@map test
-            Decision.Skip(test.context, Reasoning(TestSkipReason.EXCLUDED))
+            Decision.Skip(getSkipContext(test.value), Reasoning(TestSkipReason.EXCLUDED))
         }
     } else
         testScenarios
@@ -867,7 +869,7 @@ fun <T, U> selectTestsToRunWithDecision(
         filteredByName.map { test ->
             if (test !is Decision.Execute) return@map test
             if (!filterNotNames.any { getTestDescription(test.value).contains(it) }) return@map test
-            Decision.Skip(test.context, Reasoning(TestSkipReason.EXCLUDED))
+            Decision.Skip(getSkipContext(test.value), Reasoning(TestSkipReason.EXCLUDED))
         }
     } else
         filteredByName

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -475,6 +475,7 @@ open class SpecmaticJUnitSupport {
                     this.appendLine("Skipping ${contractTestDecision.context.fullApiTestDescription()}")
                     this.appendLine(contractTestDecision.reasoning.toRuleViolationText())
                 }.prependIndent(LOG_INDENT))
+                openApiCoverageReportInput.addSkipReasoning(contractTestDecision.mapValue { it.first.scenario })
                 return@mapNotNull null
             }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -409,7 +409,7 @@ open class SpecmaticJUnitSupport {
             filteredPairsBasedOnName.map { decision ->
                 if (decision !is Decision.Execute) return@map decision
                 if (testFilter.isSatisfiedBy(decision.value.first.toScenarioMetadata())) return@map decision
-                Decision.Skip(decision.context, Reasoning(TestRuleViolations.EXCLUDED))
+                Decision.Skip(decision.context, Reasoning(TestSkipReason.EXCLUDED))
             }
         } catch (e: ContractException) {
             return loadExceptionAsTestError(e)
@@ -440,7 +440,7 @@ open class SpecmaticJUnitSupport {
         return testScenarios.map { decision ->
             if (decision is Decision.Skip) return@map decision
             if (taken++ < maxTestCount) return@map decision
-            Decision.Skip(decision.context, Reasoning(TestRuleViolations.MAX_TEST_COUNT_EXCEEDED))
+            Decision.Skip(decision.context, Reasoning(TestSkipReason.MAX_TEST_COUNT_EXCEEDED))
         }
     }
 
@@ -857,7 +857,7 @@ fun <T, U> selectTestsToRunWithDecision(
         testScenarios.map { test ->
             if (test !is Decision.Execute) return@map test
             if (filterNames.any { getTestDescription(test.value).contains(it) }) return@map test
-            Decision.Skip(test.context, Reasoning(TestRuleViolations.EXCLUDED))
+            Decision.Skip(test.context, Reasoning(TestSkipReason.EXCLUDED))
         }
     } else
         testScenarios
@@ -867,7 +867,7 @@ fun <T, U> selectTestsToRunWithDecision(
         filteredByName.map { test ->
             if (test !is Decision.Execute) return@map test
             if (!filterNotNames.any { getTestDescription(test.value).contains(it) }) return@map test
-            Decision.Skip(test.context, Reasoning(TestRuleViolations.EXCLUDED))
+            Decision.Skip(test.context, Reasoning(TestSkipReason.EXCLUDED))
         }
     } else
         filteredByName

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -4,7 +4,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.*
 import io.specmatic.core.filters.ScenarioMetadataFilter
-import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsing
+import io.specmatic.core.filters.ScenarioMetadataFilter.Companion.filterUsingDecisions
 import io.specmatic.core.log.LogMessage
 import io.specmatic.core.log.ignoreLog
 import io.specmatic.core.log.logger
@@ -53,6 +53,7 @@ import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
+import kotlin.math.max
 
 @Serializable
 data class API(
@@ -259,10 +260,10 @@ open class SpecmaticJUnitSupport {
         }).asStream()
     }
 
-    private fun noTestsFoundError(reason: String): Stream<DynamicTest> {
+    private fun noTestsFoundError(reason: String): Sequence<DynamicTest> {
         return sequenceOf(DynamicTest.dynamicTest("Specmatic Test Suite") {
             ResultAssert.assertThat(Result.Failure("No tests found to run. $reason")).isSuccess()
-        }).asStream()
+        })
     }
 
     @TestFactory
@@ -318,8 +319,8 @@ open class SpecmaticJUnitSupport {
                     val endpoints: List<Endpoint> = loadedScenariosByContractPath.flatMap { (_, loaded) -> loaded.allEndpoints }
                     val filteredEndpoints: List<Endpoint> = loadedScenariosByContractPath.flatMap { (_, loaded) -> loaded.filteredEndpoints }
                     val exampleValidationResults = loadedScenariosByContractPath.associate { (contractPath, loaded) -> contractPath to loaded.exampleValidationResult }
-                    val testsWithUrls: Sequence<Pair<ContractTest, String>> = loadedScenariosByContractPath.asSequence().flatMap { (_, loaded) ->
-                        loaded.scenarios.map { test -> Pair(test, defaultBaseURL) }
+                    val testsWithUrls = loadedScenariosByContractPath.asSequence().flatMap { (_, loaded) ->
+                        loaded.scenarios.map { test -> test.mapValue { Pair(it, defaultBaseURL) }  }
                     }
 
                     TestData(testsWithUrls, endpoints, filteredEndpoints, setOf(defaultBaseURL), exampleValidationResults)
@@ -372,8 +373,8 @@ open class SpecmaticJUnitSupport {
                     val endpoints: List<Endpoint> = loadedScenariosWithBaseUrlsByContractPath.flatMap { (_, loaded, _) -> loaded.allEndpoints }
                     val filteredEndpoints: List<Endpoint> = loadedScenariosWithBaseUrlsByContractPath.flatMap { (_, loaded, _) -> loaded.filteredEndpoints }
                     val exampleValidationResults = loadedScenariosWithBaseUrlsByContractPath.associate { (contractPath, loaded, _) -> contractPath to loaded.exampleValidationResult }
-                    val testsWithUrls: Sequence<Pair<ContractTest, String>> = loadedScenariosWithBaseUrlsByContractPath.asSequence().flatMap { (_, loaded, resolvedBaseURL) ->
-                        loaded.scenarios.map { test -> Pair(test, resolvedBaseURL) }
+                    val testsWithUrls = loadedScenariosWithBaseUrlsByContractPath.asSequence().flatMap { (_, loaded, resolvedBaseURL) ->
+                        loaded.scenarios.map { test -> test.mapValue { Pair(it, resolvedBaseURL) } }
                     }
 
                     TestData(testsWithUrls, endpoints, filteredEndpoints, baseUrls, exampleValidationResults)
@@ -398,40 +399,21 @@ open class SpecmaticJUnitSupport {
 
         openApiCoverageReportInput.addEndpoints(testBuildResult.allEndpoints, testBuildResult.filteredEndpoints)
         val testScenariosWithUrls = try {
-            val filteredPairsBasedOnName = selectTestsToRun(
-                testBuildResult.scenarios,
-                filterName,
-                filterNotName
+            val filteredPairsBasedOnName = selectTestsToRunWithDecision(
+                testScenarios = testBuildResult.scenarios,
+                filterName = filterName,
+                filterNotName = filterNotName
             ) { it.first.testDescription() }
 
-            filteredPairsBasedOnName.filter { pair ->
-                testFilter.isSatisfiedBy(pair.first.toScenarioMetadata())
+            filteredPairsBasedOnName.map { decision ->
+                if (decision !is Decision.Execute) return@map decision
+                if (testFilter.isSatisfiedBy(decision.value.first.toScenarioMetadata())) return@map decision
+                Decision.Skip(decision.context, Reasoning(TestRuleViolations.EXCLUDED))
             }
         } catch (e: ContractException) {
             return loadExceptionAsTestError(e)
         } catch (e: Throwable) {
             return loadExceptionAsTestError(e)
-        }
-
-        // Check if no tests remain after filtering
-        if (!testScenariosWithUrls.iterator().hasNext()) {
-            val filterDetails = buildString {
-                if (!filterName.isNullOrBlank()) append("name filter: '$filterName'")
-                if (!filterNotName.isNullOrBlank()) {
-                    if (isNotEmpty()) append(", ")
-                    append("exclude filter: '$filterNotName'")
-                }
-                if (testFilter.expression != null) {
-                    if (isNotEmpty()) append(", ")
-                    append("expression filter: \"${specmaticConfig.getTestFilter()}\"")
-                }
-            }
-            val reason = if (filterDetails.isNotEmpty()) {
-                "Applied filters ($filterDetails) matched no test scenarios."
-            } else {
-                "No test scenarios found."
-            }
-            return noTestsFoundError(reason)
         }
 
         val actuatorBaseURL = settings.baseUrlFromArgOrSysProp()
@@ -451,13 +433,18 @@ open class SpecmaticJUnitSupport {
         }
     }
 
-    private fun firstNScenarios(testScenarios: Sequence<Pair<ContractTest, String>>): Sequence<Pair<ContractTest, String>> {
+    private fun firstNScenarios(testScenarios: Sequence<Decision<Pair<ContractTest, String>, Scenario>>): Sequence<Decision<Pair<ContractTest, String>, Scenario>> {
+        var taken = 0
         val maxTestCount = specmaticConfig.getMaxTestCount() ?: return testScenarios
-        return testScenarios.take(maxTestCount)
+        return testScenarios.map { decision ->
+            if (decision is Decision.Skip) return@map decision
+            if (taken++ < maxTestCount) return@map decision
+            Decision.Skip(decision.context, Reasoning(TestRuleViolations.MAX_TEST_COUNT_EXCEEDED))
+        }
     }
 
     private fun dynamicTestStream(
-        testScenarios: Sequence<Pair<ContractTest, String>>,
+        testScenarios: Sequence<Decision<Pair<ContractTest, String>, Scenario>>,
         actuatorBaseURL: String,
         timeoutInMilliseconds: Long,
     ): Stream<DynamicTest>
@@ -476,7 +463,18 @@ open class SpecmaticJUnitSupport {
         logger.newLine()
 
         startTime = Instant.now()
-        return testScenarios.map { (contractTest, baseURL) ->
+        return testScenarios.mapNotNull { contractTestDecision ->
+            if (contractTestDecision !is Decision.Execute) {
+                logger.boundary()
+                logger.log(buildString {
+                    appendLine("--------------------")
+                    this.appendLine("Skipping ${contractTestDecision.context.defaultAPIDescription}")
+                    this.appendLine(contractTestDecision.reasoning.toRuleViolationText())
+                })
+                return@mapNotNull null
+            }
+
+            val (contractTest, baseURL) = contractTestDecision.value
             DynamicTest.dynamicTest(contractTest.testDescription()) {
                 LicenseResolver.utilize(
                     product = LicensedProduct.OPEN_SOURCE,
@@ -528,6 +526,10 @@ open class SpecmaticJUnitSupport {
                 } catch (e: Throwable) {
                     throw e
                 } finally {
+                    logger.log(buildString {
+                        appendLine("Execution reasons for ${contractTestDecision.context.defaultAPIDescription}")
+                        appendLine(contractTestDecision.reasoning.toRuleViolationText())
+                    })
                     if (testResult != null) {
                         contractTest.testResultRecord(testResult)?.let { testResultRecord ->
                             openApiCoverageReportInput.addTestReportRecords(testResultRecord)
@@ -535,7 +537,29 @@ open class SpecmaticJUnitSupport {
                     }
                 }
             }
-        }.asStream()
+        }.ifEmpty { noTestsFoundError(noTestsFoundErrorMessage()) }.asStream()
+    }
+
+    private fun noTestsFoundErrorMessage(): String {
+        val filterDetails = buildString {
+            if (!settings.filterName.isNullOrBlank()) append("name filter: '${settings.filterName}'")
+            if (!settings.filterNotName.isNullOrBlank()) {
+                if (isNotEmpty()) append(", ")
+                append("exclude filter: '${settings.filterNotName}'")
+            }
+            if (testFilter.expression != null) {
+                if (isNotEmpty()) append(", ")
+                append("expression filter: \"${specmaticConfig.getTestFilter()}\"")
+            }
+        }
+
+        val reason = if (filterDetails.isNotEmpty()) {
+            "Applied filters ($filterDetails) matched no test scenarios."
+        } else {
+            "No test scenarios found."
+        }
+
+        return reason
     }
 
     fun constructTestBaseURL(): String {
@@ -663,8 +687,7 @@ open class SpecmaticJUnitSupport {
         }
 
         val featureWithExternalizedExamples = feature.loadExternalisedExamples()
-
-        val filteredScenariosBasedOnName = selectTestsToRun(
+        val filteredScenarioDecisionsBasedOnName = selectTestsToRun(
             featureWithExternalizedExamples.scenarios.asSequence(),
             filterName,
             filterNotName
@@ -672,14 +695,16 @@ open class SpecmaticJUnitSupport {
             it.testDescription()
         }
 
-        val filteredScenarios = filterUsing(
-            filteredScenariosBasedOnName,
+        val filteredScenarioDecisionsBasedOnFilter = filterUsingDecisions(
+            filteredScenarioDecisionsBasedOnName,
             filter
         )
 
-        val filteredEndpoints = filteredScenarios.map { scenario ->
+        val filteredEndpoints = filteredScenarioDecisionsBasedOnFilter.mapNotNull { decision ->
+            if (decision !is Decision.Execute) return@mapNotNull null
+            val scenario = decision.value
             Endpoint(
-                convertPathParameterStyle(scenario.path),
+                convertPathParameterStyle(decision.value.path),
                 scenario.method,
                 scenario.httpResponsePattern.status,
                 scenario.soapActionUnescaped,
@@ -694,19 +719,20 @@ open class SpecmaticJUnitSupport {
             )
         }.toList()
 
-        val filteredFeature = featureWithExternalizedExamples.copy(scenarios = filteredScenarios.toList())
-        val (validExampleFeature, result) = filteredFeature.validateAndFilterExamples()
+        val (validatedScenarioDecisions, result) = featureWithExternalizedExamples.validateAndFilterExamples(filteredScenarioDecisionsBasedOnFilter)
         if (specmaticConfig.getTestLenientMode() == false) result.throwOnFailure()
 
+        val validatedScenarios = validatedScenarioDecisions.mapNotNull { (it as? Decision.Execute)?.value }
+        val validExampleFeature = featureWithExternalizedExamples.copy(scenarios = validatedScenarios.toList())
         validExampleFeature.validateExamplesOrException()
-        val tests: Sequence<ContractTest> = validExampleFeature.also {
+        val tests = validExampleFeature.also {
             if (it.scenarios.isEmpty()) {
                 logger.log("All scenarios were filtered out.")
             } else if (it.scenarios.size < feature.scenarios.size) {
                 logger.debug("Selected scenarios:")
                 it.scenarios.forEach { scenario -> logger.debug(scenario.testDescription().prependIndent("  ")) }
             }
-        }.generateContractTests(suggestions, originalScenarios = feature.scenarios)
+        }.generateContractTestsWithDecision(suggestions, feature.scenarios, validatedScenarioDecisions)
 
         return LoadedTestScenarios(tests, allEndpoints, filteredEndpoints, result)
     }
@@ -775,14 +801,14 @@ open class SpecmaticJUnitSupport {
 }
 
 data class LoadedTestScenarios(
-    val scenarios: Sequence<ContractTest>,
+    val scenarios: Sequence<Decision<ContractTest, Scenario>>,
     val allEndpoints: List<Endpoint>,
     val filteredEndpoints: List<Endpoint>,
     val exampleValidationResult: Result = Result.Success()
 )
 
 private data class TestData(
-    val scenarios: Sequence<Pair<ContractTest, String>>,
+    val scenarios: Sequence<Decision<Pair<ContractTest, String>, Scenario>>,
     val allEndpoints: List<Endpoint>,
     val filteredEndpoints: List<Endpoint>,
     val baseUrls: Set<String>,
@@ -811,21 +837,35 @@ fun <T> selectTestsToRun(
     filterName: String? = null,
     filterNotName: String? = null,
     getTestDescription: (T) -> String
-): Sequence<T> {
+): Sequence<Decision<T, T>> {
+    val decisionSequence = testScenarios.map { Decision.Execute(it, it) }
+    return selectTestsToRunWithDecision(decisionSequence, filterName, filterNotName) {
+        getTestDescription(it)
+    }
+}
+
+fun <T, U> selectTestsToRunWithDecision(
+    testScenarios: Sequence<Decision<T, U>>,
+    filterName: String? = null,
+    filterNotName: String? = null,
+    getTestDescription: (T) -> String
+): Sequence<Decision<T, U>> {
     val filteredByName = if (!filterName.isNullOrBlank()) {
         val filterNames = filterName.split(",").map { it.trim() }
-
-        testScenarios.filter { test ->
-            filterNames.any { getTestDescription(test).contains(it) }
+        testScenarios.map { test ->
+            if (test !is Decision.Execute) return@map test
+            if (filterNames.any { getTestDescription(test.value).contains(it) }) return@map test
+            Decision.Skip(test.context, Reasoning(TestRuleViolations.EXCLUDED))
         }
     } else
         testScenarios
 
-    val filteredByNotName: Sequence<T> = if (!filterNotName.isNullOrBlank()) {
+    val filteredByNotName = if (!filterNotName.isNullOrBlank()) {
         val filterNotNames = filterNotName.split(",").map { it.trim() }
-
-        filteredByName.filterNot { test ->
-            filterNotNames.any { getTestDescription(test).contains(it) }
+        filteredByName.map { test ->
+            if (test !is Decision.Execute) return@map test
+            if (!filterNotNames.any { getTestDescription(test.value).contains(it) }) return@map test
+            Decision.Skip(test.context, Reasoning(TestRuleViolations.EXCLUDED))
         }
     } else
         filteredByName

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -838,7 +838,7 @@ fun <T> selectTestsToRun(
     filterNotName: String? = null,
     getTestDescription: (T) -> String
 ): Sequence<Decision<T, T>> {
-    val decisionSequence = testScenarios.map { Decision.Execute(it, it) }
+    val decisionSequence = testScenarios.map { Decision.execute(it) }
     return selectTestsToRunWithDecision(decisionSequence, filterName, filterNotName) {
         getTestDescription(it)
     }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/TestHooks.kt
@@ -5,8 +5,10 @@ import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.log.HttpLogMessage
+import io.specmatic.core.utilities.Decision
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
+import io.specmatic.test.ContractTest
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.reports.coverage.Endpoint
 
@@ -35,6 +37,7 @@ interface TestReportListener {
     fun onCoverageCalculated(coverage: Int)
     fun onPathCoverageCalculated(path: String, pathCoverage: Int)
     fun onGovernance(result: Result)
+    fun onTestDecision(decision: Decision<Pair<ContractTest, String>, Scenario>)
 }
 
 internal fun List<TestReportListener>.onEachListener(block: TestReportListener.() -> Unit) {

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -1,9 +1,11 @@
 package io.specmatic.test.reports.coverage
 
 import io.specmatic.core.Result
+import io.specmatic.core.Scenario
 import io.specmatic.core.filters.ExpressionStandardizer
 import io.specmatic.core.filters.TestRecordFilter
 import io.specmatic.core.log.HttpLogMessage
+import io.specmatic.core.utilities.Decision
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.generated.dto.coverage.CoverageEntry
@@ -14,6 +16,7 @@ import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
+import io.specmatic.test.ContractTest
 import io.specmatic.test.HttpInteractionsLog
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.TestResultRecord.Companion.getCoverageStatus
@@ -79,6 +82,8 @@ class OpenApiCoverageReportInput(
     fun onProcessingComplete() = coverageHooks.onEachListener { onEnd() }
 
     fun onGovernanceResult(result: Result) = coverageHooks.onEachListener { onGovernance(result) }
+
+    fun onTestDecision(decision: Decision<Pair<ContractTest, String>, Scenario>) = coverageHooks.onEachListener { onTestDecision(decision) }
 
     fun totalDuration(): Long {
         return httpInteractionsLog.totalDuration()

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInput.kt
@@ -1,11 +1,14 @@
 package io.specmatic.test.reports.coverage
 
+import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.filters.ExpressionStandardizer
 import io.specmatic.core.filters.TestRecordFilter
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.utilities.Decision
+import io.specmatic.core.utilities.Reasoning
+import io.specmatic.core.utilities.mapValue
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.generated.dto.coverage.CoverageEntry
@@ -42,6 +45,7 @@ class OpenApiCoverageReportInput(
     private val httpInteractionsLog: HttpInteractionsLog = HttpInteractionsLog(),
     private val previousTestResultRecord: List<TestResultRecord> = emptyList(),
     private val filteredEndpoints: MutableList<Endpoint> = mutableListOf(),
+    private val skipDecisions: MutableMap<Endpoint, Reasoning> = mutableMapOf(),
 ) {
     fun endpoints() = allEndpoints.toList()
 
@@ -127,6 +131,25 @@ class OpenApiCoverageReportInput(
         this.filteredEndpoints.addAll(filteredEndpoints)
         val excludedEndpoints = allEndpoints.toSet().minus(filteredEndpoints.toSet()).toList()
         coverageHooks.onEachListener { onEndpointApis(endpointsNotExcluded = filteredEndpoints, endpointsExcluded = excludedEndpoints) }
+    }
+
+    fun addSkipReasoning(skipDecision: Decision<Scenario, Scenario>) {
+        if (skipDecision !is Decision.Skip) return
+        val endpoint = Endpoint(
+            path = convertPathParameterStyle(skipDecision.context.path),
+            method = skipDecision.context.method,
+            responseStatus = skipDecision.context.httpResponsePattern.status,
+            soapAction = skipDecision.context.soapActionUnescaped,
+            sourceProvider = skipDecision.context.sourceProvider,
+            sourceRepository = skipDecision.context.sourceRepository,
+            sourceRepositoryBranch = skipDecision.context.sourceRepositoryBranch,
+            specification = skipDecision.context.specification,
+            requestContentType = skipDecision.context.requestContentType,
+            responseContentType = skipDecision.context.responseContentType,
+            protocol = skipDecision.context.protocol,
+            specType = skipDecision.context.specType
+        )
+        skipDecisions[endpoint] = skipDecision.reasoning
     }
 
     fun setEndpointsAPIFlag(isSet: Boolean) {
@@ -235,6 +258,7 @@ class OpenApiCoverageReportInput(
                     path = endpoint.path,
                     method = endpoint.method,
                     requestContentType = endpoint.requestContentType,
+                    responseContentType = endpoint.responseContentType,
                     responseStatus = endpoint.responseStatus,
                     request = null,
                     response = null,
@@ -250,9 +274,11 @@ class OpenApiCoverageReportInput(
                             method = endpoint.method,
                             contentType = endpoint.requestContentType,
                             responseCode = endpoint.responseStatus,
+                            responseContentType = endpoint.responseContentType,
                             protocol = endpoint.protocol
                         )
-                    )
+                    ),
+                    reasoning = skipDecisions.getOrDefault(endpoint, Reasoning())
                 )
             }
         )
@@ -425,6 +451,7 @@ class OpenApiCoverageReportInput(
                     method = testResult.method,
                     contentType = testResult.requestContentType,
                     responseCode = testResult.actualResponseStatus,
+                    responseContentType = testResult.responseContentType,
                     protocol = SpecmaticProtocol.HTTP
                 )
             ),

--- a/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/ApiCoverageReportInputTest.kt
@@ -13,12 +13,18 @@ import io.specmatic.test.reports.coverage.console.OpenAPICoverageConsoleReport
 import io.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
 import io.specmatic.test.reports.renderers.CoverageReportTextRenderer
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
 class ApiCoverageReportInputTest {
     companion object {
         const val CONFIG_FILE_PATH = "./specmatic.json"
         val specmaticConfig = SpecmaticConfig()
+    }
+
+    @AfterEach
+    fun clearFilterProperty() {
+        System.clearProperty(FILTER)
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/CtrfApiCoverageReportIntegrationTest.kt
@@ -3,10 +3,12 @@ package io.specmatic.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
+import io.specmatic.core.utilities.Reasoning
 import io.specmatic.reporter.ctrf.CtrfReportGenerator
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
+import io.specmatic.test.TestSkipReason
 import io.specmatic.test.TestResultRecord.Companion.getCoverageStatus
 import io.specmatic.test.reports.coverage.Endpoint
 import io.specmatic.test.reports.coverage.OpenApiCoverageReportInput
@@ -50,6 +52,7 @@ class CtrfApiCoverageReportIntegrationTest {
                     specification = actualSpec.canonicalPath,
                     specType = SpecType.OPENAPI,
                     requestContentType = endpoint.requestContentType,
+                    responseContentType = endpoint.responseContentType,
                 )
             )
         }
@@ -151,6 +154,7 @@ class CtrfApiCoverageReportIntegrationTest {
                     specification = endpoint.specification,
                     specType = SpecType.OPENAPI,
                     requestContentType = endpoint.requestContentType,
+                    responseContentType = endpoint.responseContentType,
                 )
             )
         }
@@ -282,6 +286,43 @@ class CtrfApiCoverageReportIntegrationTest {
         assertThat(findTextValue(reportNode, "apiCoverage")).isEqualTo("100%")
         assertThat(tests.single()["extra"]["wip"].asBoolean()).isTrue()
         assertThat(executionOperations.single()["coverageStatus"].asText()).isEqualTo("WIP")
+    }
+
+    @Test
+    fun `ctrf report should include decision snapshots in final test entries`() {
+        val specFile = File("src/test/resources/openapi/api_coverage/openapi.yaml").canonicalFile
+        val endpoint = Endpoint(
+            path = "/pets/find",
+            method = "GET",
+            responseStatus = 200,
+            specification = specFile.canonicalPath,
+            protocol = io.specmatic.license.core.SpecmaticProtocol.HTTP,
+            specType = SpecType.OPENAPI,
+        )
+
+        val input = OpenApiCoverageReportInput(configFilePath = specFile.canonicalPath, endpointsAPISet = true)
+        input.addEndpoints(listOf(endpoint), listOf(endpoint))
+        input.addTestReportRecords(
+            TestResultRecord(
+                path = endpoint.path,
+                method = endpoint.method,
+                responseStatus = endpoint.responseStatus,
+                request = null,
+                response = null,
+                result = TestResult.NotCovered,
+                specification = endpoint.specification,
+                specType = SpecType.OPENAPI,
+                reasoning = Reasoning(mainReason = TestSkipReason.EXCLUDED),
+            )
+        )
+
+        val consoleReport = input.generate()
+        val reportNode = ctrfReportNode(input, consoleReport)
+        val decisions = reportNode["results"]["tests"].single()["extra"]["decisions"].toList()
+        assertThat(decisions).hasSize(1)
+        assertThat(decisions.single()["id"].asText()).isNotBlank()
+        assertThat(decisions.single()["title"].asText()).isNotBlank()
+        assertThat(decisions.single()["summary"].asText()).contains("did not match the selected filters")
     }
 
     private fun findTextValue(node: com.fasterxml.jackson.databind.JsonNode, fieldName: String): String? {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/FilterIntegrationTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/FilterIntegrationTest.kt
@@ -6,6 +6,7 @@ import io.specmatic.reporter.model.TestResult
 import io.specmatic.stub.ContractStub
 import io.specmatic.stub.createStub
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
@@ -20,10 +21,15 @@ import java.util.stream.Stream
 private const val MESSAGE_FRAGMENT_WHEN_NO_TESTS_WERE_FOUND = "No tests found to run"
 
 class FilterIntegrationTest {
+    @AfterEach
+    fun restoreFilterProperty() {
+        System.clearProperty(FILTER_PROPERTY_KEY)
+    }
+
     @ParameterizedTest
     @MethodSource("filterProvider")
     fun contractTestWithDifferentFilters(filter: String, expectedSuccessfulTestCount: Int) {
-        System.setProperty("filter", filter)
+        System.setProperty(FILTER_PROPERTY_KEY, filter)
 
         val contractTestHarness = SpecmaticJUnitSupport()
 
@@ -43,7 +49,7 @@ class FilterIntegrationTest {
 
     @Test
     fun shouldThrowExceptionWhenNoTestsFoundDueToFiltering() {
-        System.setProperty("filter", "METHOD='NONEXISTENT'")
+        System.setProperty(FILTER_PROPERTY_KEY, "METHOD='NONEXISTENT'")
 
         val tests = SpecmaticJUnitSupport().contractTest().toList()
 
@@ -61,7 +67,7 @@ class FilterIntegrationTest {
 
     @Test
     fun shouldNotThrowExceptionWhenTestsRunButNoneSucceed() {
-        System.setProperty("filter", "EXAMPLE-NAME='SUCCESS'")
+        System.setProperty(FILTER_PROPERTY_KEY, "EXAMPLE-NAME='SUCCESS'")
 
         val tests = SpecmaticJUnitSupport().contractTest().toList()
 
@@ -79,6 +85,8 @@ class FilterIntegrationTest {
     }
 
     companion object {
+        private const val FILTER_PROPERTY_KEY = "filter"
+
         @JvmStatic
         fun filterProvider(): Stream<Arguments> {
             return Stream.of(

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.test
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
+import io.specmatic.core.Scenario
 import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.SpecmaticConfigV1V2Common
 import io.specmatic.core.TestConfig
@@ -37,6 +38,7 @@ import io.specmatic.test.SpecmaticJUnitSupport.Companion.TEST_BASE_URL
 import io.specmatic.test.listeners.ContractExecutionListener
 import io.specmatic.test.reports.TestReportListener
 import io.specmatic.test.reports.coverage.Endpoint
+import io.specmatic.test.reports.TestExecutionResult
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.AfterEach
@@ -757,6 +759,22 @@ paths:
     }
 
     @Test
+    fun `contractTest should send test decisions to coverage hooks via OpenApiCoverageReportInput`() {
+        val listener = RecordingTestDecisionListener()
+        val specFile = File("src/test/resources/openapi/alpha_beta_spec.yaml")
+        val (server, baseUrl) = startAlphaBetaStubServer()
+
+        try {
+            SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(testBaseURL = baseUrl, contractPaths = specFile.canonicalPath, coverageHooks = listOf(listener)))
+            SpecmaticJUnitSupport().contractTest().toList()
+            assertThat(listener.decisions).isNotEmpty.allSatisfy { assertThat(it).isInstanceOf(Decision.Execute::class.java) }
+        } finally {
+            server.stop(0)
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
     fun `should load soapAction from scenarios into Endpoints if specification is WSDL`() {
         val specFile = File("src/test/resources/simple.wsdl")
         val specmaticJUnitSupport = SpecmaticJUnitSupport()
@@ -1134,6 +1152,26 @@ paths:
         override fun onCoverageCalculated(coverage: Int) = Unit
         override fun onPathCoverageCalculated(path: String, pathCoverage: Int) = Unit
         override fun onGovernance(result: Result) = Unit
+        override fun onTestDecision(decision: Decision<Pair<ContractTest, String>, Scenario>) = Unit
+    }
+
+    private class RecordingTestDecisionListener : TestReportListener {
+        val decisions = mutableListOf<Decision<Pair<ContractTest, String>, Scenario>>()
+
+        override fun onTestDecision(decision: Decision<Pair<ContractTest, String>, Scenario>) {
+            decisions.add(decision)
+        }
+
+        override fun onEndpointApis(endpointsNotExcluded: List<Endpoint>, endpointsExcluded: List<Endpoint>) = Unit
+        override fun onActuatorApis(apisNotExcluded: List<API>, apisExcluded: List<API>) = Unit
+        override fun onPathCoverageCalculated(path: String, pathCoverage: Int) = Unit
+        override fun onExampleErrors(resultsBySpecFile: Map<String, Result>) = Unit
+        override fun onTestResult(result: TestExecutionResult) = Unit
+        override fun onCoverageCalculated(coverage: Int) = Unit
+        override fun onActuator(enabled: Boolean) = Unit
+        override fun onGovernance(result: Result) = Unit
+        override fun onTestsComplete() = Unit
+        override fun onEnd() = Unit
     }
 
     @AfterEach

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -603,7 +603,7 @@ paths:
     }
 
     @Test
-    fun `contractTest should skip scenarios beyond maxTestCount and still print execution reasons for executed tests`(@TempDir tempDir: File) {
+    fun `contractTest should skip scenarios beyond maxTestCount`(@TempDir tempDir: File) {
         val specFile = File("src/test/resources/openapi/alpha_beta_spec.yaml")
         val configFile = writeSpecmaticConfig(tempDir, baseUrl = null, maxTestCount = 1)
         val (server, baseUrl) = startAlphaBetaStubServer()
@@ -613,12 +613,6 @@ paths:
                 val tests = SpecmaticJUnitSupport().contractTest()
                 assertDoesNotThrow { tests.forEach { it.executable.execute() } }
             }
-
-            assertThat(output).containsSubsequence(
-                "Executed Scenario: GET /alpha -> 200 (returns application/json) with the request from the example 'ok'",
-                "Executed Using Example",
-                "This operation was executed by using an available example"
-            )
 
             assertThat(output).containsSubsequence(
                 "Skipping Scenario: GET /beta -> 200 (returns application/json) with the request from the example 'ok'",

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -577,7 +577,7 @@ paths:
             }
 
             assertThat(output).containsSubsequence(
-                "Skipping Scenario: GET /beta -> 200 (returns application/json)", "Excluded from Run",
+                "Skipping Scenario: GET /beta -> 200 (responseContentType application/json)", "Excluded from Run",
                 "This operation was skipped because it did not match the selected filters"
             )
         } finally {
@@ -615,7 +615,7 @@ paths:
             }
 
             assertThat(output).containsSubsequence(
-                "Skipping Scenario: GET /beta -> 200 (returns application/json) with the request from the example 'ok'",
+                "Skipping Scenario: GET /beta -> 200 (responseContentType application/json) with the request from the example 'ok'",
                 "Maximum Test Count Exceeded",
                 "This operation was skipped because it exceeded the maximum test count"
             )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -576,7 +576,7 @@ paths:
             }
 
             assertThat(output).containsSubsequence(
-                "Skipping GET /beta -> 200 (returns application/json)", "Excluded from Run",
+                "Skipping Scenario: GET /beta -> 200 (returns application/json)", "Excluded from Run",
                 "This operation was skipped because it did not match the selected filters"
             )
         } finally {
@@ -614,13 +614,13 @@ paths:
             }
 
             assertThat(output).containsSubsequence(
-                "Executed GET /alpha -> 200 (returns application/json)",
+                "Executed Scenario: GET /alpha -> 200 (returns application/json) with the request from the example 'ok'",
                 "Executed Using Example",
                 "This operation was executed by using an available example"
             )
 
             assertThat(output).containsSubsequence(
-                "Skipping GET /beta -> 200 (returns application/json)",
+                "Skipping Scenario: GET /beta -> 200 (returns application/json) with the request from the example 'ok'",
                 "Maximum Test Count Exceeded",
                 "This operation was skipped because it exceeded the maximum test count"
             )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -25,6 +25,7 @@ import io.specmatic.core.config.v3.components.sources.SourceV3
 import io.specmatic.core.filters.ScenarioMetadataFilter
 import io.specmatic.core.utilities.yamlMapper
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.utilities.Decision
 import io.specmatic.core.utilities.Flags
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
@@ -474,14 +475,10 @@ paths:
                 filter = ScenarioMetadataFilter.from("")
             )
 
+            // Verify the test name contains the correct endpoint and size
             val testsWithStrictModeList = testsWithStrictMode.toList()
-            val testCountWithStrictMode = testsWithStrictModeList.size
-
-            // Only GET /users/{id} should generate tests (has external example)
-            assertThat(testCountWithStrictMode).isEqualTo(1)
-
-            // Verify the test name contains the correct endpoint
-            val testDescriptionsWithStrictMode = testsWithStrictModeList.map { it.testDescription() }
+            val testDescriptionsWithStrictMode = testsWithStrictModeList.executedTestDescriptions()
+            assertThat(testDescriptionsWithStrictMode.size).isEqualTo(1)
             assertThat(testDescriptionsWithStrictMode).allMatch {
                 it.contains("GET /users/(id:number) -> 200")
             }
@@ -514,14 +511,10 @@ paths:
                 filter = ScenarioMetadataFilter.from("")
             )
 
+            // Verify test names include both endpoints and size
             val testsWithoutStrictModeList = testsWithoutStrictMode.toList()
-            val testCountWithoutStrictMode = testsWithoutStrictModeList.size
-
-            // Both endpoints should generate tests when strictMode is false
-            assertThat(testCountWithoutStrictMode).isGreaterThan(1)
-
-            // Verify test names include both endpoints
-            val testDescriptionsWithoutStrictMode = testsWithoutStrictModeList.map { it.testDescription() }
+            val testDescriptionsWithoutStrictMode = testsWithoutStrictModeList.executedTestDescriptions()
+            assertThat(testDescriptionsWithoutStrictMode.size).isGreaterThan(1)
             assertThat(testDescriptionsWithoutStrictMode).anyMatch {
                 it.contains("GET /users/(id:number) -> 200")
             }
@@ -544,7 +537,7 @@ paths:
             filter = ScenarioMetadataFilter.from("!(PATH='/products' && METHOD='POST' && STATUS='201')")
         )
 
-        assertThat(testData.scenarios.map { it.testDescription() }.toList()).doesNotContain(" Scenario: POST /products -> 201 with the request from the example 'SUCCESS'")
+        assertThat(testData.scenarios.executedTestDescriptions()).doesNotContain(" Scenario: POST /products -> 201 with the request from the example 'SUCCESS'")
         assertThat(testData.allEndpoints).contains(
             Endpoint(
                 path = "/products",
@@ -596,7 +589,7 @@ paths:
             )
         }
 
-        assertThat(loaded.scenarios.map { it.testDescription() }.toList()).allMatch { it.contains("GET /order_action_figure") }
+        assertThat(loaded.scenarios.executedTestDescriptions()).allMatch { it.contains("GET /order_action_figure") }
     }
 
     @Test
@@ -616,7 +609,7 @@ paths:
             )
         }
 
-        assertThat(loaded.scenarios.map { it.testDescription() }.toList())
+        assertThat(loaded.scenarios.executedTestDescriptions())
             .hasSize(1)
             .allMatch { it.contains("GET /orders -> 200") }
     }
@@ -636,7 +629,7 @@ paths:
             filter = ScenarioMetadataFilter.from("")
         )
 
-        val testDescriptions = loaded.scenarios.map { it.testDescription() }.toList()
+        val testDescriptions = loaded.scenarios.executedTestDescriptions()
         assertThat(loaded.exampleValidationResult).isInstanceOf(Result.Failure::class.java)
         assertThat(loaded.exampleValidationResult.reportString()).contains("invalid_test_GET_200.json").contains("Error loading example")
         assertThat(testDescriptions).anyMatch { it.contains("POST /test -> 201") }
@@ -1046,4 +1039,18 @@ paths:
         SpecmaticJUnitSupport.settingsStaging.remove()
         System.getProperties().keys.minus(initialPropertyKeys).forEach { println("Clearing $it"); System.clearProperty(it.toString()) }
     }
+}
+
+private fun Iterable<Decision<ContractTest, *>>.executedTestDescriptions(): List<String> {
+    return this.mapNotNull { decision ->
+        if (decision is Decision.Execute) decision.value.testDescription()
+        else null
+    }
+}
+
+private fun Sequence<Decision<ContractTest, *>>.executedTestDescriptions(): List<String> {
+    return this.mapNotNull { decision ->
+        if (decision is Decision.Execute) decision.value.testDescription()
+        else null
+    }.toList()
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -50,6 +50,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.junit.platform.launcher.TestExecutionListener
 import org.opentest4j.TestAbortedException
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
 import java.io.File
 import java.io.PrintStream
 import java.util.*
@@ -561,6 +563,72 @@ paths:
     }
 
     @Test
+    fun `contractTest should mark scenarios as EXCLUDED when filter excludes them`(@TempDir tempDir: File) {
+        val specFile = File("src/test/resources/openapi/alpha_beta_spec.yaml")
+        val (server, baseUrl) = startAlphaBetaStubServer()
+        try {
+            SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(testBaseURL = baseUrl, contractPaths = specFile.canonicalPath, configFile = "", generative = false, filter = "PATH='/alpha'",))
+            val output = captureStdout {
+                val tests = SpecmaticJUnitSupport().contractTest().toList()
+                assertThat(tests).hasSize(1)
+            }
+
+            assertThat(output).containsSubsequence(
+                "Skipping GET /beta -> 200", "Excluded from Run",
+                "This operation was skipped because it did not match the selected filters"
+            )
+        } finally {
+            server.stop(0)
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `contractTest should use expression filter in no tests found message and mark scenarios as EXCLUDED`(@TempDir tempDir: File) {
+        val specFile = File("src/test/resources/openapi/alpha_beta_spec.yaml")
+        val (server, baseUrl) = startAlphaBetaStubServer()
+        try {
+            SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(testBaseURL = baseUrl, contractPaths = specFile.canonicalPath, configFile = "", generative = false, filter = "METHOD='PATCH'"))
+            val tests = SpecmaticJUnitSupport().contractTest().toList()
+            val error = assertThrows<AssertionError> { tests.single().executable.execute() }
+            assertThat(error.message).contains("No tests found to run.")
+            assertThat(error.message).contains("expression filter: \"METHOD='PATCH'\"")
+        } finally {
+            server.stop(0)
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `contractTest should skip scenarios beyond maxTestCount and still print execution reasons for executed tests`(@TempDir tempDir: File) {
+        val specFile = File("src/test/resources/openapi/alpha_beta_spec.yaml")
+        val configFile = writeSpecmaticConfig(tempDir, baseUrl = null, maxTestCount = 1)
+        val (server, baseUrl) = startAlphaBetaStubServer()
+        try {
+            SpecmaticJUnitSupport.settingsStaging.set(ContractTestSettings(testBaseURL = baseUrl, contractPaths = specFile.canonicalPath, configFile = configFile.canonicalPath, generative = false, filter = ""))
+            val output = captureStdout {
+                val tests = SpecmaticJUnitSupport().contractTest()
+                assertDoesNotThrow { tests.forEach { it.executable.execute() } }
+            }
+
+            assertThat(output).containsSubsequence(
+                "Execution reasons for GET /alpha -> 200",
+                "Executed Using Example",
+                "This operation was executed by using an available example"
+            )
+
+            assertThat(output).containsSubsequence(
+                "Skipping GET /beta -> 200",
+                "Maximum Test Count Exceeded",
+                "This operation was skipped because it exceeded the maximum test count"
+            )
+        } finally {
+            server.stop(0)
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
     fun `should load only example of scenarios which have been filtered`() {
         val specFile = File("src/test/resources/invalid_example/openapi.yaml")
         assertDoesNotThrow {
@@ -999,7 +1067,7 @@ paths:
             .isEqualTo(0)
     }
 
-    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null): File {
+    private fun writeSpecmaticConfig(tempDir: File, baseUrl: String? = null, maxTestCount: Int? = null): File {
         val configFile = tempDir.resolve("specmatic.yaml")
         val config = SpecmaticConfigV3(
             version = SpecmaticConfigVersion.VERSION_3,
@@ -1008,13 +1076,47 @@ paths:
                     CommonServiceConfig(
                         definitions = emptyList(),
                         runOptions = RefOrValue.Value(TestRunOptions(openapi = OpenApiTestConfig(baseUrl = baseUrl))),
-                        settings = RefOrValue.Value(TestSettings())
+                        settings = RefOrValue.Value(TestSettings(maxTestCount = maxTestCount))
                     )
                 )
             )
         )
         configFile.writeText(yamlMapper.writeValueAsString(config))
         return configFile
+    }
+
+    private fun startAlphaBetaStubServer(): Pair<HttpServer, String> {
+        val server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/alpha") { exchange ->
+            val bytes = """{"value":"alpha"}""".toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+
+        server.createContext("/beta") { exchange ->
+            val bytes = """{"value":"beta"}""".toByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+
+        server.start()
+        val baseUrl = "http://localhost:${server.address.port}"
+        return server to baseUrl
+    }
+
+    private fun captureStdout(block: () -> Unit): String {
+        val originalOut = System.out
+        val outputStream = java.io.ByteArrayOutputStream()
+        System.setOut(PrintStream(outputStream))
+        return try {
+            block()
+            outputStream.toString()
+        } finally {
+            System.out.flush()
+            System.setOut(originalOut)
+        }
     }
 
     private class RecordingExampleErrorsListener : TestReportListener {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -574,7 +574,7 @@ paths:
             }
 
             assertThat(output).containsSubsequence(
-                "Skipping GET /beta -> 200", "Excluded from Run",
+                "Skipping GET /beta -> 200 (returns application/json)", "Excluded from Run",
                 "This operation was skipped because it did not match the selected filters"
             )
         } finally {
@@ -612,13 +612,13 @@ paths:
             }
 
             assertThat(output).containsSubsequence(
-                "Execution reasons for GET /alpha -> 200",
+                "Execution reasons for GET /alpha -> 200 (returns application/json)",
                 "Executed Using Example",
                 "This operation was executed by using an available example"
             )
 
             assertThat(output).containsSubsequence(
-                "Skipping GET /beta -> 200",
+                "Skipping GET /beta -> 200 (returns application/json)",
                 "Maximum Test Count Exceeded",
                 "This operation was skipped because it exceeded the maximum test count"
             )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.test
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.Result
+import io.specmatic.core.ResiliencyTestSuite
 import io.specmatic.core.Scenario
 import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.SpecmaticConfigV1V2Common
@@ -680,8 +681,39 @@ paths:
         }
 
         assertThat(loaded.scenarios.executedTestDescriptions())
-            .hasSize(1)
-            .allMatch { it.contains("GET /orders -> 200") }
+            .anyMatch { it.contains("GET /orders -> 200") }
+    }
+
+    @Test
+    fun `loadTestScenarios should generate 4xx negative scenarios from externalized 2xx examples`() {
+        val specFile = File("src/test/resources/openapi/filter_by_tags_externalized_examples.yaml")
+        val strictModeConfig = SpecmaticConfigV1V2Common().withTestModes(strictMode = true, lenientMode = null)
+        val loaded = assertDoesNotThrow {
+            SpecmaticJUnitSupport().loadTestScenarios(
+                path = specFile.canonicalPath,
+                suggestionsPath = "",
+                suggestionsData = "",
+                config = TestConfig(emptyMap(), emptyMap()),
+                filterName = null,
+                filterNotName = null,
+                specmaticConfig = strictModeConfig,
+                generative = ResiliencyTestSuite.all,
+                filter = ScenarioMetadataFilter.from("")
+            )
+        }
+
+        val executedTestDescriptions = loaded.scenarios.executedTestDescriptions()
+        assertThat(executedTestDescriptions).anyMatch {
+            it.contains("-ve") &&
+                it.contains("GET /orders -> 4xx") &&
+                it.contains("with the request from the example 'INLINE_GET_ORDERS'")
+        }
+
+        assertThat(executedTestDescriptions).anyMatch {
+            it.contains("-ve") &&
+                it.contains("GET /orders -> 4xx") &&
+                it.contains("with the request from the example 'Get Orders'")
+        }
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -612,7 +612,7 @@ paths:
             }
 
             assertThat(output).containsSubsequence(
-                "Execution reasons for GET /alpha -> 200 (returns application/json)",
+                "Executed GET /alpha -> 200 (returns application/json)",
                 "Executed Using Example",
                 "This operation was executed by using an available example"
             )

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -793,7 +793,7 @@ class OpenApiCoverageReportInputTest {
 
         // Assert that the responseStatus of testResultRecord's operation is updated
         val missingInSpecTestResult = report.testResultRecords.single { it.result == TestResult.MissingInSpec }
-        assertThat(missingInSpecTestResult.operations.first()).isEqualTo(OpenAPIOperation("/current", "GET", null, 400, SpecmaticProtocol.HTTP))
+        assertThat(missingInSpecTestResult.operations.first()).isEqualTo(OpenAPIOperation("/current", "GET", null, 400, SpecmaticProtocol.HTTP, null))
     }
 
     @Test

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -1,13 +1,16 @@
 package io.specmatic.test.reports.coverage
 
 import io.specmatic.core.Result
+import io.specmatic.core.Scenario
 import io.specmatic.core.loadSpecmaticConfig
+import io.specmatic.core.utilities.Decision
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.API
+import io.specmatic.test.ContractTest
 import io.specmatic.test.TestResultRecord
 import io.specmatic.test.reports.OpenApiCoverageReportProcessor
 import io.specmatic.test.reports.TestExecutionResult
@@ -1247,5 +1250,6 @@ class OpenApiCoverageReportInputTest {
         override fun onTestsComplete() = Unit
         override fun onExampleErrors(resultsBySpecFile: Map<String, Result>) = Unit
         override fun onEnd() = Unit
+        override fun onTestDecision(decision: Decision<Pair<ContractTest, String>, Scenario>) = Unit
     }
 }

--- a/junit5-support/src/test/resources/openapi/alpha_beta_spec.yaml
+++ b/junit5-support/src/test/resources/openapi/alpha_beta_spec.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: Two Endpoints
+  version: 1.0.0
+paths:
+  /alpha:
+    get:
+      responses:
+        '200':
+          description: alpha ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: string
+                required:
+                  - value
+              examples:
+                ok:
+                  value:
+                    value: alpha
+  /beta:
+    get:
+      responses:
+        '200':
+          description: beta ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: string
+                required:
+                  - value
+              examples:
+                ok:
+                  value:
+                    value: beta

--- a/junit5-support/src/test/resources/openapi/filter_by_tags_externalized_examples.yaml
+++ b/junit5-support/src/test/resources/openapi/filter_by_tags_externalized_examples.yaml
@@ -12,6 +12,9 @@ paths:
           name: orderId
           schema:
             type: integer
+          examples:
+            INLINE_GET_ORDERS:
+              value: 5
       responses:
         '200':
           description: OK
@@ -24,6 +27,21 @@ paths:
                 properties:
                   id:
                     type: integer
+              examples:
+                INLINE_GET_ORDERS:
+                  value:
+                    id: 5
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
   /products:
     post:
       requestBody:


### PR DESCRIPTION
What: Introduces end-to-end response-content-type awareness in the example module(s) flow

Why: Request context was already considered, but response variants could still collide or be selected ambiguously. This closes that gap for multi-response-representation APIs

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
