### PR TITLE
fix (test-result-record): handle test result message for all test result types

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -91,16 +91,10 @@ data class TestResultRecord(
     }
 
     override fun testMessage(): String {
-        return when {
-            result == TestResult.Failed && actualResponseStatus != responseStatus ->
-                "Expected status ${responseStatus}, but got $actualResponseStatus"
-
-            result == TestResult.Failed ->
-                "Test failed: ${scenarioResult?.let { "Scenario failure" } ?: "Unknown error"}"
-
-            isWip -> "Work in progress test"
-            else -> ""
-        }
+        if(isWip) return "Work in progress test"
+        if(scenarioResult == null) return ""
+        if(scenarioResult.isSuccess()) return ""
+        return scenarioResult.reportString()
     }
 
     override fun testName(): String {

--- a/core/src/test/kotlin/io/specmatic/test/TestResultRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/TestResultRecordTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.test
 
+
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.time.Instant
+
 
 class TestResultRecordTest {
 
@@ -172,6 +174,44 @@ class TestResultRecordTest {
         ).getCoverageStatus()
 
         assertEquals(CoverageStatus.WIP, coverageStatus)
+    }
+
+    @Test
+    fun `returns WIP message when isWip is true`() {
+        val record = testResultRecord(isWip = true, result = TestResult.NotCovered)
+        val result = record.testMessage()
+        assertEquals("Work in progress test", result)
+    }
+
+    @Test
+    fun `returns empty string when scenarioResult is null`() {
+        val record = testResultRecord(result = TestResult.MissingInSpec, isWip = false)
+        val result = record.testMessage()
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `returns empty string when scenarioResult is success`() {
+        val record = testResultRecord(
+            result = TestResult.Success,
+            isWip = false
+        ).copy(scenarioResult = io.specmatic.core.Result.Success())
+
+        val result = record.testMessage()
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `returns report string when scenarioResult fails`() {
+        val failure = io.specmatic.core.Result.Failure("Something went wrong")
+
+        val record = testResultRecord(
+            result = TestResult.Failed,
+            isWip = false
+        ).copy(scenarioResult = failure)
+
+        val result = record.testMessage()
+        assertTrue(result.contains("Something went wrong"))
     }
 
     private fun testResultRecord(


### PR DESCRIPTION
Reason for change -
The HTML report was missing the details around why a certain test failed especially when it comes to a "missing in spec" test.
This caused because the ctrf report which is used to render the html report, itself did not have those details.
This PR makes sure that the error details are set in the ctrf report during its generation.
This is done by relying directly on the test result while setting these details in the ctrf report.

