### PR TITLE
If a conformance test failure is expected make sure that there's a reason attached with it.

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -2,7 +2,9 @@ name: Conformance Tests
 
 on:
   push:
-    branches: [ "main", "disable-expected-failures-conformance" ]
+    branches:
+      - "main"
+      - "sahilm/conformance-tests**"
 
 jobs:
   conformance-tests:

--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -233,8 +233,9 @@ class OpenApiSpec(private val specFile: File) {
     private fun String.escapeJsonPointer(): String = replace("~", "~0").replace("/", "~1")
 
     fun findExtensionByKey(key: String): String? {
-        val extension = openApi.extensions?.get(key) ?: return null
-        return extension.toString()
+        val extensions = openApi.extensions ?: return null
+        if (!extensions.containsKey(key)) return null
+        return extensions[key]?.toString().orEmpty()
     }
 
     companion object {

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -22,7 +22,7 @@ abstract class AbstractConformanceTest(
     private lateinit var allLogs: String
     private lateinit var httpExchanges: List<HttpExchange>
 
-    internal val spec: OpenApiSpec =
+    private val spec: OpenApiSpec =
         OpenApiSpec(File("${workDir.absolutePath}/${specsDirName}/$openAPISpecFile"))
 
     @RegisterExtension

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -7,12 +7,11 @@ import io.specmatic.conformance_test_support.OpenApiSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.File
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(OrderAnnotation::class)
-@ExtendWith(ExpectedFailureExtension::class)
 abstract class AbstractConformanceTest(
     private val openAPISpecFile: String,
     private val workDir: File = File("build/resources/test"),
@@ -26,6 +25,8 @@ abstract class AbstractConformanceTest(
     internal val spec: OpenApiSpec =
         OpenApiSpec(File("${workDir.absolutePath}/${specsDirName}/$openAPISpecFile"))
 
+    @RegisterExtension
+    val expectedFailureExtension = ExpectedFailureExtension { tag -> spec.findExtensionByKey(tag) }
 
     @BeforeAll
     fun setup() {

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/ExpectedFailureExtension.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/ExpectedFailureExtension.kt
@@ -31,6 +31,12 @@ class ExpectedFailureExtension(private val findFailureReason: (String) -> String
             return
         }
 
+        if (failureReason.isBlank()) {
+            throw AssertionFailedError(
+                "Spec declares `${annotation.tag}` but has no failure reason. Add a reason to the spec file, e.g. `${annotation.tag}: \"short explanation\"`."
+            )
+        }
+
         try {
             invocation.proceed()
         } catch (e: Throwable) {

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/ExpectedFailureExtension.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/ExpectedFailureExtension.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext
 import org.opentest4j.AssertionFailedError
 import java.lang.reflect.Method
 
-class ExpectedFailureExtension : InvocationInterceptor {
+class ExpectedFailureExtension(private val findFailureReason: (String) -> String?) : InvocationInterceptor {
 
     override fun interceptTestMethod(
         invocation: InvocationInterceptor.Invocation<Void>,
@@ -24,8 +24,7 @@ class ExpectedFailureExtension : InvocationInterceptor {
             return
         }
 
-        val spec = (extensionContext.requiredTestInstance as AbstractConformanceTest).spec
-        val failureReason = spec.findExtensionByKey(annotation.tag)
+        val failureReason = findFailureReason(annotation.tag)
 
         if (failureReason == null) {
             invocation.proceed()


### PR DESCRIPTION
If a conformance test failure is expected make sure that there's a reason attached with it. A missing reason is equivalent to a test failure.