### PR TITLE
Fix Accept header negotiation in mock response selection

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -478,26 +478,8 @@ data class Feature(
     }
 
     private fun filterByBestStatusClass(scenarios: List<Scenario>): List<Scenario> {
-        val bestScenarios = mutableListOf<Scenario>()
-        var bestRank: Int? = null
-
-        for (scenario in scenarios) {
-            val currentRank = statusClassRank(scenario.status)
-
-            when {
-                bestRank == null || currentRank < bestRank -> {
-                    bestRank = currentRank
-                    bestScenarios.clear()
-                    bestScenarios.add(scenario)
-                }
-
-                currentRank == bestRank -> {
-                    bestScenarios.add(scenario)
-                }
-            }
-        }
-
-        return if (bestScenarios.isEmpty()) scenarios else bestScenarios
+        val bestRank = scenarios.minOfOrNull { statusClassRank(it.status) } ?: return scenarios
+        return scenarios.filter { statusClassRank(it.status) == bestRank }
     }
 
     private fun statusClassRank(status: Int): Int {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -374,9 +374,26 @@ data class Feature(
     }
 
     private fun getMatchingAndSortedScenarios(httpRequest: HttpRequest, scenarios: List<Scenario>): List<Scenario> {
-        val statusFilteredScenarios = filterByExpectedResponseStatus(httpRequest.expectedResponseCode(), scenarios)
+        val expectedResponseCode = httpRequest.expectedResponseCode()
+        val statusFilteredScenarios = filterByExpectedResponseStatus(expectedResponseCode, scenarios)
         val pathAndMethodMatchedScenarios = statusFilteredScenarios.filter { scenario -> scenario.matchesPathStructureAndMethod(httpRequest) }
-        return applyAcceptHeaderSort(httpRequest, pathAndMethodMatchedScenarios)
+
+        if (expectedResponseCode != null) {
+            return applyAcceptHeaderSelection(httpRequest, pathAndMethodMatchedScenarios)
+        }
+
+        val acceptHeader = httpRequest.headers.getCaseInsensitive(ACCEPT)?.value?.trim().orEmpty()
+        if (acceptHeader.isBlank()) {
+            return pathAndMethodMatchedScenarios
+        }
+
+        val acceptMediaTypes = acceptMediaTypesFor(acceptHeader) ?: return pathAndMethodMatchedScenarios
+        if (isWildcardOnlyAcceptHeader(acceptMediaTypes)) {
+            return pathAndMethodMatchedScenarios
+        }
+
+        val bestStatusClassScenarios = filterByBestStatusClass(pathAndMethodMatchedScenarios)
+        return applyAcceptHeaderSelection(httpRequest, bestStatusClassScenarios)
     }
 
     private fun filterByExpectedResponseStatus(expectedResponseCode: Int?, scenarios: List<Scenario>): List<Scenario> {
@@ -390,7 +407,7 @@ data class Feature(
         unexpectedKeyCheck: UnexpectedKeyCheck
     ): Map<Int, Pair<ResponseBuilder?, Results>> {
         try {
-            val acceptHeaderSortedScenarios = applyAcceptHeaderSort(httpRequest, scenarios)
+            val acceptHeaderSortedScenarios = getMatchingAndSortedScenarios(httpRequest, scenarios)
             val resultList = matchingScenarioToResultList(httpRequest, serverState, mismatchMessages, unexpectedKeyCheck, acceptHeaderSortedScenarios)
             val matchingScenarios = matchingScenarios(resultList)
 
@@ -440,7 +457,7 @@ data class Feature(
         })
     }
 
-    private fun applyAcceptHeaderSort(httpRequest: HttpRequest, scenarios: List<Scenario>): List<Scenario> {
+    private fun applyAcceptHeaderSelection(httpRequest: HttpRequest, scenarios: List<Scenario>): List<Scenario> {
         val acceptHeader = httpRequest.headers.getCaseInsensitive(ACCEPT)?.value?.trim().orEmpty()
         if (acceptHeader.isBlank()) return scenarios
         if (!isAcceptHeaderParseable(acceptHeader)) {
@@ -449,18 +466,59 @@ data class Feature(
         }
 
         val acceptMediaTypes = acceptMediaTypesFor(acceptHeader) ?: return scenarios
-        val ranked = scenarios.map { scenario ->
-            RankedScenarioResult(
-                scenario = scenario,
-                acceptMatchRank = acceptMatchRank(
-                    acceptMediaTypes = acceptMediaTypes,
-                    responseContentType = resolveResponseContentTypeForAccept(scenario),
-                    unknownContentTypeRank = acceptMediaTypes.size
-                )
-            )
+        if (isWildcardOnlyAcceptHeader(acceptMediaTypes)) {
+            return scenarios
         }
 
-        return ranked.sortedWith(compareBy { it.acceptMatchRank }).map { it.scenario }
+        val (matchingScenarios, remainingScenarios) = scenarios.partition { scenario ->
+            acceptMatchesScenario(acceptMediaTypes, scenario)
+        }
+
+        return if (matchingScenarios.isEmpty()) scenarios else matchingScenarios + remainingScenarios
+    }
+
+    private fun filterByBestStatusClass(scenarios: List<Scenario>): List<Scenario> {
+        val bestScenarios = mutableListOf<Scenario>()
+        var bestRank: Int? = null
+
+        for (scenario in scenarios) {
+            val currentRank = statusClassRank(scenario.status)
+
+            when {
+                bestRank == null || currentRank < bestRank -> {
+                    bestRank = currentRank
+                    bestScenarios.clear()
+                    bestScenarios.add(scenario)
+                }
+
+                currentRank == bestRank -> {
+                    bestScenarios.add(scenario)
+                }
+            }
+        }
+
+        return if (bestScenarios.isEmpty()) scenarios else bestScenarios
+    }
+
+    private fun statusClassRank(status: Int): Int {
+        return when (status / 100) {
+            2 -> 0
+            3 -> 1
+            4 -> 2
+            5 -> 3
+            else -> 4
+        }
+    }
+
+    private fun isWildcardOnlyAcceptHeader(acceptMediaTypes: List<String>): Boolean {
+        return acceptMediaTypes.all { it.contains("*") }
+    }
+
+    private fun acceptMatchesScenario(acceptMediaTypes: List<String>, scenario: Scenario): Boolean {
+        val responseContentType = resolveResponseContentTypeForAccept(scenario) ?: return false
+        return acceptMediaTypes.any { acceptMediaType ->
+            isResponseContentTypeAccepted(acceptMediaType, responseContentType)
+        }
     }
 
     private fun resolveResponseContentTypeForAccept(scenario: Scenario): String? {
@@ -528,7 +586,7 @@ data class Feature(
         httpRequest: HttpRequest,
         scenarios: List<Scenario>
     ): Sequence<Pair<Scenario, Result>> {
-        val scenarioSequence = scenarios.asSequence()
+        val scenarioSequence = getMatchingAndSortedScenarios(httpRequest, scenarios).asSequence()
 
         val localCopyOfServerState = serverState
         return scenarioSequence.zip(scenarioSequence.map {
@@ -743,23 +801,8 @@ data class Feature(
         }
     }
 
-    private data class RankedScenarioResult(
-        val scenario: Scenario,
-        val acceptMatchRank: Int
-    )
-
     private fun acceptMediaTypesFor(acceptHeader: String): List<String>? {
         return acceptMediaTypesByPriority(acceptHeader).takeIf { it.isNotEmpty() }
-    }
-
-    private fun acceptMatchRank(acceptMediaTypes: List<String>, responseContentType: String?, unknownContentTypeRank: Int): Int {
-        val normalisedContentType = normaliseMediaType(responseContentType)
-        if (normalisedContentType.isNullOrBlank()) return unknownContentTypeRank
-        val rank = acceptMediaTypes.indexOfFirst { acceptMediaType ->
-            isResponseContentTypeAccepted(acceptMediaType, normalisedContentType)
-        }
-
-        return rank.takeIf { it >= 0 } ?: unknownContentTypeRank
     }
 
     fun matchingHttpPathPatternFor(path: String): HttpPathPattern? {

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -4198,7 +4198,7 @@ paths:
         }
 
         @Test
-        fun `stubResponseMap should not filter matches by Specmatic response code header`() {
+        fun `stubResponseMap should filter matches by Specmatic response code header`() {
             val feature = OpenApiSpecification.fromYAML(
                 """
                 openapi: 3.0.3
@@ -4228,8 +4228,7 @@ paths:
                 unexpectedKeyCheck = ValidateUnexpectedKeys
             )
 
-            assertThat(responseMap.keys).containsExactlyInAnyOrder(200, 400)
-            assertThat(responseMap[200]?.first?.scenario?.status).isEqualTo(200)
+            assertThat(responseMap.keys).containsExactly(400)
             assertThat(responseMap[400]?.first?.scenario?.status).isEqualTo(400)
         }
     }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -956,7 +956,42 @@ Feature: Test
     }
 
     @Test
-    fun `fake response should prefer lower status code among accept-compatible responses`() {
+    fun `fake response should use first matching scenario when request has no Accept header and no forced response code`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: No negotiation without Accept
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '400':
+                      description: JSON Bad Request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                    '200':
+                      description: JSON OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(method = "GET", path = "/hello")
+        val result = fakeHttpResponse(listOf(feature), request, SpecmaticConfig())
+
+        val response = assertFoundStubbedResponse(result)
+        assertThat(response.status).isEqualTo(400)
+        assertThat(response.contentType()).startsWith("application/json")
+    }
+
+    @Test
+    fun `fake response should use the first 2xx response matching Accept`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             openapi: 3.0.3
@@ -997,7 +1032,46 @@ Feature: Test
 
         assertThat(result).isInstanceOf(FoundStubbedResponse::class.java)
         val response = (result as FoundStubbedResponse).response.response
-        assertThat(response.status).isEqualTo(201)
+        assertThat(response.status).isEqualTo(200)
+        assertThat(response.contentType()).startsWith("text/plain")
+    }
+
+    @Test
+    fun `fake response should prefer 2xx over 4xx when Accept is present`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Prefer success class
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '400':
+                      description: JSON Bad Request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                    '200':
+                      description: JSON OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(
+            method = "GET",
+            path = "/hello",
+            headers = mapOf("Accept" to "application/json")
+        )
+        val result = fakeHttpResponse(listOf(feature), request, SpecmaticConfig())
+
+        val response = assertFoundStubbedResponse(result)
+        assertThat(response.status).isEqualTo(200)
         assertThat(response.contentType()).startsWith("application/json")
     }
 
@@ -1032,25 +1106,56 @@ Feature: Test
     }
 
     @Test
-    fun `fake response should preserve scenario order among equal accept-rank responses`() {
+    fun `fake response should prefer 204 over 400 when Accept is wildcard`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             openapi: 3.0.3
             info:
-              title: Accept tie-break by status
+              title: Wildcard should not promote 400
               version: 1.0.0
             paths:
               /hello:
                 get:
                   responses:
+                    '204':
+                      description: No Content
                     '400':
                       description: JSON Bad Request
                       content:
                         application/json:
                           schema:
                             type: object
-                    '201':
-                      description: JSON Created
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(
+            method = "GET",
+            path = "/hello",
+            headers = mapOf("Accept" to "*/*")
+        )
+
+        val result = fakeHttpResponse(listOf(feature), request, SpecmaticConfig())
+
+        val response = assertFoundStubbedResponse(result)
+        assertThat(response.status).isEqualTo(204)
+    }
+
+    @Test
+    fun `fake response should prefer 204 over 400 when Accept is specific but only 400 has a media type`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Specific Accept should not promote 400
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '204':
+                      description: No Content
+                    '400':
+                      description: JSON Bad Request
                       content:
                         application/json:
                           schema:
@@ -1065,20 +1170,117 @@ Feature: Test
         )
 
         val result = fakeHttpResponse(listOf(feature), request, SpecmaticConfig())
-        assertThat(result).isInstanceOf(FoundStubbedResponse::class.java)
 
-        val response = (result as FoundStubbedResponse).response.response
-        assertThat(response.status).isEqualTo(400)
-        assertThat(response.contentType()).startsWith("application/json")
+        val response = assertFoundStubbedResponse(result)
+        assertThat(response.status).isEqualTo(204)
     }
 
     @Test
-    fun `fake response should keep original scenario order when Accept header is malformed`() {
+    fun `fake response should negotiate within the winning 2xx class`() {
         val feature = OpenApiSpecification.fromYAML(
             """
             openapi: 3.0.3
             info:
-              title: Malformed Accept should skip sorting
+              title: Negotiate within success class
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '200':
+                      description: JSON OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                    '201':
+                      description: Plain text Created
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                    '400':
+                      description: JSON Bad Request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(
+            method = "GET",
+            path = "/hello",
+            headers = mapOf("Accept" to "text/plain")
+        )
+
+        val result = fakeHttpResponse(listOf(feature), request, SpecmaticConfig())
+
+        val response = assertFoundStubbedResponse(result)
+        assertThat(response.status).isEqualTo(201)
+        assertThat(response.contentType()).startsWith("text/plain")
+    }
+
+    @Test
+    fun `fake response should negotiate within a forced response code before falling back to first response with that status`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Forced response code negotiation
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                        text/plain:
+                          schema:
+                            type: string
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val plainTextPreferredRequest = HttpRequest(
+            method = "GET",
+            path = "/hello",
+            headers = mapOf(
+                "Accept" to "text/plain",
+                SPECMATIC_RESPONSE_CODE_HEADER to "200"
+            )
+        )
+
+        val plainTextPreferredResult = fakeHttpResponse(listOf(feature), plainTextPreferredRequest, SpecmaticConfig())
+        val plainTextPreferredResponse = assertFoundStubbedResponse(plainTextPreferredResult)
+        assertThat(plainTextPreferredResponse.status).isEqualTo(200)
+        assertThat(plainTextPreferredResponse.contentType()).startsWith("text/plain")
+
+        val fallbackRequest = HttpRequest(
+            method = "GET",
+            path = "/hello",
+            headers = mapOf(
+                "Accept" to "image/png",
+                SPECMATIC_RESPONSE_CODE_HEADER to "200"
+            )
+        )
+
+        val fallbackResult = fakeHttpResponse(listOf(feature), fallbackRequest, SpecmaticConfig())
+        val fallbackResponse = assertFoundStubbedResponse(fallbackResult)
+        assertThat(fallbackResponse.status).isEqualTo(200)
+        assertThat(fallbackResponse.contentType()).startsWith("application/json")
+    }
+
+    @Test
+    fun `fake response should use first matching scenario when Accept header is malformed`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Malformed Accept should skip negotiation
               version: 1.0.0
             paths:
               /hello:
@@ -1110,6 +1312,11 @@ Feature: Test
         val response = (result as FoundStubbedResponse).response.response
         assertThat(response.status).isEqualTo(400)
         assertThat(response.contentType()).startsWith("text/plain")
+    }
+
+    private fun assertFoundStubbedResponse(result: StubbedResponseResult): HttpResponse {
+        assertThat(result).isInstanceOf(FoundStubbedResponse::class.java)
+        return (result as FoundStubbedResponse).response.response
     }
 
     private fun assertResponseFailure(stubResponse: HttpStubResponse, errorMessage: String) {

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubTest.kt
@@ -133,6 +133,113 @@ internal class HttpStubTest {
     }
 
     @Test
+    fun `createStub should return 204 instead of later 400 when request Accept header is wildcard`() {
+        val tempDir = Files.createTempDirectory("specmatic-create-stub-accept-negotiation").toFile()
+        val openApiSpec = tempDir.resolve("api.yaml")
+        val specmaticConfig = tempDir.resolve("specmatic.yaml")
+        val port = ServerSocket(0).use { it.localPort }
+
+        openApiSpec.writeText(
+            """
+            openapi: 3.0.3
+            info:
+              title: Terms conditions
+              version: 1.0.0
+            paths:
+              /v1/clients/{id}/terms-conditions:
+                post:
+                  parameters:
+                    - in: path
+                      name: id
+                      required: true
+                      schema:
+                        type: string
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - clientId
+                            - termsCode
+                            - businessContext
+                            - version
+                            - status
+                          properties:
+                            clientId:
+                              type: string
+                            termsCode:
+                              type: string
+                            businessContext:
+                              type: string
+                            version:
+                              type: string
+                            status:
+                              type: string
+                  responses:
+                    '204':
+                      description: No Content
+                    '400':
+                      description: Bad Request
+                      content:
+                        application/problem+json:
+                          schema:
+                            type: object
+                            required:
+                              - title
+                              - status
+                            properties:
+                              title:
+                                type: string
+                              status:
+                                type: integer
+            """.trimIndent()
+        )
+
+        specmaticConfig.writeText(
+            """
+            version: 2
+            contracts:
+              - consumes:
+                  - ${openApiSpec.canonicalPath}
+            """.trimIndent()
+        )
+
+        try {
+            createStub(
+                host = "localhost",
+                port = port,
+                timeoutMillis = STUB_SHUTDOWN_TIMEOUT,
+                givenConfigFileName = specmaticConfig.canonicalPath
+            ).use { stub ->
+                val response = stub.client.execute(
+                    HttpRequest(
+                        method = "POST",
+                        path = "/v1/clients/COE:CLIENTCODE/terms-conditions",
+                        headers = mapOf("Accept" to "*/*", "Content-Type" to "application/json"),
+                        body = parsedJSONObject(
+                            """
+                            {
+                              "clientId": "COE:CLIENTCODE",
+                              "businessContext": "CLAIM_UPDATE_PAYOUT_METHOD",
+                              "termsCode": "PRU-TC-2024",
+                              "version": "v1.0.3",
+                              "status": "ACCEPTED"
+                            }
+                            """.trimIndent()
+                        )
+                    )
+                )
+
+                assertThat(response.status).isEqualTo(204)
+            }
+        } finally {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun `should log summary and not full swagger specification payload in logs and console`() {
         LogTail.clear()
         val tempDir = Files.createTempDirectory("specmatic-swagger-spec-log").toFile()

--- a/junit5-support/build.gradle.kts
+++ b/junit5-support/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 dependencies {
     implementation("io.specmatic.build-reporter:specmatic-reporter-min:${project.property("specmaticReporterVersion")}") {
         exclude(group = "commons-logging", module = "commons-logging")
+        exclude(group = "io.swagger.parser.v3", module = "swagger-parser")
     }
 
     implementation("net.minidev:json-smart:2.6.0")


### PR DESCRIPTION
## What
- Update mock response selection so `Accept` negotiation no longer promotes `4xx` responses over available `2xx` responses.
- Preserve declared-order selection when there is no meaningful `Accept` negotiation, and keep `Specmatic-Response-Code` as an explicit override.
- Add regression coverage for the customer-reported `204` vs later `400` case and related status/media-type combinations.

## Why
- `Accept: */*` was causing a later `400` response to win over an earlier `204` success response after the OSS upgrade.
- The previous behavior broke the expected stub contract for no-content success responses and made wildcard `Accept` act like a preference for error responses.

## How
- Refined `Feature.kt` selection logic to separate status-class ranking from `Accept` negotiation.
- Kept `Specmatic-Response-Code` handling as a forced-status path, with `Accept` only used to choose among responses within that status.
- Added tests covering:
  - wildcard and absent `Accept` (no content negotiation by mock)
  - forced status selection
  - `2xx` vs `4xx` precedence
  - `createStub(...)` behavior for the reported repro
