### PR TITLE
Fix OpenAPI requestBody optional default handling

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -118,7 +118,7 @@ class OpenApiSpecification(
 
         fun patternsFrom(jsonSchema: Map<String, Any?>, schemaName: String = "Schema"): Map<String, Pattern> {
             val definitions = try {
-                (jsonSchema["${'$'}defs"] as? Map<String, Any>).orEmpty()
+                (jsonSchema[$$"$defs"] as? Map<String, Any>).orEmpty()
             } catch (_: Throwable) {
                 emptyMap()
             }
@@ -144,8 +144,8 @@ class OpenApiSpecification(
                 when (value) {
                     is String -> {
                         when {
-                            key == "\$ref" && value.startsWith("#/\$defs/") -> value.replace(
-                                "#/\$defs/",
+                            key == $$"$ref" && value.startsWith($$"#/$defs/") -> value.replace(
+                                $$"#/$defs/",
                                 "#/components/schemas/"
                             )
 
@@ -401,7 +401,7 @@ class OpenApiSpecification(
             val pathNames = pathsNode.fieldNames().asSequence().toList()
             pathNames.forEach { pathName ->
                 val pathNode = pathsNode.get(pathName) as? ObjectNode ?: return@forEach
-                val ref = pathNode.get("\$ref")?.asText() ?: return@forEach
+                val ref = pathNode.get($$"$ref")?.asText() ?: return@forEach
                 if (!ref.startsWith("#/components/pathItems/")) return@forEach
 
                 val referencedPathItem = root.at(ref.removePrefix("#"))
@@ -410,7 +410,7 @@ class OpenApiSpecification(
                 val resolvedPathItem = referencedPathItem.deepCopy<ObjectNode>()
                 val inlineFieldNames = pathNode.fieldNames().asSequence().toList()
                 inlineFieldNames.forEach { fieldName ->
-                    if (fieldName != "\$ref") {
+                    if (fieldName != $$"$ref") {
                         val fieldValue = pathNode.get(fieldName)
                         if (fieldValue != null) {
                             resolvedPathItem.set<JsonNode>(fieldName, fieldValue.deepCopy())
@@ -1265,7 +1265,7 @@ class OpenApiSpecification(
         val headerComponentName = header.`$ref`.substringAfterLast("/")
         val hasReusableHeader = parsedOpenApi.components?.headers?.contains(headerComponentName) == true
         return Pair(
-            first = collectorContext.at("\$ref").requirePojo(
+            first = collectorContext.at($$"$ref").requirePojo(
                 message = { "Header reference '${header.`$ref`}' could not be resolved, defaulting to empty schema" },
                 extract = { parsedOpenApi.components?.headers?.get(headerComponentName) },
                 ruleViolation = { OpenApiLintViolations.UNRESOLVED_REFERENCE },
@@ -1284,7 +1284,7 @@ class OpenApiSpecification(
         val responseComponentName = response.`$ref`.substringAfterLast("/")
         val hasReusableResponse = parsedOpenApi.components?.responses?.contains(responseComponentName) == true
         return Pair(
-            first = collectorContext.at("\$ref").requirePojo(
+            first = collectorContext.at($$"$ref").requirePojo(
                 message = { "Response reference '${response.`$ref`}' could not be resolved, defaulting to empty response" },
                 extract = { parsedOpenApi.components?.responses?.get(responseComponentName) },
                 ruleViolation = { OpenApiLintViolations.UNRESOLVED_REFERENCE },
@@ -1566,7 +1566,7 @@ class OpenApiSpecification(
                         else
                             exampleRequestBuilder.examplesWithRequestBodies(exampleBodies, actualContentType)
 
-                    val bodyIsRequired: Boolean = requestBody.required ?: true
+                    val bodyIsRequired: Boolean = requestBody.required ?: false
 
                     val body = toSpecmaticPattern(mediaType, contentType = contentType, collectorContext = mediaTypeContext).let {
                         if (bodyIsRequired)
@@ -1960,7 +1960,7 @@ class OpenApiSpecification(
         }
 
         val schemasWithOneOf = deepListOfAllOfs.filter { it.schema.oneOf != null }
-        val oneOfs = schemasWithOneOf.map { (schemaToProcess, schemaPatternName, schemaCollectorContext) ->
+        val oneOfs = schemasWithOneOf.flatMap { (schemaToProcess, schemaPatternName, schemaCollectorContext) ->
             schemaToProcess.oneOf.mapIndexed { index, schema ->
                 val indexContext = schemaCollectorContext.at("oneOf").at(index)
                 val resolvedRef = resolveSchemaIfRef(schema, schemaPatternName, indexContext)
@@ -1982,7 +1982,7 @@ class OpenApiSpecification(
                     )
                 }
             }
-        }.flatten().map { (componentName, schemaProperty) ->
+        }.map { (componentName, schemaProperty) ->
             toJSONObjectPattern(schemaProperty.properties, "(${componentName})", schemaProperty.extensions)
         }
 
@@ -2133,7 +2133,7 @@ class OpenApiSpecification(
 
         collectorContext.checkPojo(
             value = schema,
-            message = { "Schema has both \$ref (${schema.`$ref`}) and a type ${schema.type} defined, ignoring other properties" },
+            message = { $$"Schema has both $ref ($${schema.`$ref`}) and a type $${schema.type} defined, ignoring other properties" },
             isValid = { parsedOpenApi.specVersion == SpecVersion.V31 || it.type == null },
             createDefault = { it },
             ruleViolation = { OpenApiLintViolations.REF_HAS_SIBLINGS },
@@ -2556,7 +2556,7 @@ class OpenApiSpecification(
         val componentName = extractComponentName(component, collectorContext)
         val components = parsedOpenApi.components ?: Components()
         val schemas = components.schemas.orEmpty()
-        return componentName to collectorContext.at("\$ref").requirePojo(
+        return componentName to collectorContext.at($$"$ref").requirePojo(
             message = { "Failed to resolve reference to schema $componentName, defaulting to any schema" },
             extract = { schemas[componentName] },
             createDefault = { Schema<Any>().also { it.properties = emptyMap() } },
@@ -2568,7 +2568,7 @@ class OpenApiSpecification(
         val componentName = extractComponentName(component, collectorContext)
         val hasRefedOutBody = parsedOpenApi.components?.requestBodies?.contains(componentName) == true
         return Pair(
-            first = collectorContext.at("\$ref").requirePojo(
+            first = collectorContext.at($$"$ref").requirePojo(
                 message = { "Failed to resolve reference to requestBodies $componentName, defaulting to empty requestBody" },
                 ruleViolation = { OpenApiLintViolations.UNRESOLVED_REFERENCE },
                 extract = { parsedOpenApi.components?.requestBodies?.get(componentName) },
@@ -2584,7 +2584,7 @@ class OpenApiSpecification(
 
     private fun extractComponentName(component: String, collectorContext: CollectorContext): String {
         if (!component.startsWith("#")) {
-            val refContext = collectorContext.at("\$ref")
+            val refContext = collectorContext.at($$"$ref")
             val componentPath = component.substringAfterLast("#")
             val filePath = component.substringBeforeLast("#")
             refContext.record(
@@ -2840,7 +2840,7 @@ class OpenApiSpecification(
         val parameterComponentName = extractComponentName(parameter.`$ref`, collectorContext)
         val hasReusableParameter = parsedOpenApi.components?.parameters?.contains(parameterComponentName) == true
 
-        val resolvedParameter = collectorContext.at("\$ref").requirePojo(
+        val resolvedParameter = collectorContext.at($$"$ref").requirePojo(
             message = { "Parameter reference '${parameter.`$ref`}' could not be resolved, keeping unresolved parameter definition" },
             extract = { parsedOpenApi.components?.parameters?.get(parameterComponentName) },
             ruleViolation = { OpenApiLintViolations.UNRESOLVED_REFERENCE },

--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -3,6 +3,7 @@ package io.specmatic.core
 import io.ktor.util.*
 import io.specmatic.conversions.NoSecurityScheme
 import io.specmatic.conversions.OpenAPISecurityScheme
+import io.specmatic.conversions.OptionalBodyPattern
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
@@ -798,6 +799,10 @@ data class HttpRequestPattern(
         return isNon4xxResponseStatus
     }
 
+    private fun shouldGenerateNoBodyNegativeScenario(): Boolean {
+        return body !is OptionalBodyPattern && body !is NoBodyPattern && headersPattern.contentType?.lowercase() != "text/plain"
+    }
+
     fun newBasedOn(resolver: Resolver): Sequence<HttpRequestPattern> {
         return attempt(breadCrumb = "REQUEST") {
             val newHttpPathPatterns = httpPathPattern?.let { httpPathPattern ->
@@ -858,11 +863,17 @@ data class HttpRequestPattern(
 
             val newQueryParamsPatterns = httpQueryParamPattern.negativeBasedOn(row, resolver)
 
-            val newBodies: Sequence<ReturnValue<out Pattern>> = returnValue(breadCrumb = "BODY") returnNewBodies@ {
+            val newBodies: Sequence<ReturnValue<out Pattern>> = (returnValue(breadCrumb = "BODY") returnNewBodies@ {
                 val rawRequestBody = row.getFieldOrNull(REQUEST_BODY_FIELD) ?: return@returnNewBodies body.negativeBasedOn(row, resolver)
                 val parsedValue = body.parse(rawRequestBody, resolver)
                 body.matches(parsedValue, resolver).throwOnFailure()
                 this.body.negativeBasedOn(row.noteRequestBody(), resolver)
+            }).let { generatedBodyNegatives ->
+                if (shouldGenerateNoBodyNegativeScenario()) {
+                    sequenceOf(HasValue(NoBodyPattern)).plus(generatedBodyNegatives)
+                } else {
+                    generatedBodyNegatives
+                }
             }
 
             val newHeadersPattern = headersPattern.negativeBasedOn(row, resolver, BreadCrumb.PARAM_HEADER.value)

--- a/core/src/test/kotlin/integration_tests/DefaultValuesInOpenapiSpecification.kt
+++ b/core/src/test/kotlin/integration_tests/DefaultValuesInOpenapiSpecification.kt
@@ -296,7 +296,7 @@ class DefaultValuesInOpenapiSpecification {
             "salary mutated to boolean",
             "salary mutated to string",
         )
-        assertThat(results.results).hasSize(16)
+        assertThat(results.results).hasSize(17)
     }
 
     @Test

--- a/core/src/test/kotlin/integration_tests/DictionaryTest.kt
+++ b/core/src/test/kotlin/integration_tests/DictionaryTest.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.HttpResponsePattern
+import io.specmatic.core.NoBodyValue
 import io.specmatic.core.Resolver
 import io.specmatic.core.SPECMATIC_STUB_DICTIONARY
 import io.specmatic.core.Scenario
@@ -886,18 +887,21 @@ class DictionaryTest {
                         )
                         HttpResponse.OK
                     } else {
-                        assertThat((request.body as JSONObjectValue).findFirstChildByName("id")).satisfiesAnyOf(
-                            { id -> assertThat(id).isInstanceOf(StringValue::class.java) },
-                            { id -> assertThat(id).isInstanceOf(BooleanValue::class.java) },
-                            { id -> assertThat(id).isInstanceOf(NullValue::class.java) }
-                        )
+                        when (val requestBody = request.body) {
+                            is JSONObjectValue -> assertThat(requestBody.findFirstChildByName("id")).satisfiesAnyOf(
+                                { id -> assertThat(id).isInstanceOf(StringValue::class.java) },
+                                { id -> assertThat(id).isInstanceOf(BooleanValue::class.java) },
+                                { id -> assertThat(id).isInstanceOf(NullValue::class.java) }
+                            )
+                            else -> assertThat(requestBody).isEqualTo(NoBodyValue)
+                        }
                         HttpResponse.ERROR_400
                     }
                 }
             })
 
-            assertThat(result.results).hasSize(4)
-            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(4)
+            assertThat(result.results).hasSize(5)
+            assertThat(result.successCount).withFailMessage(result.report()).isEqualTo(5)
         }
 
         private fun Scenario.withBadRequest(): List<Scenario> {

--- a/core/src/test/kotlin/integration_tests/InterpolatedPathsE2ETest.kt
+++ b/core/src/test/kotlin/integration_tests/InterpolatedPathsE2ETest.kt
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
+import java.net.ServerSocket
 
 class InterpolatedPathsE2ETest {
     private val specFile = File("src/test/resources/openapi/interpolated_paths_e2e.yaml")
@@ -39,6 +40,8 @@ class InterpolatedPathsE2ETest {
     private fun Feature.onlyPath(internalPath: String): Feature {
         return copy(scenarios = scenarios.filter { it.path == internalPath })
     }
+
+    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
 
     private fun captureMockEvents(testBlock: (MockEventListener) -> Unit): List<MockEvent> {
         val events = mutableListOf<MockEvent>()
@@ -83,7 +86,7 @@ class InterpolatedPathsE2ETest {
         })
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
-        assertThat(results.testCount).isEqualTo(12)
+        assertThat(results.testCount).isEqualTo(13)
         assertThat(expectedStatusesSeen).contains(200, 400)
         assertThat(positiveDictionaryPathSeen).isTrue()
     }
@@ -143,7 +146,12 @@ class InterpolatedPathsE2ETest {
     fun `stub should serve inline and external examples and emit expected mock events`(openApiVersion: String) {
         val feature = loadFeature(openApiVersion)
         val events = captureMockEvents { listener ->
-            HttpStub(feature, scenarioStubs = externalScenarioStubs(), listeners = listOf(listener)).use { stub ->
+            HttpStub(
+                feature,
+                scenarioStubs = externalScenarioStubs(),
+                port = freePort(),
+                listeners = listOf(listener)
+            ).use { stub ->
                 val inlineResponse = stub.client.execute(HttpRequest("GET", "/example/inline-A,inline-B/status"))
                 val externalResponse = stub.client.execute(HttpRequest("GET", "/example/external-A,external-B/status"))
                 val externalTokenResponse = stub.client.execute(HttpRequest("GET", "/example/token-A,DICT-ID2/status"))
@@ -193,7 +201,7 @@ class InterpolatedPathsE2ETest {
     @ValueSource(strings = ["3.0.3", "3.1.0"])
     fun `loop test should pass when contract tests run against stub for interpolated paths`(openApiVersion: String) {
         val feature = loadFeature(openApiVersion, loadExternalExamples = true)
-        val results = HttpStub(feature, scenarioStubs = externalScenarioStubs()).use { stub ->
+        val results = HttpStub(feature, scenarioStubs = externalScenarioStubs(), port = freePort()).use { stub ->
             feature.executeTests(stub.client)
         }
 

--- a/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
+++ b/core/src/test/kotlin/integration_tests/LoadTestsFromExternalisedFiles.kt
@@ -1497,6 +1497,9 @@ class LoadTestsFromExternalisedFiles {
                                     return if (request.headers["Specmatic-Response-Code"] == "400") {
                                         evidences.add("bad request")
                                         HttpResponse(status = 400, body = parsedJSONObject("""{"code": 400, "message": "BadRequest"}"""))
+                                    } else if (request.headers["PET-ID"] == null || request.headers["CREATOR-ID"] == null || request.body !is JSONObjectValue) {
+                                        evidences.add("bad request")
+                                        HttpResponse(status = 400, body = parsedJSONObject("""{"code": 400, "message": "BadRequest"}"""))
                                     } else {
                                         assertThat(request.method).isEqualTo(expectedGoodRequest.method)
                                         assertThat(request.path).isEqualTo(expectedGoodRequest.path)
@@ -1525,7 +1528,7 @@ class LoadTestsFromExternalisedFiles {
                 assertThat(evidences.distinct()).containsExactlyInAnyOrder(
                     "bad request",
                 )
-                assertThat(results).hasOnlyElementsOfTypes(Result.Success::class.java).hasSize(23)
+                assertThat(results).hasOnlyElementsOfTypes(Result.Success::class.java).hasSize(24)
             }
         }
 

--- a/core/src/test/kotlin/integration_tests/OneOfDiscriminatorTest.kt
+++ b/core/src/test/kotlin/integration_tests/OneOfDiscriminatorTest.kt
@@ -2,8 +2,6 @@ package integration_tests
 
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.*
-import io.specmatic.core.SPECMATIC_TYPE_HEADER
-import io.specmatic.core.jsonObject
 import io.specmatic.core.pattern.parsedJSONObject
 import io.specmatic.core.value.JSONObjectValue
 import io.specmatic.mock.ScenarioStub
@@ -21,7 +19,7 @@ class OneOfDiscriminatorTest {
     @Nested
     inner class ChildrenDoNotHaveDiscriminator {
         val getAPI = OpenApiSpecification.fromYAML(
-"""
+$$"""
 openapi: 3.0.3
 info:
   title: Product API
@@ -42,14 +40,14 @@ paths:
           content:
             application/json:
               schema:
-                ${"$"}ref: '#/components/schemas/Product'
+                $ref: '#/components/schemas/Product'
 components:
   schemas:
     Product:
       type: object
       oneOf:
-        - ${"$"}ref: '#/components/schemas/Food'
-        - ${"$"}ref: '#/components/schemas/Gadget'
+        - $ref: '#/components/schemas/Food'
+        - $ref: '#/components/schemas/Gadget'
       discriminator:
         propertyName: type
         mapping:
@@ -66,7 +64,7 @@ components:
 
     Food:
       allOf:
-        - ${"$"}ref: '#/components/schemas/ProductType'
+        - $ref: '#/components/schemas/ProductType'
         - type: object
           properties:
             id:
@@ -79,7 +77,7 @@ components:
 
     Gadget:
       allOf:
-        - ${"$"}ref: '#/components/schemas/ProductType'
+        - $ref: '#/components/schemas/ProductType'
         - type: object
           properties:
             id:
@@ -93,7 +91,7 @@ components:
         ).toFeature()
 
         val patchAPI = OpenApiSpecification.fromYAML(
-"""
+$$"""
 openapi: 3.0.3
 info:
   title: Product API
@@ -113,21 +111,21 @@ paths:
         content:
           application/json:
             schema:
-              ${"$"}ref: '#/components/schemas/Product'
+              $ref: '#/components/schemas/Product'
       responses:
         200:
           description: 'Successful response with product details'
           content:
             application/json:
               schema:
-                ${"$"}ref: '#/components/schemas/Product'
+                $ref: '#/components/schemas/Product'
 components:
   schemas:
     Product:
       type: object
       oneOf:
-        - ${"$"}ref: '#/components/schemas/Food'
-        - ${"$"}ref: '#/components/schemas/Gadget'
+        - $ref: '#/components/schemas/Food'
+        - $ref: '#/components/schemas/Gadget'
       discriminator:
         propertyName: type
         mapping:
@@ -144,7 +142,7 @@ components:
 
     Food:
       allOf:
-        - ${"$"}ref: '#/components/schemas/ProductType'
+        - $ref: '#/components/schemas/ProductType'
         - type: object
           properties:
             id:
@@ -157,7 +155,7 @@ components:
 
     Gadget:
       allOf:
-        - ${"$"}ref: '#/components/schemas/ProductType'
+        - $ref: '#/components/schemas/ProductType'
         - type: object
           properties:
             id:
@@ -290,11 +288,11 @@ components:
 
         @Test
         fun `tests from discriminator object without examples should generate the right objects`() {
-            val results = patchAPI.executeTests(object : TestExecutor {
+            patchAPI.executeTests(object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     val jsonRequest = request.body as? JSONObjectValue ?: fail("Expected request to be a json object")
 
-                    when(jsonRequest.findFirstChildByPath("type")?.toStringLiteral()) {
+                    when (jsonRequest.findFirstChildByPath("type")?.toStringLiteral()) {
                         "food" -> assertThat(jsonRequest.jsonObject).containsKey("expirationDate")
                         "gadget" -> assertThat(jsonRequest.jsonObject).containsKey("warrantyPeriod")
                         else -> fail("Expected request to have a type of either food or gadget")
@@ -309,7 +307,7 @@ components:
     @Test
     fun `discriminator in oneOf should be honored when children declare their own discriminator`() {
         val feature = OpenApiSpecification.fromYAML(
-            """
+            $$"""
 openapi: 3.0.3
 info:
   title: Product API
@@ -330,15 +328,15 @@ paths:
           content:
             application/json:
               schema:
-                ${"$"}ref: '#/components/schemas/Product'
+                $ref: '#/components/schemas/Product'
 
 components:
   schemas:
     Product:
       type: object
       oneOf:
-        - ${"$"}ref: '#/components/schemas/Food'
-        - ${"$"}ref: '#/components/schemas/Gadget'
+        - $ref: '#/components/schemas/Food'
+        - $ref: '#/components/schemas/Gadget'
       discriminator:
         propertyName: type
         mapping:
@@ -355,7 +353,7 @@ components:
 
     Food:
       allOf:
-        - ${"$"}ref: '#/components/schemas/ProductType'
+        - $ref: '#/components/schemas/ProductType'
         - type: object
           properties:
             id:
@@ -372,7 +370,7 @@ components:
 
     Gadget:
       allOf:
-        - ${"$"}ref: '#/components/schemas/ProductType'
+        - $ref: '#/components/schemas/ProductType'
         - type: object
           properties:
             id:
@@ -409,7 +407,7 @@ components:
 
     @Test
     fun `tests generated with discriminator should have only the discriminator values against the discriminator property`() {
-        val spec = """
+        val spec = $$"""
 openapi: 3.0.0
 info:
   title: Pet Store API
@@ -418,24 +416,25 @@ paths:
   /pets:
     post:
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              ${"$"}ref: '#/components/schemas/Pet'
+              $ref: '#/components/schemas/Pet'
       responses:
         '200':
           description: This is a 200 response.
           content:
             application/json:
               schema:
-                ${"$"}ref: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
 
 components:
   schemas:
     Pet:
       oneOf:
-        - ${"$"}ref: '#/components/schemas/Dog'
-        - ${"$"}ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
       discriminator:
         propertyName: petType
         mapping:
@@ -458,7 +457,7 @@ components:
 
     Dog:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             barkVolume:
@@ -468,7 +467,7 @@ components:
 
     Cat:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             whiskerLength:
@@ -500,7 +499,7 @@ components:
 
     @Test
     fun `tests for api with discriminator having one example should result in one test`() {
-        val spec = """
+        val spec = $$"""
 openapi: 3.0.0
 info:
   title: Pet Store API
@@ -509,10 +508,11 @@ paths:
   /pets:
     post:
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              ${"$"}ref: '#/components/schemas/Pet'
+              $ref: '#/components/schemas/Pet'
             examples:
               dog:
                 value:
@@ -526,7 +526,7 @@ paths:
           content:
             application/json:
               schema:
-                ${"$"}ref: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
               examples:
                 dog:
                   value:
@@ -538,8 +538,8 @@ components:
   schemas:
     Pet:
       oneOf:
-        - ${"$"}ref: '#/components/schemas/Dog'
-        - ${"$"}ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
       discriminator:
         propertyName: petType
         mapping:
@@ -562,7 +562,7 @@ components:
 
     Dog:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             barkVolume:
@@ -572,7 +572,7 @@ components:
 
     Cat:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             whiskerLength:
@@ -608,7 +608,7 @@ components:
 
     @Test
     fun `tests with discriminator should fail if the discriminator value is wrong`() {
-        val spec = """
+        val spec = $$"""
 openapi: 3.0.0
 info:
   title: Pet Store API
@@ -620,7 +620,7 @@ paths:
         content:
           application/json:
             schema:
-              ${"$"}ref: '#/components/schemas/Pet'
+              $ref: '#/components/schemas/Pet'
             examples:
               dog:
                 value:
@@ -640,7 +640,7 @@ paths:
           content:
             application/json:
               schema:
-                ${"$"}ref: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
               examples:
                 dog:
                   value:
@@ -659,8 +659,8 @@ components:
   schemas:
     Pet:
       oneOf:
-        - ${"$"}ref: '#/components/schemas/Dog'
-        - ${"$"}ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
       discriminator:
         propertyName: petType
         mapping:
@@ -683,7 +683,7 @@ components:
 
     Dog:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             barkVolume:
@@ -693,7 +693,7 @@ components:
 
     Cat:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             whiskerLength:
@@ -720,7 +720,7 @@ components:
 
     @Test
     fun `positive generative tests with discriminator should contain only the discriminator value in the discriminator property`() {
-        val spec = """
+        val spec = $$"""
 openapi: 3.0.0
 info:
   title: Pet Store API
@@ -729,10 +729,11 @@ paths:
   /pets:
     post:
       requestBody:
+        required: true
         content:
           application/json:
             schema:
-              ${"$"}ref: '#/components/schemas/Pet'
+              $ref: '#/components/schemas/Pet'
             examples:
               dog:
                 value:
@@ -746,7 +747,7 @@ paths:
           content:
             application/json:
               schema:
-                ${"$"}ref: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
               examples:
                 dog:
                   value:
@@ -758,8 +759,8 @@ components:
   schemas:
     Pet:
       oneOf:
-        - ${"$"}ref: '#/components/schemas/Dog'
-        - ${"$"}ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
       discriminator:
         propertyName: petType
         mapping:
@@ -782,7 +783,7 @@ components:
 
     Dog:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             barkVolume:
@@ -792,7 +793,7 @@ components:
 
     Cat:
       allOf:
-        - ${"$"}ref: '#/components/schemas/Pet_base'
+        - $ref: '#/components/schemas/Pet_base'
         - type: object
           properties:
             whiskerLength:
@@ -823,7 +824,7 @@ components:
 
                 println(jsonRequest.toStringLiteral())
 
-                if (scenario.isNegative == false) {
+                if (!scenario.isNegative) {
                     jsonRequest.findFirstChildByPath("petType")?.toStringLiteral()?.let { petTypesSeen.add(it) }
                 }
             }

--- a/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
+++ b/core/src/test/kotlin/integration_tests/OpenApi31Test.kt
@@ -210,7 +210,7 @@ class OpenApi31Test {
             feature.executeTests(stub.client)
         }.results
 
-        assertThat(results.size).isEqualTo(87)
+        assertThat(results.size).isEqualTo(95)
         assertThat(Result.fromResults(results))
             .withFailMessage { Result.fromResults(results).reportString() }
             .isInstanceOf(Result.Success::class.java)
@@ -228,7 +228,7 @@ class OpenApi31Test {
             openApi30Specification.toFeature().copy(specmaticConfig = specmaticConfig).executeTests(stub.client)
         }.results
 
-        assertThat(results.size).isEqualTo(87 + 2) // +2 Due to multiTypEnum representation
+        assertThat(results.size).isEqualTo(95 + 2) // +2 Due to multiTypEnum representation
         assertThat(Result.fromResults(results))
             .withFailMessage { Result.fromResults(results).reportString() }
             .isInstanceOf(Result.Success::class.java)
@@ -246,7 +246,7 @@ class OpenApi31Test {
             openApi31Specification.toFeature().copy(specmaticConfig = specmaticConfig).executeTests(stub.client)
         }.results
 
-        assertThat(results.size).isEqualTo(87)
+        assertThat(results.size).isEqualTo(95)
         assertThat(Result.fromResults(results))
             .withFailMessage { Result.fromResults(results).reportString() }
             .isInstanceOf(Result.Success::class.java)

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -153,22 +153,25 @@ class GenerativeTests {
         val fromExample = 1
         val positiveGenerated = 1
         val negativeGenerativeAll = 3 + 3
-        val negativeGenerativeNothing = 3
+        val negativeGenerativeNothing = 4
 
         var optionalKeyOccurrence = 0
 
-        val OPTIONAL_KEY = "description"
+        val optionalKey = "description"
 
         try {
             val results = try {
                 feature.enableGenerativeTesting().executeTests(object : TestExecutor {
                     override fun execute(request: HttpRequest): HttpResponse {
-                        val jsonRequestBody = request.body as JSONObjectValue
+                        return when (val requestBody = request.body) {
+                            is JSONObjectValue -> {
+                                if(optionalKey in requestBody.jsonObject)
+                                    optionalKeyOccurrence += 1
 
-                        if(OPTIONAL_KEY in jsonRequestBody.jsonObject)
-                            optionalKeyOccurrence += 1
-
-                        return HttpResponse.OK
+                                HttpResponse.OK
+                            }
+                            else -> HttpResponse.ERROR_400
+                        }
                     }
 
                     override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
@@ -251,7 +254,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(7)
+            assertThat(results.results).hasSize(8)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -314,7 +317,7 @@ class GenerativeTests {
 
         try {
             val results = runGenerativeTests(feature)
-            assertThat(results.results).hasSize(7)
+            assertThat(results.results).hasSize(8)
         } catch (e: ContractException) {
             println(e.report())
             throw e
@@ -1028,7 +1031,7 @@ class GenerativeTests {
     @Test
     fun `generative positive-only tests with REQUEST-BODY example`() {
         val specification = OpenApiSpecification.fromYAML(
-            """
+            $$"""
             openapi: "3.0.1"
             info:
               title: "Person API"
@@ -1055,7 +1058,7 @@ class GenerativeTests {
                             address:
                               type: "array"
                               items:
-                                ${'$'}ref: "#/components/schemas/Address"
+                                $ref: "#/components/schemas/Address"
                   responses:
                     200:
                       description: "Get person by id"
@@ -1157,7 +1160,7 @@ class GenerativeTests {
             }
         })
 
-        assertThat(results.results).hasSize(11)
+        assertThat(results.results).hasSize(12)
     }
 
     private fun runGenerativeTests(
@@ -1187,10 +1190,10 @@ class GenerativeTests {
             every { getMaxTestRequestCombinations() } returns null
         }
         mockkObject(SpecmaticConfigV1V2Common.Companion)
-        every { SpecmaticConfigV1V2Common.Companion.getAttributeSelectionPattern(any()) } returns AttributeSelectionPattern()
+        every { SpecmaticConfigV1V2Common.getAttributeSelectionPattern(any()) } returns AttributeSelectionPattern()
 
         val feature = OpenApiSpecification.fromYAML(
-            """
+            $$"""
             openapi: 3.0.0
             info:
               version: 1.0.0
@@ -1205,7 +1208,7 @@ class GenerativeTests {
                     content:
                       application/json:
                         schema:
-                          ${"$"}ref: '#/components/schemas/Product'
+                          $ref: '#/components/schemas/Product'
                   responses:
                     '200':
                       description: Product created successfully
@@ -1238,11 +1241,17 @@ class GenerativeTests {
 
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
-                val body = request.body as JSONObjectValue
-
-                if (body.jsonObject["name"] !is StringValue) {
-                    testType.add("name mutated to " + body.jsonObject["name"]!!.displayableType())
-                    return HttpResponse.ERROR_400
+                when (val body = request.body) {
+                    is JSONObjectValue -> {
+                        if (body.jsonObject["name"] !is StringValue) {
+                            testType.add("name mutated to " + body.jsonObject["name"]!!.displayableType())
+                            return HttpResponse.ERROR_400
+                        }
+                    }
+                    else -> {
+                        testType.add("name omitted")
+                        return HttpResponse.ERROR_400
+                    }
                 }
 
                 testType.add("name not mutated")
@@ -1257,6 +1266,7 @@ class GenerativeTests {
 
         assertThat(testType).containsExactlyInAnyOrder(
             "name not mutated",
+            "name omitted",
             "name mutated to null",
             "name mutated to boolean",
             "name mutated to number"
@@ -1277,10 +1287,10 @@ class GenerativeTests {
         }
 
         mockkObject(SpecmaticConfigV1V2Common.Companion)
-        every { SpecmaticConfigV1V2Common.Companion.getAttributeSelectionPattern(any()) } returns AttributeSelectionPattern()
+        every { SpecmaticConfigV1V2Common.getAttributeSelectionPattern(any()) } returns AttributeSelectionPattern()
 
         val feature = OpenApiSpecification.fromYAML(
-            """
+            $$"""
             openapi: 3.0.0
             info:
               version: 1.0.0
@@ -1295,7 +1305,7 @@ class GenerativeTests {
                     content:
                       application/json:
                         schema:
-                          ${"$"}ref: '#/components/schemas/Product'
+                          $ref: '#/components/schemas/Product'
                         examples:
                           SUCCESS:
                             value:
@@ -1715,6 +1725,7 @@ class GenerativeTests {
                 post:
                   summary: Create person record
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         examples:
@@ -1776,7 +1787,7 @@ class GenerativeTests {
             }
         })
 
-        assertThat(results.testCount).isEqualTo(8)
+        assertThat(results.testCount).isEqualTo(9)
         assertThat(testsSeen).doesNotContain("-ve" to "BAD_REQUEST")
         assertThat(testsSeen).doesNotContain("-ve" to "SERVER_ERROR")
     }
@@ -2322,6 +2333,7 @@ class GenerativeTests {
             "+ve  Scenario: POST /items -> 201 with the request from the example 'sampleItems' where REQUEST.BODY contains all the keys",
             "+ve  Scenario: POST /items -> 201 with the request from the example 'sampleItems' where REQUEST.BODY contains all the keys AND the key quantity is set to the largest possible value",
             "+ve  Scenario: POST /items -> 201 with the request from the example 'sampleItems' where REQUEST.BODY contains all the keys AND the key quantity is set to the smallest possible value '1'",
+            "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems'",
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key name is mutated from string to boolean",
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key name is mutated from string to boolean AND quantity is set to the largest possible value",
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key name is mutated from string to boolean AND quantity is set to the smallest possible value '1'",

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
@@ -410,7 +410,7 @@ Background:
 
         assertThat(results.results.size).isEqualTo(14)
         assertThat(results.results.filterIsInstance<Result.Success>().size).isEqualTo(5)
-        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(8)
+        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(9)
     }
 
     @Test
@@ -455,7 +455,7 @@ Background:
 
         assertThat(results.results.size).isEqualTo(18)
         assertThat(results.results.filterIsInstance<Result.Success>().size).isEqualTo(4)
-        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(13)
+        assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(14)
     }
 
     @Test
@@ -1562,6 +1562,9 @@ Scenario: zero should return not found
 
         val results: Results = feature.enableGenerativeTesting().executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
+                if (request.body == NoBodyValue)
+                    return HttpResponse(400, headers = mapOf("Content-Type" to "application/json"), body = parsedJSONObject("""{"data": "information"}"""))
+
                 val jsonBody = request.body as JSONObjectValue
                 if (jsonBody.jsonObject["id"]?.toStringLiteral()?.toIntOrNull() != null)
                     return HttpResponse(200, body = StringValue("""{"data": "it worked!"}"""))
@@ -2026,6 +2029,9 @@ components:
 
         val results: Results = feature.enableGenerativeTesting().executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
+                if (request.body == NoBodyValue)
+                    return HttpResponse(400, body = parsedJSONObject("""{"error_in_400": "message"}"""))
+
                 val jsonBody = request.body as JSONObjectValue
                 if (jsonBody.jsonObject["id"]?.toStringLiteral()?.toIntOrNull() != null)
                     return HttpResponse(200, body = StringValue("it worked"))

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiKtTest.kt
@@ -408,7 +408,7 @@ Background:
                 }
             )
 
-        assertThat(results.results.size).isEqualTo(13)
+        assertThat(results.results.size).isEqualTo(14)
         assertThat(results.results.filterIsInstance<Result.Success>().size).isEqualTo(5)
         assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(8)
     }
@@ -453,7 +453,7 @@ Background:
             }
         )
 
-        assertThat(results.results.size).isEqualTo(17)
+        assertThat(results.results.size).isEqualTo(18)
         assertThat(results.results.filterIsInstance<Result.Success>().size).isEqualTo(4)
         assertThat(results.results.filterIsInstance<Result.Failure>().size).isEqualTo(13)
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7461,7 +7461,7 @@ paths:
     }
 
     @Test
-    fun `requestBody is required by default`() {
+    fun `as per openapi spec requestBody should be optional by default when required is omitted`() {
         val feature = OpenApiSpecification.fromYAML(
             """
                 ---
@@ -7493,17 +7493,10 @@ paths:
         ).toFeature()
 
         feature.matchResult(
-            HttpRequest("POST", "/person", body = parsedJSONObject("""{"id": "abc123"}""")),
-            HttpResponse.OK
-        ).let { matchResult ->
-            assertThat(matchResult).withFailMessage(matchResult.reportString()).isInstanceOf(Result.Success::class.java)
-        }
-
-        feature.matchResult(
             HttpRequest("POST", "/person", body = NoBodyValue),
             HttpResponse.OK
         ).let { matchResult ->
-            assertThat(matchResult).withFailMessage(matchResult.reportString()).isInstanceOf(Result.Failure::class.java)
+            assertThat(matchResult).withFailMessage(matchResult.reportString()).isInstanceOf(Result.Success::class.java)
         }
     }
 
@@ -7601,6 +7594,227 @@ paths:
         ).let { matchResult ->
             assertThat(matchResult).withFailMessage(matchResult.reportString()).isInstanceOf(Result.Success::class.java)
         }
+    }
+
+    @Test
+    fun `requestBody marked optional should use OptionalBodyPattern`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      summary: "Get person by id"
+                      requestBody:
+                        required: false
+                        content:
+                          application/json:
+                            schema:
+                              required:
+                              - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: "Get person by id"
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                """.trimIndent(), ""
+        ).toFeature()
+
+        val scenario = feature.scenarios.single()
+
+        assertThat(scenario.httpRequestPattern.body).isInstanceOf(OptionalBodyPattern::class.java)
+    }
+
+    @Test
+    fun `requestBody is by default optional and should use OptionalBodyPattern`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      summary: "Get person by id"
+                      requestBody:
+                        content:
+                          application/json:
+                            schema:
+                              required:
+                              - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: "Get person by id"
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                """.trimIndent(), ""
+        ).toFeature()
+
+        val scenario = feature.scenarios.single()
+
+        assertThat(scenario.httpRequestPattern.body).isInstanceOf(OptionalBodyPattern::class.java)
+    }
+
+    @Test
+    fun `requestBody marked optional should generate no-body positive scenarios and no no-body negative scenarios`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      requestBody:
+                        required: false
+                        content:
+                          application/json:
+                            schema:
+                              required:
+                              - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: "Get person by id"
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                        400:
+                          description: "Bad request"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        assertThat(generatedPositiveRequests(feature).map { it.body }).contains(NoBodyValue)
+        assertThat(generatedNegativeRequests(feature).map { it.body }).doesNotContain(NoBodyValue)
+    }
+
+    @Test
+    fun `requestBody omitted required should generate no-body positive scenarios and no no-body negative scenarios`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      requestBody:
+                        content:
+                          application/json:
+                            schema:
+                              required:
+                              - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: "Get person by id"
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                        400:
+                          description: "Bad request"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        assertThat(generatedPositiveRequests(feature).map { it.body }).contains(NoBodyValue)
+        assertThat(generatedNegativeRequests(feature).map { it.body }).doesNotContain(NoBodyValue)
+    }
+
+    @Test
+    fun `requestBody marked required should generate no-body negative scenarios and no no-body positive scenarios`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      requestBody:
+                        required: true
+                        content:
+                          application/json:
+                            schema:
+                              required:
+                              - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: "Get person by id"
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                        400:
+                          description: "Bad request"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        assertThat(generatedPositiveRequests(feature).map { it.body }).doesNotContain(NoBodyValue)
+        assertThat(generatedNegativeRequests(feature).map { it.body }).contains(NoBodyValue)
+    }
+
+    @Test
+    fun `requestBody marked required with text plain should not generate no-body negative scenarios`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+                ---
+                openapi: "3.0.1"
+                info:
+                  title: "Person API"
+                  version: "1"
+                paths:
+                  /person:
+                    post:
+                      requestBody:
+                        required: true
+                        content:
+                          text/plain:
+                            schema:
+                              type: string
+                      responses:
+                        200:
+                          description: "Get person by id"
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                        400:
+                          description: "Bad request"
+            """.trimIndent(), ""
+        ).toFeature()
+
+        assertThat(generatedNegativeRequests(feature).map { it.body }).doesNotContain(NoBodyValue)
     }
 
     @Test
@@ -7796,6 +8010,7 @@ paths:
                     post:
                       summary: "Get person by id"
                       requestBody:
+                        required: true
                         content:
                           application/json:
                             schema:
@@ -7823,15 +8038,20 @@ paths:
 
         val results = feature.executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
-                val jsonRequestBody = request.body as JSONObjectValue
-                return when (val age = jsonRequestBody.jsonObject["age"]) {
-                    is NumberValue -> {
-                        val ageValue = BigDecimal(age.number.toString())
-                        actualAges.add(ageValue)
-                        if (minAge < ageValue && ageValue < maxAge)
-                            HttpResponse(204, EmptyString)
-                        else
-                            HttpResponse(400, EmptyString)
+                return when (val requestBody = request.body) {
+                    is JSONObjectValue -> {
+                        when (val age = requestBody.jsonObject["age"]) {
+                            is NumberValue -> {
+                                val ageValue = BigDecimal(age.number.toString())
+                                actualAges.add(ageValue)
+                                if (minAge < ageValue && ageValue < maxAge)
+                                    HttpResponse(204, EmptyString)
+                                else
+                                    HttpResponse(400, EmptyString)
+                            }
+
+                            else -> HttpResponse(400, EmptyString)
+                        }
                     }
 
                     else -> HttpResponse(400, EmptyString)
@@ -7850,7 +8070,7 @@ paths:
             maxOutsideBounds
         )
 
-        assertThat(results.results.size).isEqualTo(8)
+        assertThat(results.results.size).isEqualTo(9)
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
     }
 
@@ -8337,6 +8557,7 @@ components:
                     post:
                       summary: "Get person by id"
                       requestBody:
+                        required: true
                         content:
                           application/json:
                             schema:
@@ -9666,6 +9887,7 @@ paths:
             post:
               summary: Create a sample object
               requestBody:
+                required: true
                 content:
                   application/json:
                     schema:
@@ -9739,6 +9961,7 @@ paths:
             post:
               summary: Create a sample object
               requestBody:
+                required: true
                 content:
                   application/json:
                     schema:
@@ -10385,6 +10608,7 @@ paths:
               /choice:
                 post:
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         schema:
@@ -11229,11 +11453,11 @@ paths:
             invalid yaml content
             this is not valid yaml: [
         """.trimIndent()
-        
+
         val invalidOpenApiFile = tempDir.resolve(File("invalidOpenApi.yaml"))
         invalidOpenApiFile.createNewFile()
         invalidOpenApiFile.writeText(invalidOpenApiContent)
-        
+
         try {
             assertThatThrownBy {
                 OpenApiSpecification.checkSpecValidity(invalidOpenApiFile.canonicalPath)
@@ -11348,9 +11572,9 @@ paths:
     @Test
     fun `getImplicitOverlayContent should return empty string when OpenAPI file does not exist`(@TempDir tempDir: File) {
         val nonExistentOpenApiFile = tempDir.resolve("non_existent_api.yaml")
-        
+
         val result = OpenApiSpecification.getImplicitOverlayContent(nonExistentOpenApiFile.canonicalPath)
-        
+
         assertThat(result).isEmpty()
     }
 
@@ -11368,12 +11592,12 @@ paths:
                     '200':
                       description: Success
         """.trimIndent()
-        
+
         val openApiFile = tempDir.resolve("test_api.yaml")
         openApiFile.writeText(openApiContent)
-        
+
         val result = OpenApiSpecification.getImplicitOverlayContent(openApiFile.canonicalPath)
-        
+
         assertThat(result).isEmpty()
     }
 
@@ -11391,7 +11615,7 @@ paths:
                     '200':
                       description: Success
         """.trimIndent()
-        
+
         val overlayContent = """
             overlay: 1.0.0
             info:
@@ -11401,15 +11625,15 @@ paths:
               - target: $.info.description
                 update: "API with overlay applied"
         """.trimIndent()
-        
+
         val openApiFile = tempDir.resolve("test_api.yaml")
         openApiFile.writeText(openApiContent)
-        
+
         val overlayFile = tempDir.resolve("test_api_overlay.yaml")
         overlayFile.writeText(overlayContent)
-        
+
         val result = OpenApiSpecification.getImplicitOverlayContent(openApiFile.canonicalPath)
-        
+
         assertThat(result).isEqualTo(overlayContent)
     }
 
@@ -11474,7 +11698,7 @@ paths:
 
         assertThat(unreferenced.keys).containsExactlyInAnyOrder("(UnreferencedSchema)", "(AnotherUnreferenced)")
     }
-    
+
     @Test
     fun `HEAD method should be supported in OpenAPI specification parsing`() {
         val openApiContent = """
@@ -11499,18 +11723,18 @@ paths:
 
         val spec = OpenApiSpecification.fromYAML(openApiContent, "")
         val feature = spec.toFeature()
-        
+
         // Verify that HEAD scenarios are created
         val headScenarios = feature.scenarios.filter { it.httpRequestPattern.method == "HEAD" }
         assertThat(headScenarios).isNotEmpty
-        
+
         // Verify the HEAD scenario details
         val headScenario = headScenarios.first()
         assertThat(headScenario.httpRequestPattern.httpPathPattern?.toInternalPath()).isEqualTo("/status")
         assertThat(headScenario.httpResponsePattern.status).isIn(200, 404)
     }
 
-    @Test  
+    @Test
     fun `HEAD method with internal examples should be loaded successfully for stub mode`() {
         val openApiContent = """
             openapi: 3.0.0
@@ -12198,6 +12422,7 @@ paths:
             "+ve  Scenario: POST /orders -> 200 with a request where REQUEST.BODY contains all the keys AND the key status is set to 'fulfilled' from enum",
             "+ve  Scenario: POST /orders -> 200 with a request where REQUEST.BODY contains all the keys AND the key status is set to 'pending' from enum",
             "+ve  Scenario: POST /orders -> 200 with a request where REQUEST.BODY contains only the mandatory keys",
+            "-ve  Scenario: POST /orders -> 4xx",
             "-ve  Scenario: POST /orders -> 4xx with a request where REQUEST.BODY contains all the keys AND the key productId is mutated from number to null AND status is set to 'fulfilled' from enum",
             "-ve  Scenario: POST /orders -> 4xx with a request where REQUEST.BODY contains all the keys AND the key productId is mutated from number to boolean AND status is set to 'pending' from enum",
             "-ve  Scenario: POST /orders -> 4xx with a request where REQUEST.BODY contains all the keys AND the key productId is mutated from number to string AND status is set to 'fulfilled' from enum",
@@ -12591,5 +12816,13 @@ paths:
                     inventory:
                       type: integer
         """.trimIndent()
+    }
+
+    private fun generatedPositiveRequests(feature: Feature): List<HttpRequest> {
+        return feature.generateContractTestScenarios(emptyList()).toList().map { it.second.value.generateHttpRequest() }
+    }
+
+    private fun generatedNegativeRequests(feature: Feature): List<HttpRequest> {
+        return feature.negativeTestScenarios().toList().map { it.second.value.generateHttpRequest() }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/OptionalBodyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OptionalBodyPatternTest.kt
@@ -114,4 +114,111 @@ class OptionalBodyPatternTest {
 
         assertThat(result).isInstanceOf(HasFailure::class.java)
     }
+
+    @Test
+    fun `should generate a positive test with empty body when requestBody is marked optional`() {
+        val requests = generatedRequests(
+            """
+                openapi: 3.0.1
+                info:
+                  title: Person API
+                  version: 1.0.0
+                paths:
+                  /person:
+                    post:
+                      requestBody:
+                        required: false
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                              required:
+                                - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: Success
+            """.trimIndent()
+        )
+
+        assertThat(requests.map { it.body }).anySatisfy {
+            assertThat(it).isEqualTo(NoBodyValue)
+        }
+    }
+
+    @Test
+    fun `should generate a positive test with empty body when requestBody required is omitted`() {
+        val requests = generatedRequests(
+            """
+                openapi: 3.0.1
+                info:
+                  title: Person API
+                  version: 1.0.0
+                paths:
+                  /person:
+                    post:
+                      requestBody:
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                              required:
+                                - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: Success
+            """.trimIndent()
+        )
+
+        assertThat(requests.map { it.body }).anySatisfy {
+            assertThat(it).isEqualTo(NoBodyValue)
+        }
+    }
+
+    @Test
+    fun `should generate both body and no body positive tests when requestBody is optional`() {
+        val requests = generatedRequests(
+            """
+                openapi: 3.0.1
+                info:
+                  title: Person API
+                  version: 1.0.0
+                paths:
+                  /person:
+                    post:
+                      requestBody:
+                        required: false
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                              required:
+                                - id
+                              properties:
+                                id:
+                                  type: string
+                      responses:
+                        200:
+                          description: Success
+            """.trimIndent()
+        )
+
+        assertThat(requests.map { it.body }).anySatisfy {
+            assertThat(it).isInstanceOf(JSONObjectValue::class.java)
+        }
+        assertThat(requests.map { it.body }).anySatisfy {
+            assertThat(it).isEqualTo(NoBodyValue)
+        }
+    }
+
+    private fun generatedRequests(openApiSpec: String): List<HttpRequest> {
+        val feature = OpenApiSpecification.fromYAML(openApiSpec, "").toFeature()
+
+        return feature.generateContractTestScenarios(emptyList()).toList().map { it.second.value.generateHttpRequest() }
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/RegexSupportTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/RegexSupportTest.kt
@@ -67,6 +67,7 @@ class RegexSupportTest {
                     post:
                       summary: "Get person by id"
                       requestBody:
+                        required: true
                         content:
                           application/json:
                             schema:
@@ -115,6 +116,7 @@ class RegexSupportTest {
                     post:
                       summary: "Get person by id"
                       requestBody:
+                        required: true
                         content:
                           application/json:
                             schema:
@@ -167,6 +169,7 @@ class RegexSupportTest {
                     post:
                       summary: "Get person by id"
                       requestBody:
+                        required: true
                         content:
                           application/json:
                             schema:

--- a/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ContractTests.kt
@@ -1082,7 +1082,13 @@ Examples:
             routing {
                 route("/{...}") {
                     handle {
-                        val body = parsedJSONObject(call.receiveText())
+                        val requestText = call.receiveText()
+                        if (requestText.isBlank()) {
+                            call.respond(HttpStatusCode.BadRequest)
+                            return@handle
+                        }
+
+                        val body = parsedJSONObject(requestText)
 
                         when(body.jsonObject["id"]) {
                             is NumberValue -> call.respondText("Hello, Ktor!")

--- a/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureKtTest.kt
@@ -1143,12 +1143,16 @@ paths:
             Pair("(string)", "(boolean)"),
             Pair("(null)", "(string)"),
             Pair("(number)", "(string)"),
-            Pair("(boolean)", "(string)")
+            Pair("(boolean)", "(string)"),
+            Pair("(no-body)", "(no-body)")
         )
 
         val actualRequestTypes: List<Pair<String, String>> = tests.map {
-            val bodyType = it.httpRequestPattern.body as JSONObjectPattern
-            bodyType.pattern["data2"].toString() to bodyType.pattern["data1"].toString()
+            when (val bodyType = it.httpRequestPattern.body) {
+                is JSONObjectPattern -> bodyType.pattern["data2"].toString() to bodyType.pattern["data1"].toString()
+                is NoBodyPattern -> "(no-body)" to "(no-body)"
+                else -> error("Unexpected request body pattern ${bodyType::class.qualifiedName}")
+            }
         }
 
         actualRequestTypes.forEach { keyTypesInRequest ->
@@ -1222,7 +1226,7 @@ paths:
 
         val featureComplete = Feature(name = "Orders Complete", scenarios = listOf(orderPostOk, orderPostBadRequest), protocol = SpecmaticProtocol.HTTP)
         val results = featureComplete.negativeTestScenarios(originalScenarios = featureComplete.scenarios).toList()
-        assertThat(results).hasSize(3)
+        assertThat(results).hasSize(4)
     }
 
     @Test
@@ -1237,6 +1241,6 @@ paths:
 
         val featureComplete = Feature(name = "Orders Complete", scenarios = listOf(orderPostOk), protocol = SpecmaticProtocol.HTTP)
         val results = featureComplete.negativeTestScenarios(originalScenarios = featureComplete.scenarios).toList()
-        assertThat(results).hasSize(3)
+        assertThat(results).hasSize(4)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -2503,6 +2503,7 @@ paths:
     post:
       summary: Add Pet
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/resources/openapi/spec_with_dictionary/spec.yaml
+++ b/core/src/test/resources/openapi/spec_with_dictionary/spec.yaml
@@ -16,6 +16,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/InputData'
+        required: true
       responses:
         '200':
           description: Says hello

--- a/core/src/test/resources/openapi/specs_for_additional_headers_in_examples/additional_headers_test_content_type.yaml
+++ b/core/src/test/resources/openapi/specs_for_additional_headers_in_examples/additional_headers_test_content_type.yaml
@@ -21,6 +21,7 @@ paths:
               value: 1
           required: true
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/core/src/test/resources/openapi/specs_for_additional_headers_in_examples/additional_headers_test_security_scheme.yaml
+++ b/core/src/test/resources/openapi/specs_for_additional_headers_in_examples/additional_headers_test_security_scheme.yaml
@@ -21,6 +21,7 @@ paths:
               value: 1
           required: true
       requestBody:
+        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
**What**:

Align OpenAPI request body handling with the spec by treating omitted `requestBody.required` as optional, and update the affected core tests to match the new positive and negative scenario generation.

**Why**:

OpenAPI defaults `requestBody.required` to `false`, but Specmatic was defaulting it to required. Fixing that behavior changes generated positive and negative scenarios, so older tests that assumed the previous default needed to be updated.

**How**:

- changed OpenAPI request-body conversion to default omitted `requestBody.required` to optional
- added focused coverage for omitted, `required: false`, and `required: true` request-body generation behavior
- updated older integration and core tests to account for missing-body scenarios moving between positive and negative generation
- updated a few test stubs and counts to handle the additional no-body scenario
- switched one interpolated-paths stub test to use random ports to avoid test-time port collisions

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

**Issue ID**:
Closes: #2395 

**Validation**:

- `./gradlew :specmatic-core:test --tests "integration_tests.DictionaryTest"`
- `./gradlew :specmatic-core:test --tests "integration_tests.GenerativeTests"`
- `./gradlew :specmatic-core:test --tests "integration_tests.LoadTestsFromExternalisedFiles"`
- `./gradlew :specmatic-core:test --tests "integration_tests.OpenApi31Test"`
- `./gradlew :specmatic-core:test --tests "integration_tests.InterpolatedPathsE2ETest"`
- `./gradlew :specmatic-core:test --tests "io.specmatic.core.FeatureKtTest"`
