### PR TITLE
fix: preserve mtlsEnabled in referenced v3 runOptions

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/HttpsConfiguration.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.config
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
@@ -108,6 +109,7 @@ data class HttpsConfiguration(
 
     fun keyPasswordOrDefault(): String = keyStore?.password ?: "forgotten"
 
+    @JsonIgnore
     fun isMtlsEnabled(): Boolean = mtlsEnabled == true
 
     fun overrideWith(other: HttpsConfiguration?): HttpsConfiguration {

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3ImplTest.kt
@@ -114,6 +114,45 @@ class SpecmaticConfigV3ImplTest {
     }
 
     @Test
+    fun `should resolve mTLS setting from referenced v3 mock run options cert`() {
+        val config = v3Config(
+            """
+            version: 3
+            components:
+              runOptions:
+                mtlsMock:
+                  openapi:
+                    type: mock
+                    host: localhost
+                    port: 9443
+                    cert:
+                      mtlsEnabled: true
+                      keyStore:
+                        file: ./server-cert.jks
+                      keyStorePassword: password
+            dependencies:
+              services:
+                - service:
+                    definitions:
+                      - definition:
+                          source:
+                            filesystem:
+                              directory: ./specs
+                          specs:
+                            - spec:
+                                id: order-api
+                                path: order.yaml
+                    runOptions:
+                      ${'$'}ref: "#/components/runOptions/mtlsMock"
+            """.trimIndent()
+        )
+
+        val incomingMtlsRegistry = config.getStubHttpsConfiguration().toIncomingMtlsRegistry()
+
+        assertThat(incomingMtlsRegistry.get("localhost", 9443)).isTrue()
+    }
+
+    @Test
     fun `should resolve mTLS setting from v3 wsdl mock run options cert`() {
         val config = v3Config(
             """


### PR DESCRIPTION
**What**

This pull request introduces improvements to the handling and testing of mutual TLS (mTLS) configuration in the Specmatic codebase. The main focus is on ensuring that mTLS settings are correctly resolved from referenced configuration sections, and on improving the internal representation of the `HttpsConfiguration` class.

**Why**

This was a bug fix. It should have worked in a reffed out `runOptions`, but the config loader was throwing an exception due to a serialization bug.

**How**

Enhancements to mTLS configuration handling and testing:

* Added a new test to verify that mTLS settings are correctly resolved from referenced v3 mock run options certs, ensuring configuration references work as expected (`SpecmaticConfigV3ImplTest.kt`).

Improvements to the `HttpsConfiguration` class:

* Added the `@JsonIgnore` annotation to the `isMtlsEnabled()` method to prevent it from being serialized, ensuring only relevant fields are included in JSON representations (`HttpsConfiguration.kt`).
* Imported `@JsonIgnore` to support the above change (`HttpsConfiguration.kt`).