### PR TITLE
Ensure positive mutations from OptionalBody include relevant details

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpRequestPattern.kt
@@ -870,7 +870,7 @@ data class HttpRequestPattern(
                 this.body.negativeBasedOn(row.noteRequestBody(), resolver)
             }).let { generatedBodyNegatives ->
                 if (shouldGenerateNoBodyNegativeScenario()) {
-                    sequenceOf(HasValue(NoBodyPattern)).plus(generatedBodyNegatives)
+                    sequenceOf(HasValue(NoBodyPattern, "has been omitted", "BODY")).plus(generatedBodyNegatives)
                 } else {
                     generatedBodyNegatives
                 }

--- a/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
@@ -16,7 +16,7 @@ object NoBodyPattern : Pattern {
 
     override fun generate(resolver: Resolver): Value = NoBodyValue
 
-    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this, "has been omitted"))
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 

--- a/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/NoBodyPattern.kt
@@ -16,7 +16,7 @@ object NoBodyPattern : Pattern {
 
     override fun generate(resolver: Resolver): Value = NoBodyValue
 
-    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this))
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> = sequenceOf(HasValue(this, "has been omitted"))
 
     override fun newBasedOn(resolver: Resolver): Sequence<Pattern> = sequenceOf(this)
 

--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -281,19 +281,16 @@ data class AnyPattern(
         }
 
         val isNullable = updatedPatterns.any(::isEmpty)
