### PR TITLE
Abort contract test suite after connectivity failure

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -411,7 +411,8 @@ enum class FailureReason(val fluffLevel: Int, val objectMatchOccurred: Boolean) 
     DiscriminatorMismatch(0, true),
     FailedButDiscriminatorMatched(0, true),
     FailedButObjectTypeMatched(0, true),
-    ScenarioMismatch(2, false)
+    ScenarioMismatch(2, false),
+    ConnectivityFailure(0, false)
 }
 
 data class MatchFailureDetails(

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -15,8 +15,14 @@ import io.specmatic.test.fixtures.OpenAPIFixtureExecutor
 import io.specmatic.test.handlers.ResponseHandler
 import io.specmatic.test.handlers.ResponseHandlerRegistry
 import io.specmatic.test.handlers.ResponseHandlingResult
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.time.Instant
 import java.util.ServiceLoader
+import javax.net.ssl.SSLException
 import kotlin.jvm.java
 
 private const val BEFORE_FIXTURE_DISCRIMINATOR_KEY = "before"
@@ -215,8 +221,26 @@ data class ScenarioAsTest(
             )
         } catch (exception: Throwable) {
             return ContractTestExecutionResult(
-                result = Result.Failure(exceptionCauseMessage(exception)).updateScenario(testScenario)
+                result = Result.Failure(
+                    exceptionCauseMessage(exception),
+                    failureReason = exception.connectivityFailureReason()
+                ).updateScenario(testScenario)
             )
+        }
+    }
+
+    private fun Throwable.connectivityFailureReason(): FailureReason? {
+        return if (isConnectivityFailure()) FailureReason.ConnectivityFailure else null
+    }
+
+    private fun Throwable.isConnectivityFailure(): Boolean {
+        return generateSequence(this) { it.cause }.any {
+            it is ConnectException ||
+                it is SocketTimeoutException ||
+                it is HttpRequestTimeoutException ||
+                it is UnknownHostException ||
+                it is NoRouteToHostException ||
+                it is SSLException
         }
     }
 

--- a/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/SpecmaticJUnitSupport.kt
@@ -43,6 +43,7 @@ import java.net.URL
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Stream
 import kotlin.streams.asStream
 import java.security.SecureRandom
@@ -386,15 +387,6 @@ open class SpecmaticJUnitSupport {
         }
 
         settings.coverageHooks.forEach { it.onExampleErrors(testBuildResult.exampleValidationResults) }
