### PR TITLE
Skip asyncapi files during OpenAPI bcc

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -28,9 +28,14 @@ class BackwardCompatibilityCheckCommandV2 : BackwardCompatibilityCheckBaseComman
         return testBackwardCompatibility(oldFeature as Feature, newFeature as Feature)
     }
 
+    companion object {
+        private val jsonMapper = ObjectMapper()
+        private val yamlMapper = ObjectMapper(YAMLFactory())
+    }
+
     private fun isYAML(string: String): Boolean {
         return try {
-            ObjectMapper(YAMLFactory()).readValue(string, Map::class.java)
+            yamlMapper.readValue(string, Map::class.java)
             true
         } catch (e: Throwable) {
             false
@@ -39,8 +44,17 @@ class BackwardCompatibilityCheckCommandV2 : BackwardCompatibilityCheckBaseComman
 
     private fun isJSON(string: String): Boolean {
         return try {
-            ObjectMapper().readValue(string, Map::class.java)
+            jsonMapper.readValue(string, Map::class.java)
             true
+        } catch (e: Throwable) {
+            false
+        }
+    }
+
+    private fun isAsyncAPI(string: String): Boolean {
+        return try {
+            val map = yamlMapper.readValue(string, Map::class.java)
+            map.containsKey("asyncapi")
         } catch (e: Throwable) {
             false
         }
@@ -50,6 +64,12 @@ class BackwardCompatibilityCheckCommandV2 : BackwardCompatibilityCheckBaseComman
         if (this.extension !in CONTRACT_EXTENSIONS) return false
 
         val content = this.readText()
+
+        // The current design conflates the collection of changes to specs and examples.
+        // This means that we must filter out asyncapi files with a negative check when loading up all files.
+        if (isAsyncAPI(content)) {
+            return false
+        }
 
         return when (this.extension.lowercase()) {
             "yaml", "yml" -> isYAML(content)

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -9,13 +9,14 @@ import io.mockk.spyk
 import io.specmatic.core.IFeature
 import io.specmatic.core.Results
 import io.specmatic.core.git.SystemGit
-import io.specmatic.core.utilities.SystemExit
-import io.specmatic.core.utilities.SystemExitException
 import io.specmatic.reporter.backwardcompat.dto.OperationUsageResponse
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -459,6 +460,38 @@ class BackwardCompatibilityCheckCommandV2Test {
             val exampleDir = BackwardCompatibilityCheckCommandV2().getParentExamplesDirectory(Paths.get(exampleFile))
             assertThat(exampleDir).isEqualTo(expectedDir?.let(Paths::get))
         }
+    }
+
+    @Test
+    fun `should skip asyncapi spec files`() {
+        val asyncApiFile = File("src/test/resources/specifications/asyncapi.yaml").canonicalFile
+        val gitAsyncApiFile = tempDir.resolve("asyncapi.yaml").canonicalFile
+        asyncApiFile.copyTo(gitAsyncApiFile)
+
+        val apiFile = File("src/test/resources/specifications/spec_with_examples/api.yaml").canonicalFile
+        val gitApiFile = tempDir.resolve("api.yaml").canonicalFile
+        apiFile.copyTo(gitApiFile)
+
+        commitAndPush(tempDir, "Initial commit")
+        gitAsyncApiFile.writeText(gitAsyncApiFile.readText().replace("address: ping", "address: ping-v2"))
+        gitApiFile.writeText(gitApiFile.readText().replace("endpoint", "modified endpoint"))
+
+        val (stdOut, exitCode) = captureStandardOutput {
+            BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+        }
+
+        assertThat(exitCode).isEqualTo(0)
+
+        assertThat(stdOut).containsIgnoringWhitespaces(
+            """
+            - Specs that have changed: 
+            1. $gitApiFile
+            """.trimIndent()
+        ).containsIgnoringWhitespaces(
+            """
+            Files checked: 1 (Passed: 1, Failed: 0)
+            """.trimIndent()
+        )
     }
 
     @AfterEach

--- a/application/src/test/resources/specifications/asyncapi.yaml
+++ b/application/src/test/resources/specifications/asyncapi.yaml
@@ -1,0 +1,55 @@
+asyncapi: 3.0.0
+info:
+  version: "0.0.1"
+  title: "ping pong mania"
+
+channels:
+  ping:
+    address: ping
+    messages:
+      ping:
+        $ref: '#/components/messages/ping'
+  ping_v2:
+    address: ping
+    messages:
+      ping:
+        $ref: '#/components/messages/ping'
+  pong:
+    address: pong
+    messages:
+      pong:
+        $ref: "#/components/messages/pong"
+
+operations:
+  pingRequest:
+    description: receive a ping and send a pong
+    action: receive
+    channel:
+      $ref: '#/channels/ping_v2'
+    messages:
+      - $ref: '#/channels/ping_v2/messages/ping'
+    reply:
+      channel:
+        $ref: '#/channels/pong'
+      messages:
+        - $ref: '#/channels/pong/messages/pong'
+
+components:
+  messages:
+    ping:
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          event:
+            type: string
+            const: ping
+
+    pong:
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          event:
+            type: string
+            const: pong

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -227,10 +227,14 @@ class OpenApiSpecification(
         }
 
         fun getParsedOpenApi(openApiFilePath: String): OpenAPI {
+            // TODO: This is ignoring parse errors for example it declares asyncapi files as valid and parseable
+            // To fix it must check that the returned result has no messages
             return OpenAPIV3Parser().read(openApiFilePath, null, resolveExternalReferences())
         }
 
         fun isParsable(openApiFilePath: String): Boolean {
+            // TODO: This is ignoring parse errors for example it declares asyncapi files as valid and parseable
+            // To fix it must check that the returned result has no messages
             return OpenAPIV3Parser().read(openApiFilePath, null, resolveExternalReferences()) != null
         }
 


### PR DESCRIPTION
The current design conflates the collection of changes to specs and examples. This means that we must filter out asyncapi files with a negative check when loading up all files.