-        val patternResults: Sequence<Pair<Sequence<ReturnValue<Pattern>>?, Throwable?>> =
-            updatedPatterns.asSequence().sortedBy(::isEmpty).map { innerPattern ->
-                try {
-                    val patterns =
-                        resolver.withCyclePrevention(innerPattern, isNullable) { cyclePreventedResolver ->
-                            val row = discriminator?.removeKeyFromRow(row) ?: row
-                            innerPattern.newBasedOn(row, cyclePreventedResolver).map { it.value }
-                        } ?: sequenceOf()
-                    Pair(patterns.map { HasValue(it) }, null)
-                } catch (e: Throwable) {
-                    Pair(null, e)
+        val patternResults: Sequence<Pair<Sequence<ReturnValue<Pattern>>?, Throwable?>> = updatedPatterns.asSequence().sortedBy(::isEmpty).mapNotNull { innerPattern ->
+            try {
+                resolver.withCyclePrevention(innerPattern, isNullable) { cyclePreventedResolver ->
+                    val row = discriminator?.removeKeyFromRow(row) ?: row
+                    Pair(innerPattern.newBasedOn(row, cyclePreventedResolver), null)
                 }
+            } catch (e: Throwable) {
+                Pair(null, e)
             }
+        }
 
         return newTypesOrExceptionIfNone(patternResults, "Could not generate new tests")
     }

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -235,7 +235,7 @@ class GenerativeTests {
                             type: integer
         """.trimIndent(), "").toFeature()
 
-        val positiveGenerativeScenarios = mutableListOf<Scenario>()
+        val positiveGenerativeChangeSummaries = mutableListOf<String?>()
         val negativeGenerativeChangeSummaries = mutableListOf<String?>()
         feature.enableGenerativeTesting().executeTests(object : TestExecutor {
             override fun execute(request: HttpRequest): HttpResponse {
@@ -244,21 +244,76 @@ class GenerativeTests {
 
             override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
                 when {
-                    scenario.testDescription().startsWith("+ve") -> positiveGenerativeScenarios.add(scenario)
+                    scenario.testDescription().startsWith("+ve") -> positiveGenerativeChangeSummaries.add(scenario.requestChangeSummary)
                     scenario.testDescription().startsWith("-ve") -> negativeGenerativeChangeSummaries.add(scenario.requestChangeSummary)
                 }
             }
         })
 
-        assertThat(positiveGenerativeScenarios).isNotEmpty
+        assertThat(positiveGenerativeChangeSummaries).isNotEmpty
         assertThat(negativeGenerativeChangeSummaries).isNotEmpty
         assertThat(negativeGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
-        assertThat(positiveGenerativeScenarios).allSatisfy { scenario ->
-            assertThat(scenario).satisfiesAnyOf(
-                { assertThat(it.httpRequestPattern.body).isInstanceOf(NoBodyPattern::class.java) },
-                { assertThat(it.requestChangeSummary).isNotBlank() },
-            )
-        }
+        assertThat(positiveGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
+        assertThat(positiveGenerativeChangeSummaries).contains("REQUEST.BODY has been omitted")
+    }
+
+    @Test
+    fun `generative tests for required request body with enum should include change summary for positive and negative tests`() {
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: "3.0.1"
+        info:
+          title: "Order API"
+          version: "1"
+        paths:
+          /order:
+            post:
+              summary: Create order
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                          enum:
+                            - new
+                            - processing
+              responses:
+                200:
+                  description: Order created
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - id
+                        properties:
+                          id:
+                            type: integer
+        """.trimIndent(), "").toFeature()
+
+        val positiveGenerativeChangeSummaries = mutableListOf<String?>()
+        val negativeGenerativeChangeSummaries = mutableListOf<String?>()
+        feature.enableGenerativeTesting().executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                return HttpResponse.OK
+            }
+
+            override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
+                when {
+                    scenario.testDescription().startsWith("+ve") -> positiveGenerativeChangeSummaries.add(scenario.requestChangeSummary)
+                    scenario.testDescription().startsWith("-ve") -> negativeGenerativeChangeSummaries.add(scenario.requestChangeSummary)
+                }
+            }
+        })
+
+        assertThat(positiveGenerativeChangeSummaries).isNotEmpty
+        assertThat(negativeGenerativeChangeSummaries).isNotEmpty
+        assertThat(negativeGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
+        assertThat(positiveGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
+        assertThat(negativeGenerativeChangeSummaries).contains("REQUEST.BODY has been omitted")
     }
 
     @Test
@@ -2397,7 +2452,7 @@ class GenerativeTests {
             "+ve  Scenario: POST /items -> 201 with the request from the example 'sampleItems' where REQUEST.BODY contains all the keys",
             "+ve  Scenario: POST /items -> 201 with the request from the example 'sampleItems' where REQUEST.BODY contains all the keys AND the key quantity is set to the largest possible value",
             "+ve  Scenario: POST /items -> 201 with the request from the example 'sampleItems' where REQUEST.BODY contains all the keys AND the key quantity is set to the smallest possible value '1'",
-            "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems'",
+            "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY has been omitted",
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key name is mutated from string to boolean",
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key name is mutated from string to boolean AND quantity is set to the largest possible value",
             "-ve  Scenario: POST /items -> 4xx with the request from the example 'sampleItems' where REQUEST.BODY.[] contains all the keys AND the key name is mutated from string to boolean AND quantity is set to the smallest possible value '1'",

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -10,6 +10,7 @@ import io.specmatic.core.AttributeSelectionPattern
 import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
+import io.specmatic.core.NoBodyPattern
 import io.specmatic.core.Result
 import io.specmatic.core.Results
 import io.specmatic.core.Scenario
@@ -194,6 +195,69 @@ class GenerativeTests {
             println(e.report())
 
             throw e
+        }
+    }
+
+    @Test
+    fun `generative tests for optional request body with enum should include change summary for positive and negative tests`() {
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: "3.0.1"
+        info:
+          title: "Order API"
+          version: "1"
+        paths:
+          /order:
+            post:
+              summary: Create order
+              requestBody:
+                required: false
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                          enum:
+                            - new
+                            - processing
+              responses:
+                200:
+                  description: Order created
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - id
+                        properties:
+                          id:
+                            type: integer
+        """.trimIndent(), "").toFeature()
+
+        val positiveGenerativeScenarios = mutableListOf<Scenario>()
+        val negativeGenerativeChangeSummaries = mutableListOf<String?>()
+        feature.enableGenerativeTesting().executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                return HttpResponse.OK
+            }
+
+            override fun preExecuteScenario(scenario: Scenario, request: HttpRequest) {
+                when {
+                    scenario.testDescription().startsWith("+ve") -> positiveGenerativeScenarios.add(scenario)
+                    scenario.testDescription().startsWith("-ve") -> negativeGenerativeChangeSummaries.add(scenario.requestChangeSummary)
+                }
+            }
+        })
+
+        assertThat(positiveGenerativeScenarios).isNotEmpty
+        assertThat(negativeGenerativeChangeSummaries).isNotEmpty
+        assertThat(negativeGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
+        assertThat(positiveGenerativeScenarios).allSatisfy { scenario ->
+            assertThat(scenario).satisfiesAnyOf(
+                { assertThat(it.httpRequestPattern.body).isInstanceOf(NoBodyPattern::class.java) },
+                { assertThat(it.requestChangeSummary).isNotBlank() },
+            )
         }
     }
 

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -253,8 +253,7 @@ class GenerativeTests {
         assertThat(positiveGenerativeChangeSummaries).isNotEmpty
         assertThat(negativeGenerativeChangeSummaries).isNotEmpty
         assertThat(negativeGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
-        assertThat(positiveGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
-        assertThat(positiveGenerativeChangeSummaries).contains("REQUEST.BODY has been omitted")
+        assertThat(positiveGenerativeChangeSummaries).anySatisfy { assertThat(it == null || it.isBlank()).isTrue() }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7253,9 +7253,9 @@ components:
 
         val testDescriptionList = tests.map { it.testDescription() }
         assertThat(testDescriptionList).containsExactlyInAnyOrder(
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'FIRST' from enum",
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'SECOND' from enum",
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'THIRD' from enum"
+            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'FIRST' from enum AND REQUEST.BODY has been omitted",
+            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'SECOND' from enum AND REQUEST.BODY has been omitted",
+            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'THIRD' from enum AND REQUEST.BODY has been omitted"
         )
     }
 
@@ -12330,12 +12330,12 @@ paths:
         })
 
         assertThat(testDescriptions).containsExactlyInAnyOrder(
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'fulfilled' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'pending' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the param 'quantity'",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'fulfilled' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'pending' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'quantity'",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'fulfilled' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'pending' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the param 'quantity'",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'fulfilled' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'pending' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'productId', 'quantity'",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND productId is mutated from number to boolean AND status is set to 'fulfilled' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND productId is mutated from number to string AND status is set to 'pending' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND productId is mutated from number to boolean AND status is set to 'pending' from enum",
@@ -12373,12 +12373,12 @@ paths:
         })
 
         assertThat(testDescriptions).containsExactlyInAnyOrder(
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'fulfilled' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'pending' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity'",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity', 'X-Request-Source'",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'fulfilled' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'pending' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'fulfilled' from enum AND REQUEST.BODY has been omitted",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'pending' from enum AND REQUEST.BODY has been omitted",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity' AND REQUEST.BODY has been omitted",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity', 'X-Request-Source' AND REQUEST.BODY has been omitted",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'fulfilled' from enum AND REQUEST.BODY has been omitted",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'pending' from enum AND REQUEST.BODY has been omitted",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Product-Id is mutated from number to boolean AND X-Order-Status is set to 'fulfilled' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Product-Id is mutated from number to string AND X-Order-Status is set to 'pending' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Product-Id is mutated from number to boolean AND X-Order-Status is set to 'pending' from enum",
@@ -12422,7 +12422,7 @@ paths:
             "+ve  Scenario: POST /orders -> 200 with a request where REQUEST.BODY contains all the keys AND the key status is set to 'fulfilled' from enum",
             "+ve  Scenario: POST /orders -> 200 with a request where REQUEST.BODY contains all the keys AND the key status is set to 'pending' from enum",
             "+ve  Scenario: POST /orders -> 200 with a request where REQUEST.BODY contains only the mandatory keys",
-            "-ve  Scenario: POST /orders -> 4xx",
+            "-ve  Scenario: POST /orders -> 4xx with a request where REQUEST.BODY has been omitted",
             "-ve  Scenario: POST /orders -> 4xx with a request where REQUEST.BODY contains all the keys AND the key productId is mutated from number to null AND status is set to 'fulfilled' from enum",
             "-ve  Scenario: POST /orders -> 4xx with a request where REQUEST.BODY contains all the keys AND the key productId is mutated from number to boolean AND status is set to 'pending' from enum",
             "-ve  Scenario: POST /orders -> 4xx with a request where REQUEST.BODY contains all the keys AND the key productId is mutated from number to string AND status is set to 'fulfilled' from enum",

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationTest.kt
@@ -7253,9 +7253,9 @@ components:
 
         val testDescriptionList = tests.map { it.testDescription() }
         assertThat(testDescriptionList).containsExactlyInAnyOrder(
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'FIRST' from enum AND REQUEST.BODY has been omitted",
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'SECOND' from enum AND REQUEST.BODY has been omitted",
-            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'THIRD' from enum AND REQUEST.BODY has been omitted"
+            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'FIRST' from enum",
+            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'SECOND' from enum",
+            " Scenario: GET /items -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the header 'X-region' AND X-region is set to 'THIRD' from enum"
         )
     }
 
@@ -12330,12 +12330,12 @@ paths:
         })
 
         assertThat(testDescriptions).containsExactlyInAnyOrder(
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'fulfilled' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'pending' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the param 'quantity'",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'fulfilled' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'pending' from enum",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.BODY has been omitted AND REQUEST.PARAMETERS.QUERY contains the params 'productId', 'quantity'",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'fulfilled' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND status is set to 'pending' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the param 'quantity'",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'fulfilled' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'status', 'quantity' AND status is set to 'pending' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'quantity'",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND productId is mutated from number to boolean AND status is set to 'fulfilled' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND productId is mutated from number to string AND status is set to 'pending' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.QUERY contains the params 'productId', 'status', 'quantity' AND productId is mutated from number to boolean AND status is set to 'pending' from enum",
@@ -12373,12 +12373,12 @@ paths:
         })
 
         assertThat(testDescriptions).containsExactlyInAnyOrder(
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'fulfilled' from enum AND REQUEST.BODY has been omitted",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'pending' from enum AND REQUEST.BODY has been omitted",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity' AND REQUEST.BODY has been omitted",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity', 'X-Request-Source' AND REQUEST.BODY has been omitted",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'fulfilled' from enum AND REQUEST.BODY has been omitted",
-            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'pending' from enum AND REQUEST.BODY has been omitted",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'fulfilled' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Order-Status is set to 'pending' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity'",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Quantity', 'X-Request-Source'",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'fulfilled' from enum",
+            "+ve  Scenario: GET /orders -> 200 with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity' AND X-Order-Status is set to 'pending' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Product-Id is mutated from number to boolean AND X-Order-Status is set to 'fulfilled' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Product-Id is mutated from number to string AND X-Order-Status is set to 'pending' from enum",
             "-ve  Scenario: GET /orders -> 4xx with a request where REQUEST.PARAMETERS.HEADER contains the headers 'X-Product-Id', 'X-Order-Status', 'X-Quantity', 'X-Request-Source' AND X-Product-Id is mutated from number to boolean AND X-Order-Status is set to 'pending' from enum",

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyOfPatternTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.pattern
 
+import io.specmatic.GENERATION
 import io.specmatic.core.DefaultMismatchMessages
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
@@ -10,6 +11,7 @@ import io.specmatic.core.value.NumberValue
 import io.specmatic.core.value.StringValue
 import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
 internal class AnyOfPatternTest {
@@ -147,6 +149,40 @@ internal class AnyOfPatternTest {
 
         assertThat(generatedPatterns.any { it is StringPattern }).isTrue()
         assertThat(generatedPatterns.any { it is NumberPattern }).isTrue()
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `newBasedOn should preserve value details and comments from delegate patterns`() {
+        val pattern = AnyOfPattern(
+            listOf(
+                JSONObjectPattern(mapOf("id" to NumberPattern(), "name" to StringPattern())),
+                JSONObjectPattern(mapOf("id" to NumberPattern(), "code?" to StringPattern())),
+            ),
+        )
+
+        val generated = pattern.newBasedOn(Row(), resolver).toList().filterIsInstance<HasValue<Pattern>>()
+        assertThat(generated).isNotEmpty.allSatisfy {
+            assertThat(it.valueDetails).isNotEmpty
+            assertThat(it.comments()).isNotBlank
+        }
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `negativeBasedOn should preserve value details and comments from delegate patterns`() {
+        val pattern = AnyOfPattern(
+            listOf(
+                JSONObjectPattern(mapOf("id" to NumberPattern(), "name" to StringPattern())),
+                JSONObjectPattern(mapOf("id" to NumberPattern(), "code?" to StringPattern())),
+            ),
+        )
+
+        val generated = pattern.negativeBasedOn(Row(), resolver).toList().filterIsInstance<HasValue<Pattern>>()
+        assertThat(generated).isNotEmpty.allSatisfy {
+            assertThat(it.valueDetails).isNotEmpty
+            assertThat(it.comments()).isNotBlank
+        }
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/AnyPatternTest.kt
@@ -230,6 +230,17 @@ internal class AnyPatternTest {
     }
 
     @Test
+    @Tag(GENERATION)
+    fun `newBasedOn should preserve value details and comments from child patterns`() {
+        val pattern = AnyPattern(listOf(parsedPattern("""{"id": "(number)", "name": "(string)"}""")), extensions = emptyMap())
+        val generatedPattern = pattern.newBasedOn(Row(), Resolver()).toList()
+        assertThat(generatedPattern.filterIsInstance<HasValue<Pattern>>()).isNotEmpty.allSatisfy {
+            assertThat(it.valueDetails).isNotEmpty
+            assertThat(it.comments()).isNotBlank
+        }
+    }
+
+    @Test
     fun `should generate a value based on the pattern given`() {
         NumberValue(10) shouldMatch AnyPattern(listOf(parsedPattern("(number)")), extensions = emptyMap())
     }
@@ -363,6 +374,17 @@ internal class AnyPatternTest {
             NumberPattern(),
             BooleanPattern()
         )
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `negativeBasedOn should preserve value details and comments from child patterns`() {
+        val pattern = AnyPattern(listOf(EnumPattern(listOf(StringValue("red"), StringValue("blue")))), extensions = emptyMap())
+        val results = pattern.negativeBasedOn(Row(), Resolver()).toList()
+        assertThat(results.filterIsInstance<HasValue<Pattern>>()).isNotEmpty.allSatisfy {
+            assertThat(it.valueDetails).isNotEmpty
+            assertThat(it.comments()).isNotBlank
+        }
     }
 
     @Test


### PR DESCRIPTION
**What**: Ensure positive mutations from OptionalBody include relevant details

**Why**: The ValueDetails should be preserved when executing newBasedOn, as they provide the user with information about positive mutations

**How**: Fix in `AnyPattern.newBasedOn` that causes `ValueDetails` to be omitted during pattern iteration

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)