### PR TITLE
Trigger min/max items bugs in Conformance tests

### DIFF
--- a/conformance-tests/src/test/resources/specs/008-constraints/012-array-minitems.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/012-array-minitems.yaml
@@ -23,7 +23,7 @@ paths:
                       type: string
                     members:
                       type: array
-                      minItems: 1
+                      minItems: 10
                       items:
                         type: string
     post:
@@ -42,7 +42,7 @@ paths:
                   type: string
                 members:
                   type: array
-                  minItems: 1
+                  minItems: 10
                   items:
                     type: string
       responses:

--- a/conformance-tests/src/test/resources/specs/008-constraints/013-array-maxitems.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/013-array-maxitems.yaml
@@ -23,7 +23,7 @@ paths:
                       type: string
                     choices:
                       type: array
-                      maxItems: 5
+                      maxItems: 0
                       items:
                         type: string
     post:
@@ -42,7 +42,7 @@ paths:
                   type: string
                 choices:
                   type: array
-                  maxItems: 5
+                  maxItems: 0
                   items:
                     type: string
       responses:

--- a/conformance-tests/src/test/resources/specs/008-constraints/020-combined-array-constraints.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/020-combined-array-constraints.yaml
@@ -23,8 +23,8 @@ paths:
                       type: string
                     tracks:
                       type: array
-                      minItems: 1
-                      maxItems: 50
+                      minItems: 50
+                      maxItems: 100
                       uniqueItems: true
                       items:
                         type: string
@@ -44,8 +44,8 @@ paths:
                   type: string
                 tracks:
                   type: array
-                  minItems: 1
-                  maxItems: 50
+                  minItems: 50
+                  maxItems: 100
                   uniqueItems: true
                   items:
                     type: string


### PR DESCRIPTION
The conditions were such that Specmatic's default incorrect behaviour wasn't being exposed in the tests. For example for `minItems: 1` test it would never trigger any issue because Specmatic always sends at least 1 item in an array by default while being oblivious to the `min` or `max` item constraints.

Now with https://github.com/specmatic/specmatic/pull/2365 merged these tests will prevent regressions to this behaviour.

- Saachi && Yogesh && Sahil pairing