### PR TITLE
Fix generative stub handling under Accept negotiation

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -392,12 +392,7 @@ data class Feature(
             return pathAndMethodMatchedScenarios
         }
 
-        val bestStatusClassScenarios = filterByBestStatusClass(pathAndMethodMatchedScenarios)
-        val invalidRequestScenarios = pathAndMethodMatchedScenarios.filter {
-            it.status in invalidRequestStatuses && it !in bestStatusClassScenarios
-        }
-
-        return applyAcceptHeaderSelection(httpRequest, bestStatusClassScenarios) + invalidRequestScenarios
+        return orderByStatusClassThenAccept(httpRequest, pathAndMethodMatchedScenarios)
     }
 
     private fun filterByExpectedResponseStatus(expectedResponseCode: Int?, scenarios: List<Scenario>): List<Scenario> {
@@ -481,9 +476,14 @@ data class Feature(
         return if (matchingScenarios.isEmpty()) scenarios else matchingScenarios + remainingScenarios
     }
 
-    private fun filterByBestStatusClass(scenarios: List<Scenario>): List<Scenario> {
-        val bestRank = scenarios.minOfOrNull { statusClassRank(it.status) } ?: return scenarios
-        return scenarios.filter { statusClassRank(it.status) == bestRank }
+    private fun orderByStatusClassThenAccept(httpRequest: HttpRequest, scenarios: List<Scenario>): List<Scenario> {
+        return scenarios
+            .groupBy { statusClassRank(it.status) }
+            .toSortedMap()
+            .values
+            .flatMap { sameStatusClassScenarios ->
+                applyAcceptHeaderSelection(httpRequest, sameStatusClassScenarios)
+            }
     }
 
     private fun statusClassRank(status: Int): Int {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -393,7 +393,11 @@ data class Feature(
         }
 
         val bestStatusClassScenarios = filterByBestStatusClass(pathAndMethodMatchedScenarios)
-        return applyAcceptHeaderSelection(httpRequest, bestStatusClassScenarios)
+        val invalidRequestScenarios = pathAndMethodMatchedScenarios.filter {
+            it.status in invalidRequestStatuses && it !in bestStatusClassScenarios
+        }
+
+        return applyAcceptHeaderSelection(httpRequest, bestStatusClassScenarios) + invalidRequestScenarios
     }
 
     private fun filterByExpectedResponseStatus(expectedResponseCode: Int?, scenarios: List<Scenario>): List<Scenario> {

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -375,8 +375,8 @@ data class Feature(
 
     private fun getMatchingAndSortedScenarios(httpRequest: HttpRequest, scenarios: List<Scenario>): List<Scenario> {
         val expectedResponseCode = httpRequest.expectedResponseCode()
-        val statusFilteredScenarios = filterByExpectedResponseStatus(expectedResponseCode, scenarios)
-        val pathAndMethodMatchedScenarios = statusFilteredScenarios.filter { scenario -> scenario.matchesPathStructureAndMethod(httpRequest) }
+        val statusSortedScenarios = sortByExpectedResponseStatus(expectedResponseCode, scenarios)
+        val pathAndMethodMatchedScenarios = statusSortedScenarios.filter { scenario -> scenario.matchesPathStructureAndMethod(httpRequest) }
 
         if (expectedResponseCode != null) {
             return applyAcceptHeaderSelection(httpRequest, pathAndMethodMatchedScenarios)
@@ -395,9 +395,9 @@ data class Feature(
         return orderByStatusClassThenAccept(httpRequest, pathAndMethodMatchedScenarios)
     }
 
-    private fun filterByExpectedResponseStatus(expectedResponseCode: Int?, scenarios: List<Scenario>): List<Scenario> {
+    private fun sortByExpectedResponseStatus(expectedResponseCode: Int?, scenarios: List<Scenario>): List<Scenario> {
         if (expectedResponseCode == null) return scenarios
-        return scenarios.filter { it.status == expectedResponseCode }
+        return scenarios.sortedBy { it.status != expectedResponseCode }
     }
 
     fun stubResponseMap(

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -38,7 +38,6 @@ import io.specmatic.core.Results
 import io.specmatic.core.SPECMATIC_EMPTY_HEADER
 import io.specmatic.core.SPECMATIC_RESULT_HEADER
 import io.specmatic.core.Scenario
-import io.specmatic.core.ScenarioDetailsForResult
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.examples.server.ExampleMismatchMessages
@@ -1607,11 +1606,10 @@ fun fakeHttpResponse(
             val failureResponses = responses.filter { it.successResponse == null }
             val combinedFailureResult = Results(failureResponses.flatMap { it.results.results })
             val invalidRequestScenario = firstFailureScenarioWithInvalidRequestStatus(failureResponses)
-                ?: firstInvalidRequestScenarioMatchingIdentifier(features, httpRequest)
 
             if (invalidRequestScenario != null && specmaticConfig.getStubGenerative(File(invalidRequestScenario.first.path))) {
                 val feature = invalidRequestScenario.first
-                val scenario = invalidRequestScenario.second as Scenario
+                val scenario = invalidRequestScenario.second
                 val errorResponse = scenario.responseWithStubError(combinedFailureResult.report())
                 NotStubbed(
                     HttpStubResponse(errorResponse, contractPath = feature.path, scenario = scenario, feature = feature),
@@ -1650,23 +1648,12 @@ fun fakeHttpResponse(
     }
 }
 
-private fun firstFailureScenarioWithInvalidRequestStatus(failureResponses: List<ResponseDetails>): Pair<Feature, ScenarioDetailsForResult>? {
+private fun firstFailureScenarioWithInvalidRequestStatus(failureResponses: List<ResponseDetails>): Pair<Feature, Scenario>? {
     return failureResponses.asSequence().flatMap { response ->
         response.results.results.asSequence().filterIsInstance<Result.Failure>().filter {
             it.failureReason == null && it.scenario?.let { scenario -> scenario.status in invalidRequestStatuses } == true
-        }.map { failure -> response.feature to failure.scenario!! }
+        }.map { failure -> response.feature to (failure.scenario as Scenario) }
     }.firstOrNull()
-}
-
-private fun firstInvalidRequestScenarioMatchingIdentifier(
-    features: List<Feature>,
-    httpRequest: HttpRequest
-): Pair<Feature, ScenarioDetailsForResult>? {
-    return features.firstNotNullOfOrNull { feature ->
-        feature.identifierMatchingScenario(httpRequest, furtherPredicate = { it.status in invalidRequestStatuses })?.let {
-            feature to it
-        }
-    }
 }
 
 fun responseDetailsFrom(features: List<Feature>, httpRequest: HttpRequest): List<ResponseDetails> {

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -38,6 +38,7 @@ import io.specmatic.core.Results
 import io.specmatic.core.SPECMATIC_EMPTY_HEADER
 import io.specmatic.core.SPECMATIC_RESULT_HEADER
 import io.specmatic.core.Scenario
+import io.specmatic.core.ScenarioDetailsForResult
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.examples.server.ExampleMismatchMessages
@@ -1605,15 +1606,12 @@ fun fakeHttpResponse(
         null -> {
             val failureResponses = responses.filter { it.successResponse == null }
             val combinedFailureResult = Results(failureResponses.flatMap { it.results.results })
-            val firstScenarioWith400Response = failureResponses.asSequence().flatMap { response ->
-                response.results.results.asSequence().filterIsInstance<Result.Failure>().filter {
-                    it.failureReason == null && it.scenario?.let { scenario -> scenario.status == 400 || scenario.status == 422 } == true
-                }.map { failure -> response.feature to failure.scenario!! }
-            }.firstOrNull()
+            val invalidRequestScenario = firstFailureScenarioWithInvalidRequestStatus(failureResponses)
+                ?: firstInvalidRequestScenarioMatchingIdentifier(features, httpRequest)
 
-            if (firstScenarioWith400Response != null && specmaticConfig.getStubGenerative(File(firstScenarioWith400Response.first.path))) {
-                val feature = firstScenarioWith400Response.first
-                val scenario = firstScenarioWith400Response.second as Scenario
+            if (invalidRequestScenario != null && specmaticConfig.getStubGenerative(File(invalidRequestScenario.first.path))) {
+                val feature = invalidRequestScenario.first
+                val scenario = invalidRequestScenario.second as Scenario
                 val errorResponse = scenario.responseWithStubError(combinedFailureResult.report())
                 NotStubbed(
                     HttpStubResponse(errorResponse, contractPath = feature.path, scenario = scenario, feature = feature),
@@ -1649,6 +1647,25 @@ fun fakeHttpResponse(
                 scenario = fakeResponse.successResponse?.scenario
             )
         )
+    }
+}
+
+private fun firstFailureScenarioWithInvalidRequestStatus(failureResponses: List<ResponseDetails>): Pair<Feature, ScenarioDetailsForResult>? {
+    return failureResponses.asSequence().flatMap { response ->
+        response.results.results.asSequence().filterIsInstance<Result.Failure>().filter {
+            it.failureReason == null && it.scenario?.let { scenario -> scenario.status in invalidRequestStatuses } == true
+        }.map { failure -> response.feature to failure.scenario!! }
+    }.firstOrNull()
+}
+
+private fun firstInvalidRequestScenarioMatchingIdentifier(
+    features: List<Feature>,
+    httpRequest: HttpRequest
+): Pair<Feature, ScenarioDetailsForResult>? {
+    return features.firstNotNullOfOrNull { feature ->
+        feature.identifierMatchingScenario(httpRequest, furtherPredicate = { it.status in invalidRequestStatuses })?.let {
+            feature to it
+        }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -1608,8 +1608,7 @@ fun fakeHttpResponse(
             val invalidRequestScenario = firstFailureScenarioWithInvalidRequestStatus(failureResponses)
 
             if (invalidRequestScenario != null && specmaticConfig.getStubGenerative(File(invalidRequestScenario.first.path))) {
-                val feature = invalidRequestScenario.first
-                val scenario = invalidRequestScenario.second
+                val (feature, scenario) = invalidRequestScenario
                 val errorResponse = scenario.responseWithStubError(combinedFailureResult.report())
                 NotStubbed(
                     HttpStubResponse(errorResponse, contractPath = feature.path, scenario = scenario, feature = feature),
@@ -1649,11 +1648,13 @@ fun fakeHttpResponse(
 }
 
 private fun firstFailureScenarioWithInvalidRequestStatus(failureResponses: List<ResponseDetails>): Pair<Feature, Scenario>? {
-    return failureResponses.asSequence().flatMap { response ->
-        response.results.results.asSequence().filterIsInstance<Result.Failure>().filter {
-            it.failureReason == null && it.scenario?.let { scenario -> scenario.status in invalidRequestStatuses } == true
-        }.map { failure -> response.feature to (failure.scenario as Scenario) }
-    }.firstOrNull()
+    return failureResponses.firstNotNullOfOrNull { response ->
+        response.results.results.asSequence().filterIsInstance<Result.Failure>().firstNotNullOfOrNull { failure ->
+            val scenario = failure.scenario as? Scenario ?: return@firstNotNullOfOrNull null
+            if (failure.failureReason != null || scenario.status !in invalidRequestStatuses) return@firstNotNullOfOrNull null
+            response.feature to scenario
+        }
+    }
 }
 
 fun responseDetailsFrom(features: List<Feature>, httpRequest: HttpRequest): List<ResponseDetails> {

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -4236,7 +4236,7 @@ paths:
         }
 
         @Test
-        fun `stubResponseMap should filter matches by Specmatic response code header`() {
+        fun `stubResponseMap should sort and prefer matches by Specmatic response code header`() {
             val feature = OpenApiSpecification.fromYAML(
                 """
                 openapi: 3.0.3
@@ -4266,7 +4266,7 @@ paths:
                 unexpectedKeyCheck = ValidateUnexpectedKeys
             )
 
-            assertThat(responseMap.keys).containsExactly(400)
+            assertThat(responseMap.keys).containsExactly(400, 200)
             assertThat(responseMap[400]?.first?.scenario?.status).isEqualTo(400)
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -4170,6 +4170,44 @@ paths:
         }
 
         @Test
+        fun `stubResponseMap should return all matching status codes when Accept is specific`() {
+            val feature = OpenApiSpecification.fromYAML(
+                """
+                openapi: 3.0.3
+                info:
+                  title: Stub response map
+                  version: 1.0.0
+                paths:
+                  /orders:
+                    get:
+                      responses:
+                        '200':
+                          description: OK
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                        '400':
+                          description: Bad request
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                """.trimIndent(),
+                ""
+            ).toFeature()
+
+            val responseMap = feature.stubResponseMap(
+                httpRequest = HttpRequest(method = "GET", path = "/orders", headers = mapOf("Accept" to "application/json")),
+                unexpectedKeyCheck = ValidateUnexpectedKeys
+            )
+
+            assertThat(responseMap.keys).containsExactlyInAnyOrder(200, 400)
+            assertThat(responseMap[200]?.first?.scenario?.status).isEqualTo(200)
+            assertThat(responseMap[400]?.first?.scenario?.status).isEqualTo(400)
+        }
+
+        @Test
         fun `stubResponseMap should return fallback 400 entry when no scenario matches`() {
             val feature = OpenApiSpecification.fromYAML(
                 """

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -1144,6 +1144,55 @@ Feature: Test
     }
 
     @Test
+    fun `matchingStub should still match non 2xx expectation when Accept is present`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Match expectation after status preference
+              version: 1.0.0
+            paths:
+              /hello:
+                get:
+                  parameters:
+                    - in: header
+                      name: Accept
+                      required: false
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: JSON OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                    '404':
+                      description: JSON Not Found
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+            """.trimIndent(), ""
+        ).toFeature()
+
+        val request = HttpRequest(
+            method = "GET",
+            path = "/hello",
+            headers = mapOf("Accept" to "application/json")
+        )
+        val response = HttpResponse(
+            status = 404,
+            headers = mapOf("Content-Type" to "application/json"),
+            body = parsedJSONObject("{}")
+        )
+
+        val stub = feature.matchingStub(request, response)
+
+        assertThat(stub.responsePattern.status).isEqualTo(404)
+    }
+
+    @Test
     fun `fake response should honor wildcard accept semantics while selecting response content type`() {
         val feature = OpenApiSpecification.fromYAML(
             """

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -53,11 +53,15 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
 import java.nio.file.Files
 import java.security.KeyStore
 import java.util.*
 import java.util.function.Consumer
+import java.util.stream.Stream
 
 internal class HttpStubKtTest {
 
@@ -776,6 +780,62 @@ Feature: Test
         assertThat(response.body).isInstanceOf(StringValue::class.java)
         assertThat(response.body.toStringLiteral()).contains("STRICT MODE ON")
         assertThat(response.body.toStringLiteral()).contains("No matching REST stub")
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("strictGenerativeCases")
+    fun `strict and generative behavior should be stable regardless of headers`(testName: String, strictMode: Boolean, generative: Boolean, request: HttpRequest, assertion: Consumer<HttpResponse>) {
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.3
+        info:
+          title: Strict and generative matrix
+          version: 1.0.0
+        paths:
+          /hello:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required:
+                        - number
+                      properties:
+                        number:
+                          type: number
+              responses:
+                '200':
+                  description: OK
+                  content:
+                    text/plain:
+                      schema:
+                        type: string
+                '400':
+                  description: Bad request
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - message
+                        properties:
+                          message:
+                            type: string
+        """.trimIndent(), "./openapi.yaml").toFeature()
+
+        val result = getHttpResponse(
+            httpRequest = request,
+            strictMode = strictMode,
+            features = listOf(feature),
+            httpExpectations = HttpExpectations(mutableListOf()),
+            specmaticConfig = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = generative))
+        )
+
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val response = (result as NotStubbed).response.response
+        assertThat(response.status).isEqualTo(400)
+        assertion.accept(response)
     }
 
     @Test
@@ -2333,5 +2393,61 @@ paths:
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
         assertThat(results.testCount).isEqualTo(1)
+    }
+
+    companion object {
+        private val withAccept: (HttpRequest) -> HttpRequest = { it.addHeaderIfMissing("Accept", "text/plain") }
+        private val withResponseCode: (HttpRequest) -> HttpRequest = { it.addHeaderIfMissing(SPECMATIC_RESPONSE_CODE_HEADER, "200") }
+        private val baseRequest = HttpRequest(method = "POST", path = "/hello", headers = emptyMap(), body = parsedJSON("""{"number":"not-a-number"}"""))
+
+        @JvmStatic
+        fun strictGenerativeCases(): Stream<Arguments> {
+            return listOf(
+                // strict ON, generative ON
+                Arguments.of("strict ON, generative ON, base request", true, true, baseRequest, generativeAssertion()),
+                Arguments.of("strict ON, generative ON, accept header", true, true, withAccept(baseRequest), generativeAssertion()),
+                Arguments.of("strict ON, generative ON, response code header", true, true, withResponseCode(baseRequest), generativeAssertion()),
+                Arguments.of("strict ON, generative ON, both headers", true, true, withAccept(withResponseCode(baseRequest)), generativeAssertion()),
+
+                // strict ON, generative OFF
+                Arguments.of("strict ON, generative OFF, base request", true, false, baseRequest, strictModeAssertion()),
+                Arguments.of("strict ON, generative OFF, accept header", true, false, withAccept(baseRequest), strictModeAssertion()),
+                Arguments.of("strict ON, generative OFF, response code header", true, false, withResponseCode(baseRequest), strictModeAssertion()),
+                Arguments.of("strict ON, generative OFF, both headers", true, false, withAccept(withResponseCode(baseRequest)), strictModeAssertion()),
+
+                // strict OFF, generative ON
+                Arguments.of("strict OFF, generative ON, base request", false, true, baseRequest, generativeAssertion()),
+                Arguments.of("strict OFF, generative ON, accept header", false, true, withAccept(baseRequest), generativeAssertion()),
+                Arguments.of("strict OFF, generative ON, response code header", false, true, withResponseCode(baseRequest), generativeAssertion()),
+                Arguments.of("strict OFF, generative ON, both headers", false, true, withAccept(withResponseCode(baseRequest)), generativeAssertion()),
+
+                // strict OFF, generative OFF
+                Arguments.of("strict OFF, generative OFF, base request", false, false, baseRequest, defaultAssertion()),
+                Arguments.of("strict OFF, generative OFF, accept header", false, false, withAccept(baseRequest), defaultAssertion()),
+                Arguments.of("strict OFF, generative OFF, response code header", false, false, withResponseCode(baseRequest), defaultAssertion()),
+                Arguments.of("strict OFF, generative OFF, both headers", false, false, withAccept(withResponseCode(baseRequest)), defaultAssertion()),
+            ).stream()
+        }
+
+        private fun generativeAssertion() = Consumer<HttpResponse> { response ->
+            assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+            val message = (response.body as JSONObjectValue).jsonObject["message"]?.toStringLiteral().orEmpty()
+            assertThat(message).isNotBlank()
+            assertThat(message).doesNotContain("STRICT MODE ON")
+        }
+
+        private fun strictModeAssertion() = Consumer<HttpResponse> { response ->
+            assertThat(response.body).isInstanceOf(StringValue::class.java)
+            val text = response.body.toStringLiteral()
+            assertThat(text).isNotBlank()
+            assertThat(text).contains("STRICT MODE ON")
+        }
+
+        private fun defaultAssertion() = Consumer<HttpResponse> { response ->
+            assertThat(response.body).isInstanceOf(StringValue::class.java)
+            val text = response.body.toStringLiteral()
+            assertThat(text).isNotBlank()
+            assertThat(text).doesNotContain("STRICT MODE ON")
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -864,6 +864,74 @@ Feature: Test
     }
 
     @Test
+    fun `generative error response should still use invalid request response when Accept selects success response class`() {
+        val feature = OpenApiSpecification.fromYAML(
+            """
+            openapi: 3.0.3
+            info:
+              title: Generative error payload with Accept
+              version: 1.0.0
+            paths:
+              /hello:
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required:
+                            - data
+                          properties:
+                            data:
+                              type: string
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                    '400':
+                      description: Bad request
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required:
+                              - message
+                            properties:
+                              message:
+                                type: string
+            """.trimIndent(), "contracts/generative-error-payload-with-accept.yaml"
+        ).toFeature()
+
+        val request = HttpRequest(
+            method = "POST",
+            path = "/hello",
+            headers = mapOf("Accept" to "application/json"),
+            body = parsedJSONObject("""{"data": 10}""")
+        )
+        val result = fakeHttpResponse(
+            listOf(feature),
+            request,
+            SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = true))
+        )
+
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val stubbedResponse = (result as NotStubbed).response
+        val response = stubbedResponse.response
+        assertThat(response.status).isEqualTo(400)
+        assertThat(stubbedResponse.contractPath).isEqualTo(feature.path)
+        assertThat(stubbedResponse.feature).isEqualTo(feature)
+        assertThat(stubbedResponse.scenario).isNotNull
+        assertThat(stubbedResponse.scenario?.status).isEqualTo(400)
+        assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+        val responseBody = response.body as JSONObjectValue
+        assertThat(responseBody.jsonObject.getValue("message")).isInstanceOf(StringValue::class.java)
+    }
+
+    @Test
     fun `fake response should set failure stubResult when combined failures are non empty in non generative mode`() {
         val feature = OpenApiSpecification.fromYAML("""
         openapi: 3.0.3


### PR DESCRIPTION
## What
- Keep all status-class candidates available after Accept negotiation, while still ordering the preferred status class first.
- Restore generative stub fallback to find invalid-request responses even when Accept would otherwise favor a success class.
- Add regression coverage for `stubResponseMap` and `matchingStub` to verify non-2xx scenarios still participate.

## Why
- The Accept negotiation change was filtering out scenarios that other stub flows still need.
- That broke generative error payload selection and could hide non-2xx scenarios from downstream matching.

## How
- Replace best-class filtering with status-class ordering plus per-class Accept selection.
- Update generative fallback lookup to search invalid-request status scenarios explicitly.
- Add focused tests covering stub response mapping and expectation matching with `Accept` present.
