### PR TITLE
Fix distinctReport to truly de-duplicate the failures

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -373,7 +373,7 @@ abstract class BackwardCompatibilityCheckBaseCommand : Callable<Int> {
         if (backwardCompatibilityResult.success().not()) {
             logger.log("_".repeat(40).prependIndent(ONE_INDENT))
             logger.log("The Incompatibility Report:$newLine".prependIndent(ONE_INDENT))
-            logger.log(backwardCompatibilityResult.withoutViolationReport().report().prependIndent(TWO_INDENTS))
+            logger.log(backwardCompatibilityResult.withoutViolationReport().distinctReport().prependIndent(TWO_INDENTS))
 
             val verdict = failedVerdictMessage(processedSpec, hook, effectiveStrictMode, effectiveBaseBranch)
 

--- a/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
+++ b/core/src/main/kotlin/io/specmatic/core/FailureReport.kt
@@ -1,6 +1,18 @@
 package io.specmatic.core
 
 data class FailureReport(val contractPath: String?, private val scenarioMessage: String?, val scenario: ScenarioDetailsForResult?, private val matchFailureDetailList: List<MatchFailureDetails>): Report {
+
+    fun groupingKey(): String {
+        if(contractPath != null && scenario != null) return "$contractPath ${scenario.operationDescription()}"
+        if(contractPath != null) return contractPath
+        if(scenario != null) return scenario.operationDescription()
+        return ""
+    }
+
+    fun distinctByMatchFailureDetails(): FailureReport = copy(matchFailureDetailList = matchFailureDetailList.distinct())
+
+    fun mergeMatchFailureDetailsFrom(other: FailureReport): FailureReport = copy(matchFailureDetailList = matchFailureDetailList + other.matchFailureDetailList)
+
     fun errorMessage(): String {
         if (matchFailureDetailList.size != 1) return toText()
         return matchFailureDetailsErrorMessage(matchFailureDetailList.first()).joinToString("\n\n")

--- a/core/src/main/kotlin/io/specmatic/core/Results.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Results.kt
@@ -69,12 +69,22 @@ data class Results(val results: List<Result> = emptyList()) {
     }
 
     fun distinctReport(defaultMessage: String = PATH_NOT_RECOGNIZED_ERROR): String {
-        val filteredResults = withoutFluff().results.filterIsInstance<Result.Failure>()
+        val failureReports = withoutFluff().results.filterIsInstance<Result.Failure>().map(Result.Failure::toFailureReport)
 
-        return when {
-            filteredResults.isNotEmpty() -> listToDistinctReport(filteredResults)
-            else -> if(successCount > 0 && failureCount == 0) "" else defaultMessage.trim()
+        if(failureReports.isEmpty()) {
+            return when {
+                successCount > 0 && failureCount == 0 -> ""
+                else -> defaultMessage.trim()
+            }
         }
+
+        return failureReports.groupBy { it.groupingKey() }.map { (_, groupedReports) ->
+            val mergedFailureReport = groupedReports.reduce { report, otherReport ->
+                report.mergeMatchFailureDetailsFrom(otherReport)
+            }
+
+            mergedFailureReport.distinctByMatchFailureDetails().toText()
+        }.joinToString("${System.lineSeparator()}${System.lineSeparator()}")
     }
 
     fun plus(other: Results): Results = Results(results.plus(other.results))
@@ -132,10 +142,6 @@ data class Results(val results: List<Result> = emptyList()) {
             }
         })
     }
-
-    fun toResultPartialFailures(): List<Result> {
-        return results.filter { it.isPartialFailure() }
-    }
 }
 
 private fun listToReport(results: List<Result>): String {
@@ -143,10 +149,4 @@ private fun listToReport(results: List<Result>): String {
         .joinToString("${System.lineSeparator()}${System.lineSeparator()}") {
             it.toFailureReport().toText()
         }
-}
-
-private fun listToDistinctReport(results: List<Result>): String {
-    return results.filterIsInstance<Result.Failure>().map {
-        it.toFailureReport().toText()
-    }.distinct().joinToString("${System.lineSeparator()}${System.lineSeparator()}")
 }

--- a/core/src/test/kotlin/io/specmatic/core/FailureReportTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FailureReportTest.kt
@@ -2,6 +2,7 @@ package io.specmatic.core
 
 import io.specmatic.trimmedLinesString
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 internal class FailureReportTest {
@@ -16,6 +17,57 @@ internal class FailureReportTest {
 
         override fun operationDescription() = "operation 1"
         override fun failureReportSubHeading() = "API: ${operationDescription()}"
+    }
+
+    @Nested
+    inner class GroupingKeyTest {
+        @Test
+        fun `should return contract path and scenario name when both are present`() {
+            val report = FailureReport(
+                contractPath = "contract-path",
+                scenarioMessage = null,
+                scenario = FakeScenario(status = 0),
+                matchFailureDetailList = emptyList()
+            )
+
+            assertThat(report.groupingKey()).isEqualTo("contract-path operation 1")
+        }
+
+        @Test
+        fun `should return contract path when scenario is absent`() {
+            val report = FailureReport(
+                contractPath = "contract-path",
+                scenarioMessage = null,
+                scenario = null,
+                matchFailureDetailList = emptyList()
+            )
+
+            assertThat(report.groupingKey()).isEqualTo("contract-path")
+        }
+
+        @Test
+        fun `should return scenario name when contract path is absent`() {
+            val report = FailureReport(
+                contractPath = null,
+                scenarioMessage = null,
+                scenario = FakeScenario(status = 0),
+                matchFailureDetailList = emptyList()
+            )
+
+            assertThat(report.groupingKey()).isEqualTo("operation 1")
+        }
+
+        @Test
+        fun `should return empty string when both contract path and scenario are absent`() {
+            val report = FailureReport(
+                contractPath = null,
+                scenarioMessage = null,
+                scenario = null,
+                matchFailureDetailList = emptyList()
+            )
+
+            assertThat(report.groupingKey()).isEmpty()
+        }
     }
 
     @Test
@@ -147,5 +199,40 @@ internal class FailureReportTest {
         >> person.name
         error
         """.trimIndent())
+    }
+
+    @Test
+    fun `distinctByMatchFailureDetails should remove duplicate match failure details`() {
+        val duplicateDetail = MatchFailureDetails(listOf("person", "id"), listOf("error"))
+        val uniqueDetail = MatchFailureDetails(listOf("person", "name"), listOf("another error"))
+        val report = FailureReport(null, null, null, listOf(duplicateDetail, duplicateDetail, uniqueDetail))
+
+        assertThat(report.distinctByMatchFailureDetails().toText().trimmedLinesString()).isEqualTo("""
+            >> person.id
+
+               error
+
+            >> person.name
+
+               another error
+        """.trimIndent().trimmedLinesString())
+    }
+
+    @Test
+    fun `mergeMatchFailureDetailsFrom should append match failure details from the other report`() {
+        val firstDetail = MatchFailureDetails(listOf("person", "id"), listOf("first error"))
+        val secondDetail = MatchFailureDetails(listOf("person", "name"), listOf("second error"))
+        val report = FailureReport(null, null, null, listOf(firstDetail))
+        val otherReport = FailureReport(null, null, null, listOf(secondDetail))
+
+        assertThat(report.mergeMatchFailureDetailsFrom(otherReport).toText().trimmedLinesString()).isEqualTo("""
+            >> person.id
+
+               first error
+
+            >> person.name
+
+               second error
+        """.trimIndent().trimmedLinesString())
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/ResultKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ResultKtTest.kt
@@ -2,7 +2,9 @@ package io.specmatic.core
 
 import io.specmatic.core.Result.Failure
 import io.specmatic.core.Result.Success
+import io.specmatic.trimmedLinesString
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.function.Consumer
 
@@ -16,6 +18,18 @@ internal class ResultKtTest {
         override fun testDescription(): String = "scenario description"
         override fun operationDescription(): String = "operation 1"
 
+        override fun failureReportSubHeading(): String = "API: ${operationDescription()}"
+    }
+
+    private fun scenario(name: String, operationDescription: String) = object : ScenarioDetailsForResult {
+        override val status: Int = 200
+        override val ignoreFailure: Boolean = false
+        override val name: String = name
+        override val method: String = "GET"
+        override val path: String = "/route"
+
+        override fun testDescription(): String = "$name description"
+        override fun operationDescription(): String = operationDescription
         override fun failureReportSubHeading(): String = "API: ${operationDescription()}"
     }
 
@@ -79,6 +93,243 @@ internal class ResultKtTest {
         val result = Results().toResultIfAnyWithCausesOrFailure()
         assertThat(result).isInstanceOf(Failure::class.java)
     }
+
+    @Nested
+    inner class DistinctReportTest {
+        @Test
+        fun `distinctReport should return empty string when there are only successes`() {
+            val report = Results(listOf(Success())).distinctReport()
+
+            assertThat(report).isEmpty()
+        }
+
+        @Test
+        fun `distinctReport should return the default message when there are no results`() {
+            val report = Results().distinctReport()
+
+            assertThat(report).isEqualTo(PATH_NOT_RECOGNIZED_ERROR)
+        }
+
+        @Test
+        fun `distinctReport should return the default message when only fluffy failures remain after filtering`() {
+            val fluffyFailure = Failure("error", failureReason = FailureReason.URLPathMisMatch)
+
+            val report = Results(listOf(fluffyFailure)).distinctReport()
+
+            assertThat(report).isEqualTo(PATH_NOT_RECOGNIZED_ERROR)
+        }
+
+        @Test
+        fun `distinctReport should return the default message when a fluffy failure is present alongside a success`() {
+            val fluffyFailure = Failure("error", failureReason = FailureReason.URLPathMisMatch)
+
+            val report = Results(listOf(Success(), fluffyFailure)).distinctReport()
+
+            assertThat(report).isEqualTo(PATH_NOT_RECOGNIZED_ERROR)
+        }
+
+        @Test
+        fun `distinctReport should merge failures with the same scenario and deduplicate match failure details`() {
+            val timestampFailure = Failure("timestamp error", breadCrumb = "timestamp").updateScenario(scenario).updatePath("contract-path")
+            val eventFailure = Failure("event error", breadCrumb = "event").updateScenario(scenario).updatePath("contract-path")
+            val combinedFailure = Result.fromFailures(listOf(timestampFailure, eventFailure))
+                .updateScenario(scenario)
+                .updatePath("contract-path")
+
+            val report = Results(
+                listOf(
+                    combinedFailure,
+                    timestampFailure
+                )
+            ).distinctReport()
+
+            assertThat(report.trimmedLinesString()).isEqualTo(
+                """
+            Error from contract contract-path
+
+              In scenario "scenario"
+              API: operation 1
+
+                >> timestamp
+
+                    timestamp error
+
+                >> event
+
+                    event error
+            """.trimIndent().trimmedLinesString()
+            )
+        }
+
+        @Test
+        fun `distinctReport should render a single failure report as is`() {
+            val timestampFailure = Failure("timestamp error", breadCrumb = "timestamp")
+                .updateScenario(scenario)
+                .updatePath("contract-path")
+
+            val report = Results(listOf(timestampFailure)).distinctReport()
+
+            assertThat(report.trimmedLinesString()).isEqualTo(
+                """
+            Error from contract contract-path
+
+              In scenario "scenario"
+              API: operation 1
+
+                >> timestamp
+
+                    timestamp error
+            """.trimIndent().trimmedLinesString()
+            )
+        }
+
+        @Test
+        fun `distinctReport should merge failures with the same contract path when scenario is absent`() {
+            val timestampFailure = Failure("timestamp error", breadCrumb = "timestamp").updatePath("contract-path")
+            val eventFailure = Failure("event error", breadCrumb = "event").updatePath("contract-path")
+
+            val report = Results(listOf(timestampFailure, eventFailure)).distinctReport()
+
+            assertThat(report.trimmedLinesString()).isEqualTo(
+                """
+            Error from contract contract-path
+
+              >> timestamp
+
+                  timestamp error
+
+              >> event
+
+                  event error
+            """.trimIndent().trimmedLinesString()
+            )
+        }
+
+        @Test
+        fun `distinctReport should merge failures with the same scenario when contract path is absent`() {
+            val timestampFailure = Failure("timestamp error", breadCrumb = "timestamp").updateScenario(scenario)
+            val eventFailure = Failure("event error", breadCrumb = "event").updateScenario(scenario)
+
+            val report = Results(listOf(timestampFailure, eventFailure)).distinctReport()
+
+            assertThat(report.trimmedLinesString()).isEqualTo(
+                """
+            In scenario "scenario"
+            API: operation 1
+
+              >> timestamp
+
+                  timestamp error
+
+              >> event
+
+                  event error
+            """.trimIndent().trimmedLinesString()
+            )
+        }
+
+        @Test
+        fun `distinctReport should merge failures when both contract path and scenario are absent`() {
+            val timestampFailure = Failure("timestamp error", breadCrumb = "timestamp")
+            val eventFailure = Failure("event error", breadCrumb = "event")
+
+            val report = Results(listOf(timestampFailure, eventFailure)).distinctReport()
+
+            assertThat(report.trimmedLinesString()).isEqualTo(
+                """
+            >> timestamp
+
+               timestamp error
+
+            >> event
+
+               event error
+            """.trimIndent().trimmedLinesString()
+            )
+        }
+
+        @Test
+        fun `distinctReport should not merge failures from different contract paths when scenario is the same`() {
+            val sharedScenario = scenario(name = "shared scenario", operationDescription = "shared operation")
+            val firstPathFailure = Failure("timestamp error", breadCrumb = "timestamp")
+                .updateScenario(sharedScenario)
+                .updatePath("contract-path-1")
+            val secondPathFailure = Failure("event error", breadCrumb = "event")
+                .updateScenario(sharedScenario)
+                .updatePath("contract-path-2")
+
+            val report = Results(listOf(firstPathFailure, secondPathFailure)).distinctReport()
+
+            assertThat(report.trimmedLinesString()).isEqualTo(
+                """
+            Error from contract contract-path-1
+
+              In scenario "shared scenario"
+              API: shared operation
+
+                >> timestamp
+
+                    timestamp error
+
+            Error from contract contract-path-2
+
+              In scenario "shared scenario"
+              API: shared operation
+
+                >> event
+
+                    event error
+            """.trimIndent().trimmedLinesString()
+            )
+        }
+
+        @Test
+        fun `distinctReport should not merge failures from different scenarios while deduplicating the match failure details in one of the scenarios`() {
+            val timestampFailure = Failure("timestamp error", breadCrumb = "timestamp").updateScenario(scenario).updatePath("contract-path")
+            val eventFailure = Failure("event error", breadCrumb = "event").updateScenario(scenario).updatePath("contract-path")
+            val combinedFailure = Result.fromFailures(listOf(timestampFailure, eventFailure))
+                .updateScenario(scenario)
+                .updatePath("contract-path")
+
+            val otherScenario = scenario(name = "other scenario", operationDescription = "operation 2")
+            val idFailure = Failure("id error", breadCrumb = "id").updateScenario(otherScenario).updatePath("contract-path")
+
+            val report = Results(
+                listOf(
+                    combinedFailure,
+                    timestampFailure,
+                    idFailure
+                )
+            ).distinctReport()
+
+            assertThat(report.trimmedLinesString()).isEqualTo(
+                """
+            Error from contract contract-path
+
+              In scenario "scenario"
+              API: operation 1
+
+                >> timestamp
+
+                    timestamp error
+
+                >> event
+
+                    event error
+           
+            Error from contract contract-path
+            
+              In scenario "other scenario"
+              API: operation 2
+            
+                >> id
+                
+                    id error
+            """.trimIndent().trimmedLinesString()
+            )
+        }
+    }
+
 
     private fun assertMetadata(result: Result, scenario: ScenarioDetailsForResult?, contractPath: String?) {
         assertThat(result.scenario).isEqualTo(scenario)

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -1582,9 +1582,9 @@ paths:
                   type: string
       responses:
         '200':
-          description: ok
+          description: common
         '400':
-          description: bad request
+          description: common
           content:
             application/json:
               schema:
@@ -1602,7 +1602,7 @@ paths:
         val result: Results = testBackwardCompatibility(oldContract, newContract)
 
         assertThat(result.distinctReport()).isEqualToIgnoringWhitespace("""
-            In scenario "POST /ping. Response: ok"
+            In scenario "POST /ping. Response: common"
             API: POST /ping -> 200
             
               >> REQUEST.BODY.timestamp
@@ -1621,7 +1621,7 @@ paths:
               
                   This is type number in the new specification, but type string in the old specification
             
-            In scenario "POST /ping. Response: bad request"
+            In scenario "POST /ping. Response: common"
             API: POST /ping -> 400
             
               >> REQUEST.BODY.timestamp

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -1446,6 +1446,211 @@ paths:
     }
 
     @Test
+    fun `distinctReport should merge errors for a scenario block when openapi request incompatibilities overlap to avoid duplicate logs`() {
+        val oldContract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /ping:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                event:
+                  type: string
+      responses:
+        '200':
+          description: ok
+""".trimIndent(), ""
+        ).toFeature()
+
+        val newContract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /ping:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - timestamp
+              properties:
+                event:
+                  type: number
+                timestamp:
+                  type: string
+      responses:
+        '200':
+          description: ok
+""".trimIndent(), ""
+        ).toFeature()
+
+        val result: Results = testBackwardCompatibility(oldContract, newContract)
+
+        assertThat(result.distinctReport()).isEqualTo("""
+            In scenario "POST /ping. Response: ok"
+            API: POST /ping -> 200
+            
+              >> REQUEST.BODY.timestamp
+              
+                  R2001: Missing required property
+                  Documentation: https://docs.specmatic.io/rules#r2001
+                  Summary: A required property defined in the specification is missing
+              
+                  New specification expects property "timestamp" in the request but it is missing from the old specification
+              
+              >> REQUEST.BODY.event
+              
+                  R1001: Type mismatch
+                  Documentation: https://docs.specmatic.io/rules#r1001
+                  Summary: The value type does not match the expected type defined in the specification
+              
+                  This is type number in the new specification, but type string in the old specification
+        """.trimIndent())
+    }
+
+    @Test
+    fun `distinctReport should not merge errors from different scenario blocks with the same path and method when openapi request incompatibilities overlap`() {
+        val oldContract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /ping:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                event:
+                  type: string
+      responses:
+        '200':
+          description: ok
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+""".trimIndent(), ""
+        ).toFeature()
+
+        val newContract = OpenApiSpecification.fromYAML(
+            """
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /ping:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - timestamp
+              properties:
+                event:
+                  type: number
+                timestamp:
+                  type: string
+      responses:
+        '200':
+          description: ok
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - code
+                properties:
+                  message:
+                    type: number
+                  code:
+                    type: string
+""".trimIndent(), ""
+        ).toFeature()
+
+        val result: Results = testBackwardCompatibility(oldContract, newContract)
+
+        assertThat(result.distinctReport()).isEqualToIgnoringWhitespace("""
+            In scenario "POST /ping. Response: ok"
+            API: POST /ping -> 200
+            
+              >> REQUEST.BODY.timestamp
+              
+                  R2001: Missing required property
+                  Documentation: https://docs.specmatic.io/rules#r2001
+                  Summary: A required property defined in the specification is missing
+              
+                  New specification expects property "timestamp" in the request but it is missing from the old specification
+              
+              >> REQUEST.BODY.event
+              
+                  R1001: Type mismatch
+                  Documentation: https://docs.specmatic.io/rules#r1001
+                  Summary: The value type does not match the expected type defined in the specification
+              
+                  This is type number in the new specification, but type string in the old specification
+            
+            In scenario "POST /ping. Response: bad request"
+            API: POST /ping -> 400
+            
+              >> REQUEST.BODY.timestamp
+              
+                  R2001: Missing required property
+                  Documentation: https://docs.specmatic.io/rules#r2001
+                  Summary: A required property defined in the specification is missing
+              
+                  New specification expects property "timestamp" in the request but it is missing from the old specification
+              
+              >> REQUEST.BODY.event
+              
+                  R1001: Type mismatch
+                  Documentation: https://docs.specmatic.io/rules#r1001
+                  Summary: The value type does not match the expected type defined in the specification
+              
+                  This is type number in the new specification, but type string in the old specification
+            
+              >> RESPONSE.BODY.message
+              
+                  R1001: Type mismatch
+                  Documentation: https://docs.specmatic.io/rules#r1001
+                  Summary: The value type does not match the expected type defined in the specification
+              
+                  This is number in the new specification response but string in the old specification
+        """.trimIndent())
+    }
+
+    @Test
     fun `backward compatibility errors in request and response are returned together`() {
         val oldContract = OpenApiSpecification.fromYAML(
             """


### PR DESCRIPTION
Fix `distinctReport` to truly de-duplicate the error messages by grouping failure reports per scenario and merging the distinct failures