### PR TITLE
Skip status in failure reports if status == 0

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
@@ -90,8 +90,8 @@ data class FailureReport(val contractPath: String?, private val scenarioMessage:
     private fun scenarioDetails(scenario: ScenarioDetailsForResult?): String? {
         return scenario?.let {
             val scenarioLine = """${scenarioMessage ?: "In scenario"} "${scenario.name}""""
-            val urlLine =
-                "API: ${scenario.method} ${scenario.path} -> ${scenario.status}"
+            val urlLine = "API: ${scenario.method} ${scenario.path}" +
+                    if (scenario.status != 0) " -> ${scenario.status}" else ""
 
             "$scenarioLine${System.lineSeparator()}$urlLine"
         }

--- a/core/src/test/kotlin/io/specmatic/core/FailureReportTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FailureReportTest.kt
@@ -5,6 +5,56 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class FailureReportTest {
+
+    private class FakeScenario(override val status: Int) : ScenarioDetailsForResult {
+        override val ignoreFailure: Boolean = false
+        override val name: String = "fake scenario"
+        override val method: String = "GET"
+        override val path: String = "/fake"
+
+        override fun testDescription(): String = name
+    }
+
+    @Test
+    fun `should skip status if status == 0 (not provided or uninitialized)`() {
+        val matchFailureDetailList = listOf(
+            MatchFailureDetails(errorMessages = listOf("error message")),
+        )
+        val failureReport = FailureReport(
+            contractPath = null,
+            scenarioMessage = null,
+            scenario = FakeScenario(status = 0),
+            matchFailureDetailList = matchFailureDetailList
+        )
+        assertThat(failureReport.toText()).isEqualToIgnoringWhitespace(
+            """
+             In scenario "fake scenario"
+             API: GET /fake
+             error message
+        """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `should add status if status != 0`() {
+        val matchFailureDetailList = listOf(
+            MatchFailureDetails(errorMessages = listOf("error message")),
+        )
+        val failureReport = FailureReport(
+            contractPath = null,
+            scenarioMessage = null,
+            scenario = FakeScenario(status = 200),
+            matchFailureDetailList = matchFailureDetailList
+        )
+        assertThat(failureReport.toText()).isEqualToIgnoringWhitespace(
+            """
+             In scenario "fake scenario"
+             API: GET /fake -> 200
+             error message
+        """.trimIndent()
+        )
+    }
+
     @Test
     fun `breadcrumbs should be flush left and descriptions indented`() {
         val personIdDetails = MatchFailureDetails(listOf("person", "id"), listOf("error"))


### PR DESCRIPTION
If the status field is not initialized or unset we want to skip it. This is because we now have ScenarioDetails for AsyncAPI specs where status codes aren't a meaningful concept.