### PR TITLE
Fix validate command path resolution for JSON spec files

### DIFF
--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -55,13 +55,15 @@ class ValidateCommand(
 
     private fun loadSpecificationData(): List<SpecificationWithExamples> {
         if (file != null) {
-            val specification = file ?: return emptyList()
-            val loadedData = recursiveSpecificationAndExampleClassifier.load(specification) ?: return emptyList()
+            val specification = resolvePath(file ?: return emptyList())
+            val normalizedSpecification = specification.canonicalFile
+            val entryDirectory = normalizedSpecification.parentFile ?: currentDirectoryProvider()
+            val loadedData = recursiveSpecificationAndExampleClassifier.load(normalizedSpecification, entryDirectory) ?: return emptyList()
             return listOf(loadedData)
         }
 
         if (directory != null) {
-            val resolvedDirectory = directory ?: return emptyList()
+            val resolvedDirectory = resolvePath(directory ?: return emptyList())
             return recursiveSpecificationAndExampleClassifier.loadAll(resolvedDirectory)
         }
 
@@ -75,17 +77,21 @@ class ValidateCommand(
 
     private fun validateArguments() {
         if (file != null) {
-            val specification = file ?: return
+            val specification = resolvePath(file ?: return)
             if (!specification.isFile)  throw ContractException("Specification is not a file ${specification.path}")
             if (!specification.exists()) throw ContractException("Specification ${specification.path} does not exist")
             if (!specification.canRead())  throw ContractException("Specification ${specification.path} cannot be read")
         }
 
         if (directory != null) {
-            val directory = directory ?: return
+            val directory = resolvePath(directory ?: return)
             if (!directory.isDirectory)  throw ContractException("${directory.path} is not a directory")
             if (!directory.exists()) throw ContractException("Directory ${directory.path} does not exist")
         }
+    }
+
+    private fun resolvePath(path: File): File {
+        return if (path.isAbsolute) path.canonicalFile else currentDirectoryProvider().resolve(path.path).canonicalFile
     }
 
     private fun File.normalizedPath(): String {

--- a/application/src/test/kotlin/application/ValidateCommandTest.kt
+++ b/application/src/test/kotlin/application/ValidateCommandTest.kt
@@ -261,6 +261,34 @@ class ValidateCommandTest {
     }
 
     @Test
+    fun `when validate is given a relative json spec file in current directory it does not fail`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("petstore.json")
+        specFile.writeText(
+            """
+            {
+              "openapi": "3.0.1",
+              "info": {
+                "title": "Test API",
+                "version": "1"
+              },
+              "paths": {}
+            }
+            """.trimIndent()
+        )
+
+        val validator = TrackingValidator()
+        val exitCode = CommandLine(
+            ValidateCommand(
+                validator = validator,
+                currentDirectoryProvider = { tempDir.canonicalFile }
+            )
+        ).execute("--spec-file", "petstore.json")
+
+        assertThat(exitCode).isZero()
+        assertThat(validator.validatedSpecifications).containsExactly(specFile.canonicalPath)
+    }
+
+    @Test
     fun `when malformed spec exists only under dot specmatic scan does not report it`(@TempDir tempDir: File) {
         val scannedSpec = writeOpenApiFile(tempDir.resolve("contracts/kept.yaml"))
         val malformedSpec = tempDir.resolve(".specmatic/repos/broken.yaml")


### PR DESCRIPTION
## Summary

### What
- resolve `--spec-file` and `--dir` paths against the command's current working directory before validation
- normalize direct spec-file inputs to canonical files before loading examples
- add a regression test for validating a relative `petstore.json` file from the current directory

### Why
- `validate` could fail when given a relative JSON spec path because the path and entry directory were not resolved consistently
- this caused JSON OpenAPI files in the current directory to hit an exception path instead of validating normally

### How
- added a `resolvePath` helper in `ValidateCommand`
- used the resolved path in both argument validation and specification loading
- passed an explicit entry directory for direct spec-file loading

## Testing
- `GRADLE_USER_HOME=/Users/joelrosario/.codex/worktrees/f998/specmatic/temp/.gradle ./gradlew :specmatic-executable:test --tests "application.ValidateCommandTest" --no-daemon`

## Checklist
- [x] Added/updated tests for the change
- [x] Kept the fix scoped to the reported issue