### PR TITLE
Override methods for OptionalBodyPattern newBasedOn and fixValue

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OptionalBodyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OptionalBodyPattern.kt
@@ -27,6 +27,11 @@ data class OptionalBodyPattern(override val pattern: AnyPattern, private val bod
         return scalarResolveSubstitutions(substitution, value, key, this, resolver)
     }
 
+    override fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<Pattern>> {
+        val newBasedOnNoBodyPattern = sequenceOf<ReturnValue<Pattern>>(HasValue(NoBodyPattern, "has been omitted"))
+        val newBasedOnBodyPattern = bodyPattern.newBasedOn(row, resolver)
+        return newBasedOnNoBodyPattern.plus(newBasedOnBodyPattern)
+    }
 
     override fun matches(sampleData: Value?, resolver: Resolver): Result {
         val bodyPatternMatchResult = bodyPattern.matches(sampleData, resolver)

--- a/core/src/main/kotlin/io/specmatic/conversions/OptionalBodyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OptionalBodyPattern.kt
@@ -1,6 +1,7 @@
 package io.specmatic.conversions
 
 import io.specmatic.core.NoBodyPattern
+import io.specmatic.core.NoBodyValue
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.Substitution
@@ -45,5 +46,10 @@ data class OptionalBodyPattern(override val pattern: AnyPattern, private val bod
             return nobodyPatternMatchResult
 
         return bodyPatternMatchResult
+    }
+
+    override fun fixValue(value: Value, resolver: Resolver): Value {
+        if (value is NoBodyValue) return NoBodyValue
+        return bodyPattern.fixValue(value, resolver)
     }
 }

--- a/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
+++ b/core/src/test/kotlin/integration_tests/ResiliencyTests.kt
@@ -10,7 +10,6 @@ import io.specmatic.core.AttributeSelectionPattern
 import io.specmatic.core.Feature
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
-import io.specmatic.core.NoBodyPattern
 import io.specmatic.core.Result
 import io.specmatic.core.Results
 import io.specmatic.core.Scenario
@@ -252,8 +251,9 @@ class GenerativeTests {
 
         assertThat(positiveGenerativeChangeSummaries).isNotEmpty
         assertThat(negativeGenerativeChangeSummaries).isNotEmpty
+        assertThat(positiveGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
         assertThat(negativeGenerativeChangeSummaries).allSatisfy { assertThat(it).isNotBlank() }
-        assertThat(positiveGenerativeChangeSummaries).anySatisfy { assertThat(it == null || it.isBlank()).isTrue() }
+        assertThat(positiveGenerativeChangeSummaries).contains("REQUEST.BODY has been omitted")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/conversions/OneOfSupport.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OneOfSupport.kt
@@ -18,6 +18,7 @@ class OneOfSupport {
               /test:
                 post:
                   requestBody:
+                    required: true
                     content:
                       application/json:
                         schema:

--- a/core/src/test/kotlin/io/specmatic/conversions/OptionalBodyPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OptionalBodyPatternTest.kt
@@ -12,6 +12,38 @@ import org.junit.jupiter.api.Test
 
 class OptionalBodyPatternTest {
     @Test
+    fun `fixValue should retain NoBodyValue instead of converting to body pattern`() {
+        val pattern = OptionalBodyPattern.fromPattern(StringPattern())
+        val fixedValue = pattern.fixValue(NoBodyValue, Resolver())
+        assertThat(fixedValue).isEqualTo(NoBodyValue)
+    }
+
+    @Test
+    fun `fixValue should prefer body pattern when value is not no body value`() {
+        val pattern = OptionalBodyPattern.fromPattern(
+            JSONObjectPattern(
+                mapOf(
+                    "one" to NumberPattern(),
+                    "two" to NumberPattern(),
+                    "three" to NumberPattern()
+                )
+            )
+        )
+
+        val value = JSONObjectValue(
+            mapOf(
+                "one" to NumberValue(1),
+                "two" to StringValue("bad"),
+                "three" to StringValue("also_bad")
+            )
+        )
+
+        val fixedValue = pattern.fixValue(value, Resolver())
+        assertThat(fixedValue).isInstanceOf(JSONObjectValue::class.java); fixedValue as JSONObjectValue
+        assertThat(fixedValue.jsonObject.keys).containsExactlyInAnyOrder("one", "two", "three")
+    }
+
+    @Test
     fun `optional body error match`() {
         val body = OptionalBodyPattern.fromPattern(NumberPattern())
 

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -1727,6 +1727,7 @@ paths:
     post:
       summary: Add Pet
       requestBody:
+        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
**What**: Override methods for OptionalBodyPattern newBasedOn and fixValue

**Why**:
- `newBasedOn` should include the positive mutation reason for skipping the request body.
- `fixValue` should always prioritize using the bodyPattern when the value isn’t NoBodyValue

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)