-        testBuildResult.baseUrls.forEach { baseUrl ->
-            if (isBaseURLReachable(baseUrl, keyData = keyDataFor(baseUrl))) return@forEach
-            return loadExceptionAsTestError(e = ContractException("""
-            Cannot connect to server at: $baseUrl
-            Please check:
-            - Is the server running?
-            - Is the testBaseURL correct?
-            """.trimIndent()))
-        }
 
         openApiCoverageReportInput.addEndpoints(testBuildResult.allEndpoints, testBuildResult.filteredEndpoints)
         val testScenariosWithUrls = try {
@@ -462,6 +454,8 @@ open class SpecmaticJUnitSupport {
         timeoutInMilliseconds: Long,
     ): Stream<DynamicTest>
     {
+        val suiteAbortMessage = AtomicReference<String?>(null)
+
         try {
             if (queryActuator().failed && actuatorFromSwagger(actuatorBaseURL).failed) {
                 openApiCoverageReportInput.setEndpointsAPIFlag(false)
@@ -478,6 +472,10 @@ open class SpecmaticJUnitSupport {
         startTime = Instant.now()
         return testScenarios.map { (contractTest, baseURL) ->
             DynamicTest.dynamicTest(contractTest.testDescription()) {
+                suiteAbortMessage.get()?.let { message ->
+                    throw TestAbortedException(message)
+                }
+
                 LicenseResolver.utilize(
                     product = LicensedProduct.OPEN_SOURCE,
                     feature = SpecmaticFeature.TEST,
@@ -509,6 +507,12 @@ open class SpecmaticJUnitSupport {
                         }
                     val (result) = testResult
 
+                    if (result is Result.Failure && result.failureReason == FailureReason.ConnectivityFailure) {
+                        val message = connectivityFailureMessage(baseURL, result.message)
+                        suiteAbortMessage.compareAndSet(null, message)
+                        throw ContractException(message)
+                    }
+
                     if (result is Result.Success && result.isPartialSuccess()) {
                         partialSuccesses.add(result)
                     }
@@ -536,6 +540,16 @@ open class SpecmaticJUnitSupport {
                 }
             }
         }.asStream()
+    }
+
+    private fun connectivityFailureMessage(baseURL: String, reason: String): String {
+        return """
+            Cannot connect to server at: $baseURL
+            Reason: $reason
+            Please check:
+            - Is the server running?
+            - Is the testBaseURL correct?
+        """.trimIndent()
     }
 
     fun constructTestBaseURL(): String {

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -51,6 +51,7 @@ import org.junit.platform.launcher.TestExecutionListener
 import org.opentest4j.TestAbortedException
 import java.io.File
 import java.io.PrintStream
+import java.net.ServerSocket
 import java.util.*
 
 class SpecmaticJunitSupportTest {
@@ -690,6 +691,67 @@ paths:
             val result = resultsBySpec.getValue(specFile.canonicalPath)
             assertThat(result).isInstanceOf(Result.Failure::class.java)
             assertThat(result.reportString()).contains("invalid_test_GET_200.json").contains("Error loading example")
+        } finally {
+            SpecmaticJUnitSupport.settingsStaging.remove()
+        }
+    }
+
+    @Test
+    fun `contractTest should abort remaining scenarios after first connectivity failure during execution`(@TempDir tempDir: File) {
+        val specFile = tempDir.resolve("api.yaml").apply {
+            writeText(
+                """
+                openapi: 3.0.0
+                info:
+                  title: Connectivity Abort Test
+                  version: 1.0.0
+                paths:
+                  /hello:
+                    get:
+                      responses:
+                        '200':
+                          description: OK
+                          content:
+                            text/plain:
+                              schema:
+                                type: string
+                              examples:
+                                FIRST:
+                                  value: hello
+                                SECOND:
+                                  value: world
+                """.trimIndent()
+            )
+        }
+        val unusedPort = ServerSocket(0).use { it.localPort }
+        val baseUrl = "http://localhost:$unusedPort"
+
+        SpecmaticJUnitSupport.settingsStaging.set(
+            ContractTestSettings(
+                testBaseURL = baseUrl,
+                contractPaths = specFile.absolutePath,
+                filter = "",
+                configFile = "",
+                generative = false,
+                reportBaseDirectory = null,
+                coverageHooks = emptyList()
+            )
+        )
+
+        try {
+            val tests = SpecmaticJUnitSupport().contractTest().toList()
+
+            assertThat(tests).hasSize(2)
+
+            val failure = assertThrows<ContractException> {
+                tests[0].executable.execute()
+            }
+            assertThat(failure.message).contains("Cannot connect to server at: $baseUrl")
+
+            val aborted = assertThrows<TestAbortedException> {
+                tests[1].executable.execute()
+            }
+            assertThat(aborted.message).contains("Cannot connect to server at: $baseUrl")
         } finally {
             SpecmaticJUnitSupport.settingsStaging.remove()
         }


### PR DESCRIPTION
**What**:

- Add an explicit `ConnectivityFailure` failure reason for contract test execution failures caused by network-level issues.
- Abort the remaining dynamic contract tests after the first connectivity failure instead of continuing to execute the rest of the suite.
- Add coverage in `SpecmaticJunitSupportTest` for the abort-after-first-connectivity-failure behavior.

**Why**:

When the target server is unavailable, continuing to run every scenario produces repetitive failures and obscures the real problem. Failing fast after the first connectivity issue gives a clearer signal and reduces noisy test output.

**How**:

- Classify connection-related exceptions in `ScenarioAsTest` by walking the throwable cause chain and mapping known network exceptions to `FailureReason.ConnectivityFailure`.
- In `SpecmaticJUnitSupport`, detect that failure reason during scenario execution, build a user-facing connectivity error message, and store it in a shared abort flag so subsequent dynamic tests abort immediately.
- Replace the old up-front base URL reachability handling with execution-time connectivity failure handling.
- Add a JUnit test that executes two generated contract tests against an unused localhost port and verifies the first test fails with a connectivity error while the second is aborted.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link) N/A
- [ ] Sample Project added/updated (share link) N/A
- [ ] Demo video (share link) N/A
- [ ] Article on Website (share link) N/A
- [ ] Roadmpap updated (share link) N/A
- [ ] Conference Talk (share link) N/A

Validated with:
- `./gradlew :junit5-support:test --tests "io.specmatic.test.SpecmaticJunitSupportTest"`

**Issue ID**:
N/A
