### PR TITLE
Pin swagger-parser version to 2.1.35 to resolve external discriminator ref regression

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     implementation("io.specmatic.build-reporter:specmatic-reporter-min:${project.property("specmaticReporterVersion")}") {
         exclude(group = "commons-logging", module = "commons-logging")
+        exclude(group = "io.swagger.parser.v3", module = "swagger-parser")
     }
 
     implementation("joda-time:joda-time:2.14.1")
@@ -39,7 +40,7 @@ dependencies {
     implementation(project(":specmatic-mcp"))
 
     implementation("io.ktor:ktor-client-cio-jvm:2.3.13")
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.40")
+    implementation("io.swagger.parser.v3:swagger-parser:${project.property("swaggerParserVersion")}")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.10.0")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect:2.3.20")

--- a/conformance-tests/build.gradle.kts
+++ b/conformance-tests/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     implementation("org.junit.platform:junit-platform-launcher:1.14.3")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.21.2")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.2")
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.40")
+    implementation("io.swagger.parser.v3:swagger-parser:${project.property("swaggerParserVersion")}")
     implementation("com.networknt:json-schema-validator:2.0.1")
 
     runtimeOnly("ch.qos.logback:logback-classic:1.5.32")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
 
     implementation("io.specmatic.build-reporter:specmatic-reporter-min:${project.property("specmaticReporterVersion")}") {
         exclude(group = "commons-logging", module = "commons-logging")
+        exclude(group = "io.swagger.parser.v3", module = "swagger-parser")
     }
     implementation("joda-time:joda-time:2.14.1")
     implementation("net.minidev:json-smart:2.6.0")
