### PR TITLE
Skip annotations conformance reporting ci

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -2,7 +2,7 @@ name: Conformance Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "skip-annotations-conformance-reporting-ci" ]
 
 jobs:
   conformance-tests:
@@ -33,13 +33,13 @@ jobs:
       - uses: specmatic/specmatic-github-workflows/action-build-gradle@main
         continue-on-error: true
         with:
-          gradle-extra-args: "-p conformance-tests -PenableConformanceTests=true"
+          gradle-extra-args: "-p conformance-tests test -PenableConformanceTests=true --tests 'io.specmatic.conformance_tests.S008Constraints_020*'"
           github-token-for-pr-comment: ${{ secrets.GITHUB_TOKEN }} # use the CI token with write permissions to post PR comments
 
       - name: Publish Test Report
         if: always()
         continue-on-error: true
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@v6
         with:
           report_paths: 'conformance-tests/build/test-results/test/*.xml'
           detailed_summary: true
@@ -47,6 +47,7 @@ jobs:
           require_tests: false
           check_name: "conformance-tests-results"
           annotate_only: true
+          skip_annotations: true
 
       - name: Upload HTML Test Report
         if: always()

--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -2,7 +2,7 @@ name: Conformance Tests
 
 on:
   push:
-    branches: [ "main", "skip-annotations-conformance-reporting-ci" ]
+    branches: [ "main" ]
 
 jobs:
   conformance-tests:
@@ -33,7 +33,7 @@ jobs:
       - uses: specmatic/specmatic-github-workflows/action-build-gradle@main
         continue-on-error: true
         with:
-          gradle-extra-args: "-p conformance-tests test -PenableConformanceTests=true --tests 'io.specmatic.conformance_tests.S008Constraints_020*'"
+          gradle-extra-args: "-p conformance-tests -PenableConformanceTests=true"
           github-token-for-pr-comment: ${{ secrets.GITHUB_TOKEN }} # use the CI token with write permissions to post PR comments
 
       - name: Publish Test Report


### PR DESCRIPTION
Added Features -

* Upgraded (plugin)[https://github.com/mikepenz/action-junit-report] to 6.
* Skipping annotations in main summary page. Shows incorrect data.

#### Previous run of conformance 

Annotations Tab With incomplete errors:

https://github.com/specmatic/specmatic/actions/runs/24229572475

#### Current run

Annotations Tab Doesn't show incomplete errors: 

https://github.com/specmatic/specmatic/actions/runs/24231617232
