### PR TITLE
Fix HTTPFilterKeys not working as expected with negative scenarios

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
+++ b/core/src/main/kotlin/io/specmatic/core/BadRequestOrDefault.kt
@@ -16,6 +16,18 @@ class BadRequestOrDefault(val badRequestResponses: Map<Int, List<Scenario>> = em
         return scenario.withDetailsFrom(matchingScenario)
     }
 
+    fun supportsStatus(status: String): Boolean {
+        val statusInt = status.toIntOrNull() ?: return false
+        return badRequestResponses.containsKey(statusInt) || defaultResponses.isNotEmpty()
+    }
+
+    fun supportsResponseContentType(contentType: String): Boolean {
+        return badRequestResponses.values.asSequence().flatten().plus(defaultResponses).any { scenario ->
+            val responseToMatch = HttpResponse(status = scenario.status, headers = mapOf(CONTENT_TYPE to contentType))
+            scenario.matchesContentType(responseToMatch)
+        }
+    }
+
     private fun findBestMatchingScenario(httpResponse: HttpResponse): BestEffortMatch? {
         val sameStatus = badRequestResponses[httpResponse.status].orEmpty()
         val otherStatuses = badRequestResponses.filterKeys { it != httpResponse.status }.values.flatten()

--- a/core/src/main/kotlin/io/specmatic/core/filters/HTTPFilterKeys.kt
+++ b/core/src/main/kotlin/io/specmatic/core/filters/HTTPFilterKeys.kt
@@ -19,6 +19,10 @@ enum class HTTPFilterKeys(val key: String, val isPrefix: Boolean) {
     },
     STATUS("STATUS", false) {
         override fun includes(scenario: Scenario, key: String, value: String): Boolean {
+            if (scenario.isNegative && scenario.badRequestOrDefault != null) {
+                return scenario.badRequestOrDefault.supportsStatus(value)
+            }
+
             return scenario.status == value.toIntOrNull()
         }
     },
@@ -84,6 +88,10 @@ enum class HTTPFilterKeys(val key: String, val isPrefix: Boolean) {
     RESPONSE_CONTENT_TYPE("RESPONSE.CONTENT-TYPE", false) {
         override fun includes(scenario: Scenario, key: String, value: String): Boolean {
             if (value.isBlank()) return false
+            if (scenario.isNegative && scenario.badRequestOrDefault != null) {
+                return scenario.badRequestOrDefault.supportsResponseContentType(value)
+            }
+
             val contentType = scenario.httpResponsePattern.headersPattern.contentType ?: return false
             return try {
                 ContentType.parse(contentType).match(value)

--- a/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/BadRequestOrDefaultTest.kt
@@ -8,6 +8,52 @@ import org.junit.jupiter.api.Test
 
 class BadRequestOrDefaultTest {
     @Nested
+    inner class SupportsStatus {
+        @Test
+        fun `should return true when bad request status exists`() {
+            val badRequestOrDefault = BadRequestOrDefault(badRequestResponses = mapOf(400 to listOf(scenario(status = 400, contentType = "application/json"))))
+            assertThat(badRequestOrDefault.supportsStatus("400")).isTrue()
+        }
+
+        @Test
+        fun `should return false for non numeric status when default response exists`() {
+            val badRequestOrDefault = BadRequestOrDefault(defaultResponses = listOf(scenario(status = DEFAULT_RESPONSE_CODE, contentType = "application/json")))
+            assertThat(badRequestOrDefault.supportsStatus("invalid")).isFalse()
+        }
+
+        @Test
+        fun `should return false when status absent and no default response exists`() {
+            val badRequestOrDefault = BadRequestOrDefault(badRequestResponses = mapOf(401 to listOf(scenario(status = 401, contentType = "application/json"))))
+            assertThat(badRequestOrDefault.supportsStatus("400")).isFalse()
+        }
+    }
+
+    @Nested
+    inner class SupportsResponseContentType {
+        @Test
+        fun `should return true when bad request response content type exists`() {
+            val badRequestOrDefault = BadRequestOrDefault(badRequestResponses = mapOf(400 to listOf(scenario(status = 400, contentType = "application/json"))))
+            assertThat(badRequestOrDefault.supportsResponseContentType("application/json")).isTrue()
+        }
+
+        @Test
+        fun `should return true when default response content type exists`() {
+            val badRequestOrDefault = BadRequestOrDefault(defaultResponses = listOf(scenario(status = DEFAULT_RESPONSE_CODE, contentType = "application/problem+json")))
+            assertThat(badRequestOrDefault.supportsResponseContentType("application/problem+json")).isTrue()
+        }
+
+        @Test
+        fun `should return false when response content type absent across bad request and default responses`() {
+            val badRequestOrDefault = BadRequestOrDefault(
+                badRequestResponses = mapOf(400 to listOf(scenario(status = 400, contentType = "application/xml"))),
+                defaultResponses = listOf(scenario(status = DEFAULT_RESPONSE_CODE, contentType = "text/plain"))
+            )
+
+            assertThat(badRequestOrDefault.supportsResponseContentType("application/json")).isFalse()
+        }
+    }
+
+    @Nested
     inner class Matches {
         @Test
         fun `should fail when no matching or fallback response exists`() {

--- a/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/filters/HTTPFilterKeysTest.kt
@@ -5,11 +5,8 @@ import io.specmatic.core.HttpRequestPattern
 import io.specmatic.core.HttpResponsePattern
 import io.specmatic.core.Scenario
 import io.specmatic.core.ScenarioInfo
-import io.specmatic.core.HttpRequest
-import io.specmatic.core.HttpResponse
+import io.specmatic.core.BadRequestOrDefault
 import io.specmatic.core.HttpHeadersPattern
-import io.specmatic.core.value.JSONObjectValue
-import io.specmatic.mock.ScenarioStub
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
@@ -332,6 +329,26 @@ class HTTPFilterKeysTest {
         assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(scenario, "RESPONSE.CONTENT-TYPE", "application/json")).isFalse()
     }
 
+    @Test
+    fun `STATUS includes should match negative scenario using bad request fallback statuses`() {
+        val scenario = negativeScenarioWithBadRequestOrDefault(
+            scenarioStatus = 202,
+            badRequestStatuses = mapOf(400 to listOf(scenarioWithStatusAndResponseContentType(status = 400, responseContentType = "application/json")))
+        )
+
+        assertThat(HTTPFilterKeys.STATUS.includes(scenario, "STATUS", "400")).isTrue()
+    }
+
+    @Test
+    fun `RESPONSE_CONTENT_TYPE includes should match negative scenario using bad request fallback content type`() {
+        val scenario = negativeScenarioWithBadRequestOrDefault(
+            scenarioStatus = 202,
+            badRequestStatuses = mapOf(400 to listOf(scenarioWithStatusAndResponseContentType(status = 400, responseContentType = "application/json")))
+        )
+
+        assertThat(HTTPFilterKeys.RESPONSE_CONTENT_TYPE.includes(scenario, "RESPONSE.CONTENT-TYPE", "application/json")).isTrue()
+    }
+
     @ParameterizedTest(name = "blank response filter value should not match scenario response content type: \"{0}\"")
     @CsvSource(
         "'',false",
@@ -396,6 +413,25 @@ class HTTPFilterKeysTest {
                     httpRequestPattern = HttpRequestPattern(method = "POST", httpPathPattern = HttpPathPattern.from("/orders"), headersPattern = HttpHeadersPattern(contentType = requestContentType)),
                     httpResponsePattern = HttpResponsePattern(status = 200, headersPattern = HttpHeadersPattern(contentType = responseContentType)),
                 )
+            )
+        }
+
+        private fun scenarioWithStatusAndResponseContentType(status: Int, responseContentType: String?): Scenario {
+            return Scenario(
+                ScenarioInfo(
+                    specType = SpecType.OPENAPI,
+                    scenarioName = "POST /orders",
+                    protocol = SpecmaticProtocol.HTTP,
+                    httpRequestPattern = HttpRequestPattern(method = "POST", httpPathPattern = HttpPathPattern.from("/orders")),
+                    httpResponsePattern = HttpResponsePattern(status = status, headersPattern = HttpHeadersPattern(contentType = responseContentType)),
+                )
+            )
+        }
+
+        private fun negativeScenarioWithBadRequestOrDefault(scenarioStatus: Int, scenarioResponseContentType: String? = null, badRequestStatuses: Map<Int, List<Scenario>>): Scenario {
+            return scenarioWithStatusAndResponseContentType(status = scenarioStatus, responseContentType = scenarioResponseContentType).copy(
+                isNegative = true,
+                badRequestOrDefault = BadRequestOrDefault(badRequestResponses = badRequestStatuses)
             )
         }
     }


### PR DESCRIPTION
**What**: Fix the issue with HTTPFilterKeys not functioning correctly for negative scenarios

**Why**:
- In negative scenarios, the status and resContentType will default to 400 or be inherited from the original scenario
- But both the status and resContentType in negative scenarios can be queried from the BadRequestOrDefault set
- As BadRequestOrDefault set contains all the possible statuses and their contentTypes

**How**: 
- Compare `STATUS` and `RESPONSE.CONTENT-TYPE` with the BadRequestOrDefault list of scenarios

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)