@@ -40,7 +41,7 @@ dependencies {
 
     implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
 
-    implementation("io.swagger.parser.v3:swagger-parser:2.1.40")
+    implementation("io.swagger.parser.v3:swagger-parser:${project.property("swaggerParserVersion")}")
 
     implementation("dk.brics:automaton:1.12-4")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -16,8 +16,6 @@ import io.specmatic.core.pattern.resolvedHop
 import io.specmatic.core.utilities.yamlMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.CleanupMode
-import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -432,83 +430,10 @@ class OpenApiSpecificationParseTest {
     }
 
     @Test
-    fun `should load discriminator mappings that point to external schema files with nested refs`(@TempDir(cleanup = CleanupMode.ALWAYS) tempDir: File) {
-        tempDir.resolve("openapi.yaml").writeText(
-            $$"""
-            openapi: 3.0.3
-            info:
-              title: Discriminator external ref repro
-              version: 1.0.0
-            paths:
-              /animals:
-                post:
-                  requestBody:
-                    required: true
-                    content:
-                      application/json:
-                        schema:
-                          $ref: ./components/requestBodies/Payload.yaml
-                  responses:
-                    '200':
-                      description: OK
-            """.trimIndent()
-        )
+    fun `should guard against the swagger-parser regression for discriminator mappings to external schema files with nested refs`() {
+        val specFile = File("src/test/resources/openapi/discriminator_external_file_refs/openapi.yaml")
 
-        tempDir.resolve("components/requestBodies").mkdirs()
-        tempDir.resolve("components/requestBodies/Payload.yaml").writeText(
-            $$"""
-            type: object
-            required:
-              - animals
-            properties:
-              animals:
-                type: array
-                items:
-                  oneOf:
-                    - $ref: ../schemas/policy/Cat.yaml
-                    - $ref: ../schemas/policy/Dog.yaml
-                  discriminator:
-                    propertyName: type
-                    mapping:
-                      CAT: ../schemas/policy/Cat.yaml
-                      DOG: ../schemas/policy/Dog.yaml
-            """.trimIndent()
-        )
-
-        tempDir.resolve("components/schemas/policy").mkdirs()
-        tempDir.resolve("components/schemas/policy/Cat.yaml").writeText(
-            $$"""
-            type: object
-            required:
-              - type
-              - name
-            properties:
-              type:
-                type: string
-              name:
-                $ref: ./AnimalName.yaml
-            """.trimIndent()
-        )
-        tempDir.resolve("components/schemas/policy/Dog.yaml").writeText(
-            $$"""
-            type: object
-            required:
-              - type
-              - name
-            properties:
-              type:
-                type: string
-              name:
-                $ref: ./AnimalName.yaml
-            """.trimIndent()
-        )
-        tempDir.resolve("components/schemas/policy/AnimalName.yaml").writeText(
-            """
-            type: string
-            """.trimIndent()
-        )
-
-        val feature = OpenApiSpecification.fromFile(tempDir.resolve("openapi.yaml").canonicalPath).toFeature()
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
 
         assertThat(feature.scenarios).hasSize(1)
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -16,6 +16,8 @@ import io.specmatic.core.pattern.resolvedHop
 import io.specmatic.core.utilities.yamlMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.CleanupMode
+import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -427,6 +429,88 @@ class OpenApiSpecificationParseTest {
         assertThat(paramPattern).isInstanceOf(QueryParameterScalarPattern::class.java); paramPattern  as QueryParameterScalarPattern
         assertThat(paramPattern.pattern).isInstanceOf(NumberPattern::class.java)
         case.check(queryParameters.additionalProperties)
+    }
+
+    @Test
+    fun `should load discriminator mappings that point to external schema files with nested refs`(@TempDir(cleanup = CleanupMode.ALWAYS) tempDir: File) {
+        tempDir.resolve("openapi.yaml").writeText(
+            $$"""
+            openapi: 3.0.3
+            info:
+              title: Discriminator external ref repro
+              version: 1.0.0
+            paths:
+              /animals:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          $ref: ./components/requestBodies/Payload.yaml
+                  responses:
+                    '200':
+                      description: OK
+            """.trimIndent()
+        )
+
+        tempDir.resolve("components/requestBodies").mkdirs()
+        tempDir.resolve("components/requestBodies/Payload.yaml").writeText(
+            $$"""
+            type: object
+            required:
+              - animals
+            properties:
+              animals:
+                type: array
+                items:
+                  oneOf:
+                    - $ref: ../schemas/policy/Cat.yaml
+                    - $ref: ../schemas/policy/Dog.yaml
+                  discriminator:
+                    propertyName: type
+                    mapping:
+                      CAT: ../schemas/policy/Cat.yaml
+                      DOG: ../schemas/policy/Dog.yaml
+            """.trimIndent()
+        )
+
+        tempDir.resolve("components/schemas/policy").mkdirs()
+        tempDir.resolve("components/schemas/policy/Cat.yaml").writeText(
+            $$"""
+            type: object
+            required:
+              - type
+              - name
+            properties:
+              type:
+                type: string
+              name:
+                $ref: ./AnimalName.yaml
+            """.trimIndent()
+        )
+        tempDir.resolve("components/schemas/policy/Dog.yaml").writeText(
+            $$"""
+            type: object
+            required:
+              - type
+              - name
+            properties:
+              type:
+                type: string
+              name:
+                $ref: ./AnimalName.yaml
+            """.trimIndent()
+        )
+        tempDir.resolve("components/schemas/policy/AnimalName.yaml").writeText(
+            """
+            type: string
+            """.trimIndent()
+        )
+
+        val feature = OpenApiSpecification.fromFile(tempDir.resolve("openapi.yaml").canonicalPath).toFeature()
+
+        assertThat(feature.scenarios).hasSize(1)
     }
 
     companion object {

--- a/core/src/test/resources/openapi/discriminator_external_file_refs/components/requestBodies/Payload.yaml
+++ b/core/src/test/resources/openapi/discriminator_external_file_refs/components/requestBodies/Payload.yaml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - animals
+properties:
+  animals:
+    type: array
+    items:
+      oneOf:
+        - $ref: ../schemas/policy/Cat.yaml
+        - $ref: ../schemas/policy/Dog.yaml
+      discriminator:
+        propertyName: type
+        mapping:
+          CAT: ../schemas/policy/Cat.yaml
+          DOG: ../schemas/policy/Dog.yaml

--- a/core/src/test/resources/openapi/discriminator_external_file_refs/components/schemas/policy/AnimalName.yaml
+++ b/core/src/test/resources/openapi/discriminator_external_file_refs/components/schemas/policy/AnimalName.yaml
@@ -1,0 +1,1 @@
+type: string

--- a/core/src/test/resources/openapi/discriminator_external_file_refs/components/schemas/policy/Cat.yaml
+++ b/core/src/test/resources/openapi/discriminator_external_file_refs/components/schemas/policy/Cat.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - type
+  - name
+properties:
+  type:
+    type: string
+  name:
+    $ref: ./AnimalName.yaml

--- a/core/src/test/resources/openapi/discriminator_external_file_refs/components/schemas/policy/Dog.yaml
+++ b/core/src/test/resources/openapi/discriminator_external_file_refs/components/schemas/policy/Dog.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - type
+  - name
+properties:
+  type:
+    type: string
+  name:
+    $ref: ./AnimalName.yaml

--- a/core/src/test/resources/openapi/discriminator_external_file_refs/openapi.yaml
+++ b/core/src/test/resources/openapi/discriminator_external_file_refs/openapi.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Discriminator external ref repro
+  version: 1.0.0
+paths:
+  /animals:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ./components/requestBodies/Payload.yaml
+      responses:
+        '200':
+          description: OK

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,6 @@ group=io.specmatic
 version=2.44.1-SNAPSHOT
 specmaticGradlePluginVersion=0.15.6
 specmaticReporterVersion=0.3.14
+swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
## Summary
- Pin `swagger-parser` to `2.1.35` across the core, application, and conformance test modules
- Exclude the transitive parser from `specmatic-reporter-min` so the pinned version is used consistently
- Add a regression test for discriminator mappings that resolve through external schema files with nested refs

## Why
- The newer parser version breaks the external ref/discriminator case covered by the new regression test, where the discriminator mapping values are file paths
- Keeping the older parser restores the expected OpenAPI parsing behavior without changing the spec model

## How
- Centralize the parser version in `gradle.properties`
- Update module dependencies to reference the shared property
- Verify the targeted parse path with an end-to-end file-backed test
