### PR TITLE
Enforce SOAP-version-specific Content-Type for request and response

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/wsdl/SOAPVersion.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/SOAPVersion.kt
@@ -1,0 +1,23 @@
+package io.specmatic.core.wsdl
+
+import io.specmatic.core.wsdl.payload.EmptyHTTPBodyPayload
+import io.specmatic.core.wsdl.payload.SOAPPayload
+
+enum class SOAPVersion {
+    SOAP12 {
+        override val contentType: String = "application/soap+xml"
+    },
+
+    SOAP11 {
+        override val contentType: String = "text/xml"
+    };
+
+    abstract val contentType: String
+
+    fun header(soapPayload: SOAPPayload): String? {
+        return when (soapPayload) {
+            !is EmptyHTTPBodyPayload -> contentType
+            else -> null
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -9,6 +9,7 @@ import io.specmatic.core.value.FullyQualifiedName
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.value.xmlNode
 import io.specmatic.core.utilities.capitalizeFirstChar
+import io.specmatic.core.wsdl.SOAPVersion
 import io.specmatic.core.wsdl.parser.message.*
 import io.specmatic.core.wsdl.parser.operation.SOAPOperationTypeInfo
 import io.specmatic.core.wsdl.payload.EmptyHTTPBodyPayload
@@ -48,9 +49,10 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
 
     private fun operationsTypeInfo(url: String): List<SOAPOperationTypeInfo> {
         val portType = wsdl.getPortType()
+        val soapVersion = wsdl.getSOAPVersion()
 
         return wsdl.operations.map {
-            parseOperation(it, url, wsdl, portType)
+            parseOperation(it, url, wsdl, portType, soapVersion)
         }
     }
 
@@ -65,7 +67,13 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         }
     }
 
-    private fun parseOperation(bindingOperationNode: XMLNode, url: String, wsdl: WSDL, portType: XMLNode): SOAPOperationTypeInfo {
+    private fun parseOperation(
+        bindingOperationNode: XMLNode,
+        url: String,
+        wsdl: WSDL,
+        portType: XMLNode,
+        soapVersion: SOAPVersion
+    ): SOAPOperationTypeInfo {
         val operationName = bindingOperationNode.getAttributeValue("name")
 
         val soapAction = bindingOperationNode.getAttributeValueAtPath("operation", "soapAction")
@@ -133,13 +141,14 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
                 }.toMap()
 
         return SOAPOperationTypeInfo(
-            path,
-            operationName,
-            soapAction,
-            responseTypeInfo.types.mapKeys { it.key.trim() },
-            requestTypeInfo.soapPayload,
-            RequestHeaders(requestHeaders),
-            responseTypeInfo.soapPayload
+            path = path,
+            operationName = operationName,
+            soapAction = soapAction,
+            soapVersion = soapVersion,
+            types = responseTypeInfo.types.mapKeys { it.key.trim() },
+            requestPayload = requestTypeInfo.soapPayload,
+            requestHeaders = RequestHeaders(requestHeaders),
+            responsePayload = responseTypeInfo.soapPayload
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -8,9 +8,9 @@ import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.*
+import io.specmatic.core.wsdl.SOAPVersion
 import io.specmatic.core.wsdl.parser.message.*
 import io.specmatic.license.core.SpecmaticProtocol
-import io.specmatic.reporter.model.SpecType
 import java.io.File
 
 private fun namespaceToPrefixMap(wsdlNode: XMLNode): Map<String, String> {
@@ -376,6 +376,20 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
 
     fun getSchemaNamespacePrefix(namespace: String): String {
         return namespaceToPrefix[namespace] ?: throw ContractException("Tried to lookup a prefix for the namespace $namespace but could not find one")
+    }
+
+    fun getSOAPVersion(): SOAPVersion {
+        val paranoidDefaultSoapVersion = SOAPVersion.SOAP12
+
+        val wsdlBindingNode = getBinding()
+        val bindingNode = wsdlBindingNode.findChildrenByName("binding").firstOrNull() ?: return paranoidDefaultSoapVersion
+        val namespace = bindingNode.namespaces[bindingNode.namespacePrefix]
+
+        return when (namespace) {
+            "http://schemas.xmlsoap.org/wsdl/soap/" -> SOAPVersion.SOAP11
+            "http://schemas.xmlsoap.org/wsdl/soap12/" -> SOAPVersion.SOAP12
+            else -> paranoidDefaultSoapVersion
+        }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfo.kt
@@ -11,21 +11,23 @@ import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.extractCombinedExtensions
 import io.specmatic.core.pattern.withPatternDelimiters
 import io.specmatic.core.value.StringValue
+import io.specmatic.core.wsdl.SOAPVersion
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.core.wsdl.payload.RequestHeaders
 import io.specmatic.core.wsdl.payload.SOAPPayload
 
-data class SOAPOperationTypeInfo(val operationName: String, val request: SOAPRequest, val response: SOAPResponse, val types: SOAPTypes) {
+data class SOAPOperationTypeInfo(val operationName: String, val soapVersion: SOAPVersion, val request: SOAPRequest, val response: SOAPResponse, val types: SOAPTypes) {
     constructor(
         path: String,
         operationName: String,
         soapAction: String,
+        soapVersion: SOAPVersion,
         types: Map<String, Pattern>,
         requestPayload: SOAPPayload,
         requestHeaders: RequestHeaders,
         responsePayload: SOAPPayload
-    ) : this(operationName, SOAPRequest(path, operationName, soapAction, requestHeaders, requestPayload), SOAPResponse(responsePayload), SOAPTypes(types))
+    ) : this(operationName, soapVersion = soapVersion, SOAPRequest(path, operationName, soapAction, requestHeaders, requestPayload), SOAPResponse(responsePayload), SOAPTypes(types))
 
     fun expandedVariants(): List<SOAPOperationTypeInfo> {
         return types.expandedVariants().map { expandedTypes ->
@@ -57,6 +59,7 @@ data class SOAPOperationTypeInfo(val operationName: String, val request: SOAPReq
                 headersPattern = HttpHeadersPattern(
                     pattern = soapActionHeaderPattern(request.soapAction),
                     preferEscapedSoapAction = preferEscapedSoapAction,
+                    contentType = soapVersion.header(request.requestPayload)
                 ),
                 httpPathPattern = buildHttpPathPattern(request.path),
                 method = "POST",
@@ -64,6 +67,9 @@ data class SOAPOperationTypeInfo(val operationName: String, val request: SOAPReq
             ),
             httpResponsePattern = HttpResponsePattern(
                 status = 200,
+                headersPattern = HttpHeadersPattern(
+                    contentType = soapVersion.header(response.responsePayload),
+                ),
                 body = response.responsePayload.toPattern(RequestHeaders()),
             ),
             patterns = types.types.mapKeys { (typeName, _) -> withPatternDelimiters(typeName) },

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlKtTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.conversions
 
+import io.ktor.http.ContentType
 import io.specmatic.Utils.readTextResource
 import io.specmatic.core.*
 import io.specmatic.core.pattern.ContractException
@@ -531,10 +532,7 @@ Scenario: test request returns test response
         val soapRequest = HttpRequest(
             "POST",
             "/SOAPService/SimpleSOAP",
-            mapOf(
-                "SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation",
-                "Content-Type" to "application/xml"
-            ),
+            mapOf("SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = parsedValue("""<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header/><soapenv:Body><qr:Person age="22"><qr:Id>2</qr:Id><qr:Name>James Taylor</qr:Name></qr:Person></soapenv:Body></soapenv:Envelope>""")
         )
         val wsdlScenario = wsdlFeature.scenarios.single()
@@ -548,10 +546,7 @@ Scenario: test request returns test response
         val soapRequest = HttpRequest(
             "POST",
             "/SOAPService/SimpleSOAP",
-            mapOf(
-                "SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation",
-                "Content-Type" to "application/xml"
-            ),
+            mapOf("SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = parsedValue("""<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header/><soapenv:Body><qr:Person><qr:Id>2</qr:Id><qr:Name>James Taylor</qr:Name></qr:Person></soapenv:Body></soapenv:Envelope>""")
         )
         val wsdlScenario = wsdlFeature.scenarios.single()
@@ -566,10 +561,7 @@ Scenario: test request returns test response
         val soapRequest = HttpRequest(
             "POST",
             "/SOAPService/SimpleSOAP",
-            mapOf(
-                "SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation",
-                "Content-Type" to "application/xml"
-            ),
+            mapOf("SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = parsedValue("""<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header/><soapenv:Body><qr:Person age="22"><qr:Id>2</qr:Id><qr:Name>James Taylor</qr:Name></qr:Person></soapenv:Body></soapenv:Envelope>""")
         )
         val wsdlScenario = wsdlFeature.scenarios.single()
@@ -583,10 +575,7 @@ Scenario: test request returns test response
         val soapRequest = HttpRequest(
             "POST",
             "/SOAPService/SimpleSOAP",
-            mapOf(
-                "SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation",
-                "Content-Type" to "application/xml"
-            ),
+            mapOf("SOAPAction" to "http://specmatic.io/SOAPService/SimpleOperation", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = parsedValue("""<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soapenv:Header/><soapenv:Body><qr:Person><qr:Id>2</qr:Id><qr:Name>James Taylor</qr:Name></qr:Person></soapenv:Body></soapenv:Envelope>""")
         )
         val wsdlScenario = wsdlFeature.scenarios.single()

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -29,17 +29,44 @@ internal class WsdlSpecificationTest {
     }
 
     @Test
-    fun `existence of content type header`() {
+    fun `request and response content type should be parsed as text-xml for soap version_1_1`() {
         val wsdlPath = "src/test/resources/wsdl/stockquote.wsdl"
-
         val wsdlContract = wsdlContentToFeature(File(wsdlPath).readText(), wsdlPath)
-
         assertThat(wsdlContract.scenarios).allSatisfy { scenario ->
             val request = scenario.generateHttpRequest()
             assertThat(request.contentType()).isEqualTo("text/xml")
 
             val response = scenario.generateHttpResponse(emptyMap())
             assertThat(response.contentType()).isEqualTo("text/xml")
+        }
+    }
+
+    @Test
+    fun `request and response content type should be parsed as application-soap-xml for soap version_1_2`() {
+        val wsdlPath = "src/test/resources/wsdl/cdata_test_soap12/data_api.wsdl"
+        val wsdlContract = wsdlContentToFeature(File(wsdlPath).readText(), wsdlPath)
+        assertThat(wsdlContract.scenarios).allSatisfy { scenario ->
+            val request = scenario.generateHttpRequest()
+            assertThat(request.contentType()).isEqualTo("application/soap+xml")
+
+            val response = scenario.generateHttpResponse(emptyMap())
+            assertThat(response.contentType()).isEqualTo("application/soap+xml")
+        }
+    }
+
+    @Test
+    fun `request and response content type should default to application-soap-xml for unknown soap version`() {
+        val wsdlPath = "src/test/resources/wsdl/stockquote.wsdl"
+        val wsdlContentWithUnknownSoapNamespace = File(wsdlPath).readText()
+            .replace("http://schemas.xmlsoap.org/wsdl/soap/", "http://example.com/unknown-soap/")
+
+        val wsdlContract = wsdlContentToFeature(wsdlContentWithUnknownSoapNamespace, wsdlPath)
+        assertThat(wsdlContract.scenarios).allSatisfy { scenario ->
+            val request = scenario.generateHttpRequest()
+            assertThat(request.contentType()).isEqualTo("application/soap+xml")
+
+            val response = scenario.generateHttpResponse(emptyMap())
+            assertThat(response.contentType()).isEqualTo("application/soap+xml")
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WsdlSpecificationTest.kt
@@ -27,4 +27,19 @@ internal class WsdlSpecificationTest {
         println(result.toReport().toText())
         assertThat(result).isInstanceOf(Result.Success::class.java)
     }
+
+    @Test
+    fun `existence of content type header`() {
+        val wsdlPath = "src/test/resources/wsdl/stockquote.wsdl"
+
+        val wsdlContract = wsdlContentToFeature(File(wsdlPath).readText(), wsdlPath)
+
+        assertThat(wsdlContract.scenarios).allSatisfy { scenario ->
+            val request = scenario.generateHttpRequest()
+            assertThat(request.contentType()).isEqualTo("text/xml")
+
+            val response = scenario.generateHttpResponse(emptyMap())
+            assertThat(response.contentType()).isEqualTo("text/xml")
+        }
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
@@ -1,8 +1,9 @@
 package io.specmatic.core.wsdl
 
+import io.ktor.http.ContentType
+import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
-import io.specmatic.core.Result
 import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.wsdl.payload.emptySoapMessage
 import io.specmatic.stub.HttpStub
@@ -244,7 +245,7 @@ class WSDLParserContractBlackBoxTest {
             fixture.feature.executeTests(object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertHttpRequestMatches(request, fixture.scenarioStub.request)
-                    assertThat(request.headers["Content-Type"]).isNull()
+                    assertThat(request.headers["Content-Type"]).isEqualTo(ContentType.Text.Xml.toString())
                     return stub.client.execute(request)
                 }
             })
@@ -265,11 +266,46 @@ class WSDLParserContractBlackBoxTest {
             fixture.feature.executeTests(object : TestExecutor {
                 override fun execute(request: HttpRequest): HttpResponse {
                     assertHttpRequestMatches(request, fixture.scenarioStub.request)
-                    assertThat(request.headers["Content-Type"]).isNull()
+                    assertThat(request.headers["Content-Type"]).isEqualTo(ContentType.Text.Xml.toString())
                     return stub.client.execute(request)
                 }
             })
         }
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `contract test for soap version_1_2 wsdl uses example request and content-type`() {
+        val wsdlSpecPath = "src/test/resources/wsdl/cdata_test_soap12/data_api.wsdl"
+        val examplesPath = "src/test/resources/wsdl/cdata_test_soap12/data_api_examples"
+        val fixture = loadWsdlExampleFixture(wsdlSpecPath, examplesPath)
+
+        val result = fixture.feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.body).isEqualTo(fixture.scenarioStub.request.body)
+                assertThat(request.headers[CONTENT_TYPE]).startsWith("application/soap+xml")
+                return fixture.scenarioStub.response
+            }
+        })
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `contract test for soap version_1_2 wsdl generated request uses content-type`() {
+        val wsdlSpecPath = "src/test/resources/wsdl/cdata_test_soap12/data_api.wsdl"
+        val feature = parseContractFileToFeature(File(wsdlSpecPath))
+        val generatedResponse = feature.scenarios.single().generateHttpResponse(emptyMap())
+
+        val result = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.headers[CONTENT_TYPE]).startsWith("application/soap+xml")
+                return generatedResponse
+            }
+        })
 
         assertThat(result.success()).withFailMessage(result.report()).isTrue()
         assertThat(result.successCount).isEqualTo(1)

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
@@ -1,5 +1,7 @@
 package io.specmatic.core.wsdl
 
+import io.ktor.http.ContentType
+import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.value.StringValue
@@ -19,7 +21,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-scalar",
-                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicescalar=\"http://choice-scalar\"><soapenv:Body><Choicescalar:ScalarChoiceRequest><PrimaryName>PrimaryName</PrimaryName><CustomerNumber>C-123</CustomerNumber></Choicescalar:ScalarChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -42,7 +44,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-scalar",
-                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicescalar=\"http://choice-scalar\"><soapenv:Body><Choicescalar:ScalarChoiceRequest><PrimaryName>PrimaryName</PrimaryName><CustomerNumber>C-123</CustomerNumber></Choicescalar:ScalarChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -51,7 +53,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-scalar",
-                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicescalar=\"http://choice-scalar\"><soapenv:Body><Choicescalar:ScalarChoiceRequest><PrimaryName>PrimaryName</PrimaryName><LoginId>login-123</LoginId></Choicescalar:ScalarChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -70,7 +72,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-scalar",
-                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-scalar/scalarChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicescalar=\"http://choice-scalar\"><soapenv:Body><Choicescalar:ScalarChoiceRequest><PrimaryName>PrimaryName</PrimaryName><CustomerNumber>C-123</CustomerNumber><LoginId>login-123</LoginId></Choicescalar:ScalarChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -88,7 +90,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-complex",
-                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicecomplex=\"http://choice-complex\"><soapenv:Body><Choicecomplex:ComplexChoiceRequest><PrimaryName>PrimaryName</PrimaryName><Choicecomplex:CustomerByPermId><PermId>CP-123</PermId></Choicecomplex:CustomerByPermId></Choicecomplex:ComplexChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -111,7 +113,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-complex",
-                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicecomplex=\"http://choice-complex\"><soapenv:Body><Choicecomplex:ComplexChoiceRequest><PrimaryName>PrimaryName</PrimaryName><Choicecomplex:CustomerByPermId><PermId>CP-123</PermId></Choicecomplex:CustomerByPermId></Choicecomplex:ComplexChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -120,7 +122,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-complex",
-                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicecomplex=\"http://choice-complex\"><soapenv:Body><Choicecomplex:ComplexChoiceRequest><PrimaryName>PrimaryName</PrimaryName><Choicecomplex:CustomerByLogin><Domain>Retail</Domain><LoginId>login-123</LoginId></Choicecomplex:CustomerByLogin></Choicecomplex:ComplexChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -139,7 +141,7 @@ class WSDLParserMockBlackBoxTest {
                 HttpRequest(
                     method = "POST",
                     path = "/choice-complex",
-                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\""),
+                    headers = mapOf("SOAPAction" to "\"/choice-complex/complexChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
                     body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Choicecomplex=\"http://choice-complex\"><soapenv:Body><Choicecomplex:ComplexChoiceRequest><PrimaryName>PrimaryName</PrimaryName><Choicecomplex:CustomerByPermId><PermId>CP-123</PermId></Choicecomplex:CustomerByPermId><Choicecomplex:CustomerByLogin><Domain>Retail</Domain><LoginId>login-123</LoginId></Choicecomplex:CustomerByLogin></Choicecomplex:ComplexChoiceRequest></soapenv:Body></soapenv:Envelope>")
                 )
             )
@@ -174,7 +176,7 @@ class WSDLParserMockBlackBoxTest {
         val request = HttpRequest(
             method = "POST",
             path = "/choice-optional",
-            headers = mapOf("SOAPAction" to "\"/choice-optional/optionalChoice\""),
+            headers = mapOf("SOAPAction" to "\"/choice-optional/optionalChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Opt=\"http://choice-optional\"><soapenv:Body><Opt:OptionalChoiceRequest><Opt:SPName>PrimaryName</Opt:SPName></Opt:OptionalChoiceRequest></soapenv:Body></soapenv:Envelope>")
         )
 
@@ -194,7 +196,7 @@ class WSDLParserMockBlackBoxTest {
         val request = HttpRequest(
             method = "POST",
             path = "/choice-scalar-repeating",
-            headers = mapOf("SOAPAction" to "\"/choice-scalar-repeating/repeatingScalarChoice\""),
+            headers = mapOf("SOAPAction" to "\"/choice-scalar-repeating/repeatingScalarChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Repeatingscalar=\"http://choice-scalar-repeating\"><soapenv:Body><Repeatingscalar:RepeatingScalarChoiceRequest><PrimaryName>PrimaryName</PrimaryName><CustomerNumber>C-123</CustomerNumber><LoginId>login-123</LoginId></Repeatingscalar:RepeatingScalarChoiceRequest></soapenv:Body></soapenv:Envelope>")
         )
 
@@ -212,7 +214,7 @@ class WSDLParserMockBlackBoxTest {
         val request = HttpRequest(
             method = "POST",
             path = "/choice-complex-repeating",
-            headers = mapOf("SOAPAction" to "\"/choice-complex-repeating/repeatingComplexChoice\""),
+            headers = mapOf("SOAPAction" to "\"/choice-complex-repeating/repeatingComplexChoice\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Repeatingcomplex=\"http://choice-complex-repeating\"><soapenv:Body><Repeatingcomplex:RepeatingComplexChoiceRequest><PrimaryName>PrimaryName</PrimaryName><Repeatingcomplex:CustomerByPermId><PermId>CP-123</PermId></Repeatingcomplex:CustomerByPermId><Repeatingcomplex:CustomerByLogin><Domain>Retail</Domain><LoginId>login-123</LoginId></Repeatingcomplex:CustomerByLogin></Repeatingcomplex:RepeatingComplexChoiceRequest></soapenv:Body></soapenv:Envelope>")
         )
 
@@ -230,7 +232,7 @@ class WSDLParserMockBlackBoxTest {
         val request = HttpRequest(
             method = "POST",
             path = "/choice-scalar-repeating-unbounded",
-            headers = mapOf("SOAPAction" to "\"/choice-scalar-repeating-unbounded/repeatingScalarChoiceUnbounded\""),
+            headers = mapOf("SOAPAction" to "\"/choice-scalar-repeating-unbounded/repeatingScalarChoiceUnbounded\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = StringValue("<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:Repeatingscalar=\"http://choice-scalar-repeating-unbounded\"><soapenv:Body><Repeatingscalar:RepeatingScalarChoiceUnboundedRequest><PrimaryName>PrimaryName</PrimaryName><CustomerNumber>C-123</CustomerNumber><LoginId>login-123</LoginId><CustomerNumber>C-456</CustomerNumber></Repeatingscalar:RepeatingScalarChoiceUnboundedRequest></soapenv:Body></soapenv:Envelope>")
         )
 
@@ -275,12 +277,62 @@ class WSDLParserMockBlackBoxTest {
     }
 
     @Test
+    fun `mock for soap version_1_2 wsdl returns the example soap response with appropriate content-type header`() {
+        val wsdlSpecPath = "src/test/resources/wsdl/cdata_test_soap12/data_api.wsdl"
+        val wsdlExamplesPath = "src/test/resources/wsdl/cdata_test_soap12/data_api_examples"
+        val fixture = loadWsdlExampleFixture(wsdlSpecPath, wsdlExamplesPath)
+        val response = HttpStub(fixture.feature, fixture.scenarioStubs).use { stub ->
+            stub.client.execute(fixture.scenarioStub.request)
+        }
+
+        assertThat(fixture.scenarioStub.request.headers[CONTENT_TYPE]).startsWith("application/soap+xml")
+        assertThat(response.status).isEqualTo(fixture.scenarioStub.response.status)
+        assertThat(response.headers["Content-Type"]).isEqualTo("application/soap+xml")
+        assertThat(response.body).isEqualTo(fixture.scenarioStub.response.body)
+    }
+
+    @Test
+    fun `mock for soap version_1_2 wsdl generates response with appropriate content-type header`() {
+        val wsdlSpecPath = "src/test/resources/wsdl/cdata_test_soap12/data_api.wsdl"
+        val wsdlExamplesPath = "src/test/resources/wsdl/cdata_test_soap12/data_api_examples"
+        val fixture = loadWsdlExampleFixture(wsdlSpecPath, wsdlExamplesPath)
+        val response = HttpStub(fixture.feature, emptyList()).use { stub ->
+            stub.client.execute(fixture.scenarioStub.request)
+        }
+
+        assertThat(response.status).isEqualTo(fixture.scenarioStub.response.status)
+        assertThat(response.headers["Content-Type"]).isEqualTo("application/soap+xml")
+    }
+
+    @Test
+    fun `mock for wsdl should rejects request with wrong content-type`() {
+        val wsdlSpecPath = "src/test/resources/wsdl/cdata_test_soap12/data_api.wsdl"
+        val wsdlExamplesPath = "src/test/resources/wsdl/cdata_test_soap12/data_api_examples"
+        val fixture = loadWsdlExampleFixture(wsdlSpecPath, wsdlExamplesPath)
+        val invalidRequest = fixture.scenarioStub.request.copy(headers = fixture.scenarioStub.request.headers + (CONTENT_TYPE to ContentType.Text.Xml.toString()))
+        val response = HttpStub(fixture.feature, fixture.scenarioStubs).use { stub ->
+            stub.client.execute(invalidRequest)
+        }
+
+        assertThat(response.status).isEqualTo(400)
+    }
+
+    @Test
+    fun `mock for wsdl with empty http body should not enforce content-type to be present`() {
+        val wsdlSpecPath = "src/test/resources/wsdl/state_machine/no_input.wsdl"
+        val feature = parseContractFileToFeature(File(wsdlSpecPath))
+        val request = feature.scenarios.single().generateHttpRequest()
+        val response = HttpStub(feature).use { stub -> stub.client.execute(request) }
+        assertThat(response.status).isEqualTo(200)
+    }
+
+    @Test
     fun `mock for empty message part wsdl returns an empty soap response`() {
         val feature = parseContractFileToFeature(File("src/test/resources/wsdl/state_machine/empty_part.wsdl"))
         val request = HttpRequest(
             method = "POST",
             path = "/empty-part",
-            headers = mapOf("SOAPAction" to "\"/empty-part/ping\""),
+            headers = mapOf("SOAPAction" to "\"/empty-part/ping\"", CONTENT_TYPE to ContentType.Text.Xml.toString()),
             body = emptySoapMessage(),
         )
 

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfoTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfoTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.wsdl.parser.operation
 
+import io.specmatic.core.wsdl.SOAPVersion
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import io.specmatic.core.wsdl.parser.SOAPMessageType
@@ -10,13 +11,19 @@ import io.specmatic.core.wsdl.payload.RequestHeaders
 internal class SOAPOperationTypeInfoTest {
     @Test
     fun `generates a gherkin scenario given operation info`() {
-        val info = SOAPOperationTypeInfo("customer", SOAPRequest(
-            "/get",
-            "getDetails",
-            "/getDetails",
-            RequestHeaders(),
-            EmptySOAPPayload(SOAPMessageType.Input),
-        ), SOAPResponse(EmptySOAPPayload(SOAPMessageType.Output)), SOAPTypes(emptyMap()))
+        val info = SOAPOperationTypeInfo(
+            operationName = "customer",
+            soapVersion = SOAPVersion.SOAP11,
+            request = SOAPRequest(
+                "/get",
+                "getDetails",
+                "/getDetails",
+                RequestHeaders(),
+                EmptySOAPPayload(SOAPMessageType.Input),
+            ),
+            response = SOAPResponse(EmptySOAPPayload(SOAPMessageType.Output)),
+            types = SOAPTypes(emptyMap())
+        )
         val expectedSOAPPayload = """
             Scenario: customer
               When POST /get

--- a/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/SpecmaticJunitSupportTest.kt
@@ -773,6 +773,8 @@ paths:
                 method = "POST",
                 responseStatus = 200,
                 soapAction = "getInventory",
+                requestContentType = "text/xml",
+                responseContentType = "text/xml",
                 specification = specFile.canonicalPath,
                 protocol = SpecmaticProtocol.SOAP,
                 specType = SpecType.WSDL
@@ -782,6 +784,8 @@ paths:
                 method = "POST",
                 responseStatus = 200,
                 soapAction = "addInventory",
+                requestContentType = "text/xml",
+                responseContentType = "text/xml",
                 specification = specFile.canonicalPath,
                 protocol = SpecmaticProtocol.SOAP,
                 specType = SpecType.WSDL


### PR DESCRIPTION
**What:**
Add SOAP version detection from WSDL binding (SOAP 1.1 vs SOAP 1.2) and set correct Content-Type headers in request/response patterns for generated scenarios

**How:**
SOAP 1.1 -> `text/xml`
SOAP 1.2 -> `application/soap+xml`
Unknown SOAP namespace -> default `application/soap+xml`
Also skip Content-Type enforcement when payload is empty HTTP body

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)