### PR TITLE
Fix generative response resolution for HttpStub

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -41,7 +41,6 @@ import io.specmatic.core.Scenario
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.WorkingDirectory
 import io.specmatic.core.examples.server.ExampleMismatchMessages
-import io.specmatic.core.invalidRequestStatuses
 import io.specmatic.core.listOfExcludedHeaders
 import io.specmatic.core.log.HttpLogMessage
 import io.specmatic.core.log.LogMessage
@@ -105,6 +104,7 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import io.netty.handler.codec.http2.Http2SecurityUtil
 import io.specmatic.core.utilities.FileAssociation
+import io.specmatic.stub.StubMatchingContext.Companion.toStubMatchingContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -1507,14 +1507,12 @@ fun getHttpResponse(
             )
         }
 
-        val matchingFeature = features.firstOrNull { it.identifierMatchingScenario(httpRequest) != null }
-        val effectiveStrictMode = specmaticConfig.getStubStrictMode(matchingFeature?.path?.let(::File)) ?: strictMode
-        if (effectiveStrictMode) {
-            val generativeMode = specmaticConfig.getStubGenerative(matchingFeature?.path?.let(::File))
-            return strictModeHttp400Response(features, httpRequest, matchResults, generativeMode)
+        val matchingContext = features.toStubMatchingContext(httpRequest, specmaticConfig)
+        if (matchingContext.isStrictModePossible() || strictMode) {
+            return strictModeHttp400Response(matchingContext.toStrictModeContextOrDefault(), httpRequest, matchResults)
         }
 
-        return fakeHttpResponse(features, httpRequest, specmaticConfig)
+        return fakeHttpResponse(features, matchingContext, httpRequest)
     } finally {
         features.forEach { feature -> feature.clearServerState() }
     }
@@ -1596,7 +1594,11 @@ fun fakeHttpResponse(
     httpRequest: HttpRequest,
     specmaticConfig: SpecmaticConfig = SpecmaticConfig()
 ): StubbedResponseResult {
+    val configContext = features.toStubMatchingContext(httpRequest, specmaticConfig)
+    return fakeHttpResponse(features, configContext, httpRequest)
+}
 
+private fun fakeHttpResponse(features: List<Feature>, matchingContext: StubMatchingContext.Default, httpRequest: HttpRequest): StubbedResponseResult {
     if (features.isEmpty())
         return NotStubbed(HttpStubResponse(HttpResponse(400, "No valid API specifications loaded")), Result.Failure("No valid API specifications loaded"))
 
@@ -1605,42 +1607,11 @@ fun fakeHttpResponse(
         null -> {
             val failureResponses = responses.filter { it.successResponse == null }
             val combinedFailureResult = Results(failureResponses.flatMap { it.results.results })
-            val firstScenarioWith400Response = failureResponses.asSequence().flatMap { response ->
-                response.results.results.asSequence().filterIsInstance<Result.Failure>().filter {
-                    it.failureReason == null && it.scenario?.let { scenario -> scenario.status == 400 || scenario.status == 422 } == true
-                }.map { failure -> response.feature to failure.scenario!! }
-            }.firstOrNull()
-
-            if (firstScenarioWith400Response != null && specmaticConfig.getStubGenerative(File(firstScenarioWith400Response.first.path))) {
-                val feature = firstScenarioWith400Response.first
-                val scenario = firstScenarioWith400Response.second as Scenario
-                val errorResponse = scenario.responseWithStubError(combinedFailureResult.report())
-                NotStubbed(
-                    HttpStubResponse(errorResponse, contractPath = feature.path, scenario = scenario, feature = feature),
-                    combinedFailureResult.toResultIfAnyWithCausesOrFailure(),
-                )
-            } else {
-                val httpFailureResponse = combinedFailureResult.generateErrorHttpResponse(httpRequest)
-
-                val (nearestMatchingFeature, nearestMatchingScenario) =
-                    features.firstNotNullOfOrNull { feature ->
-                        feature.identifierMatchingScenario(httpRequest)?.let { scenario ->
-                            feature to scenario
-                        }
-                    } ?: Pair (null, null)
-
-                NotStubbed(
-                    response = HttpStubResponse(
-                        response = httpFailureResponse,
-                        scenario = nearestMatchingScenario,
-                        contractPath = nearestMatchingFeature?.path.orEmpty(),
-                        feature = nearestMatchingFeature
-                    ),
-                    stubResult = combinedFailureResult.toResultIfAnyWithCausesOrFailure(),
-                )
+            when (val generativeContext = matchingContext.toGenerativeContextOrNull()) {
+                null -> fakeHttpDefaultResponse(matchingContext, httpRequest, combinedFailureResult)
+                else -> fakeHttpGenerativeResponse(generativeContext, combinedFailureResult)
             }
         }
-
         else -> FoundStubbedResponse(
             HttpStubResponse(
                 generateHttpResponseFrom(fakeResponse, httpRequest),
@@ -1650,6 +1621,21 @@ fun fakeHttpResponse(
             )
         )
     }
+}
+
+private fun fakeHttpGenerativeResponse(matchingContext: StubMatchingContext.Generative, result: Results): NotStubbed {
+    return NotStubbed(
+        stubResult = result.toResultIfAnyWithCausesOrFailure(),
+        response = matchingContext.toStubResponse { it.responseWithStubError(result.report()) },
+    )
+}
+
+private fun fakeHttpDefaultResponse(matchingContext: StubMatchingContext.Default, httpRequest: HttpRequest, result: Results): NotStubbed {
+    val httpFailureResponse = result.generateErrorHttpResponse(httpRequest)
+    return NotStubbed(
+        stubResult = result.toResultIfAnyWithCausesOrFailure(),
+        response = matchingContext.toStubResponse(httpFailureResponse),
+    )
 }
 
 fun responseDetailsFrom(features: List<Feature>, httpRequest: HttpRequest): List<ResponseDetails> {
@@ -1750,40 +1736,33 @@ fun dumpIntoFirstAvailableStringField(jsonArrayValue: JSONArrayValue, stringValu
     return jsonArrayValue.copy(list = newList)
 }
 
-private fun strictModeHttp400Response(
-    features: List<Feature>,
-    httpRequest: HttpRequest,
-    matchResults: List<Pair<Result, HttpStubData>>,
-    generative: Boolean
-): NotStubbed {
+private fun strictModeHttp400Response(matchingContext: StubMatchingContext.Default, httpRequest: HttpRequest, matchResults: List<Pair<Result, HttpStubData>>): NotStubbed {
     val results = Results(matchResults.map { it.first }).withoutFluff().withoutViolationReport()
-    val strictModeReport = results.strictModeReport(httpRequest)
-    val scenario = features.firstNotNullOfOrNull { it.identifierMatchingScenario(httpRequest) }
-    val response = if (generative) {
-        generativeStrictModeResponse(httpRequest, features, strictModeReport) ?: strictModeFallbackResponse(strictModeReport)
-    } else {
-        strictModeFallbackResponse(strictModeReport)
+    return when (val generativeContext = matchingContext.toGenerativeContextOrNull()) {
+        null -> strictModeDefaultResponse(matchingContext, httpRequest, results)
+        else -> strictModeGenerativeResponse(generativeContext, httpRequest, results)
     }
+}
 
+private fun strictModeGenerativeResponse(matchingContext: StubMatchingContext.Generative, httpRequest: HttpRequest, results: Results): NotStubbed {
+    val strictModeReport = results.strictModeReport(httpRequest)
     return NotStubbed(
         stubResult = results.toResultIfAnyWithCausesOrFailure(),
-        response = HttpStubResponse(scenario = scenario, response = response),
+        response = matchingContext.toStubResponse { it.responseWithStubError(strictModeReport) },
     )
 }
 
-private fun generativeStrictModeResponse(httpRequest: HttpRequest, features: List<Feature>, strictModeReport: String): HttpResponse? {
-    return features.firstNotNullOfOrNull { feature ->
-        feature.identifierMatchingScenario(httpRequest, furtherPredicate = { it.status in invalidRequestStatuses })
-    }?.responseWithStubError(strictModeReport)
-}
-
-private fun strictModeFallbackResponse(strictModeReport: String): HttpResponse {
+private fun strictModeDefaultResponse(matchingContext: StubMatchingContext.Default, httpRequest: HttpRequest, results: Results): NotStubbed {
+    val strictModeReport = results.strictModeReport(httpRequest)
     val defaultHeaders = mapOf("Content-Type" to "text/plain", SPECMATIC_RESULT_HEADER to "failure")
-    val headers = if (strictModeReport.isEmpty()) defaultHeaders + (SPECMATIC_EMPTY_HEADER to "true") else defaultHeaders
-    return HttpResponse(
+    val response = HttpResponse(
         status = 400,
-        headers = headers,
+        headers = if (strictModeReport.isEmpty()) defaultHeaders + (SPECMATIC_EMPTY_HEADER to "true") else defaultHeaders,
         body = StringValue("STRICT MODE ON${System.lineSeparator()}${System.lineSeparator()}$strictModeReport")
+    )
+    return NotStubbed(
+        stubResult = results.toResultIfAnyWithCausesOrFailure(),
+        response = matchingContext.toStubResponse(response),
     )
 }
 

--- a/core/src/main/kotlin/io/specmatic/stub/StubMatchingContext.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/StubMatchingContext.kt
@@ -1,0 +1,119 @@
+package io.specmatic.stub
+
+import io.specmatic.core.Feature
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.Scenario
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.core.invalidRequestStatuses
+import java.io.File
+
+sealed interface StubMatchingContext {
+    class Default internal constructor(private val featurePool: List<FeatureContext>) : StubMatchingContext {
+        fun isStrictModePossible(): Boolean {
+            return featurePool.isNotEmpty() && featurePool.any { it.isStrictModeEnabled }
+        }
+
+        fun toStrictModeContextOrDefault(): Default {
+            return Default(featurePool.filter { it.isStrictModeEnabled }.ifEmpty { featurePool })
+        }
+
+        fun toGenerativeContextOrNull(): Generative? {
+            val generativeFeatureContexts = featurePool.filterIsInstance<FeatureContext.Generative>()
+            if (generativeFeatureContexts.isEmpty()) return null
+            return Generative(generativeFeatureContexts)
+        }
+
+        fun toStubResponse(response: HttpResponse): HttpStubResponse {
+            val context = featurePool.firstOrNull()
+            return HttpStubResponse(scenario = context?.firstMatching, response = response, feature = context?.feature, contractPath = context?.feature?.path.orEmpty())
+        }
+
+        companion object {
+            fun from(features: List<Feature>, httpRequest: HttpRequest, specmaticConfig: SpecmaticConfig): Default {
+                val matchingFeatures = features.mapNotNull { it.toMatchingContext(httpRequest, specmaticConfig) }
+                return Default(matchingFeatures)
+            }
+        }
+    }
+
+    class Generative internal constructor(private val featurePool: List<FeatureContext.Generative>) : StubMatchingContext {
+        fun toStubResponse(block: (Scenario) -> HttpResponse): HttpStubResponse {
+            val context = featurePool.firstOrNull() ?: throw IllegalStateException("Stub feature pool cannot be empty for Generative Context")
+            return HttpStubResponse(scenario = context.firstMatchingInvalid, response = block(context.firstMatchingInvalid), feature = context.feature, contractPath = context.feature.path)
+        }
+    }
+
+    companion object {
+        fun List<Feature>.toStubMatchingContext(httpRequest: HttpRequest, specmaticConfig: SpecmaticConfig): Default {
+            return Default.from(this, httpRequest, specmaticConfig)
+        }
+
+        private fun Feature.toMatchingContext(
+            httpRequest: HttpRequest,
+            specmaticConfig: SpecmaticConfig
+        ): FeatureContext? {
+            val isGenerativeEnabled = specmaticConfig.getStubGenerative(File(path))
+            val accumulator = MatchingAccumulator(isGenerativeEnabled)
+            val result = scenarios.fold(accumulator) { acc, scenario -> acc.add(scenario, httpRequest) }
+            return result.toFeatureContext(this, specmaticConfig)
+        }
+    }
+}
+
+internal sealed interface FeatureContext {
+    val feature: Feature
+    val firstMatching: Scenario
+    val isStrictModeEnabled: Boolean
+
+    data class Default(
+        override val feature: Feature,
+        override val firstMatching: Scenario,
+        override val isStrictModeEnabled: Boolean = false,
+    ) : FeatureContext
+
+    data class Generative(
+        override val feature: Feature,
+        val firstMatchingInvalid: Scenario,
+        override val firstMatching: Scenario,
+        override val isStrictModeEnabled: Boolean = false
+    ) : FeatureContext
+}
+
+private data class MatchingAccumulator(val isGenerativeEnabled: Boolean, val firstMatching: Scenario? = null, val firstMatchingInvalid: Scenario? = null) {
+    private val isDone: Boolean get() = firstMatching != null && (!isGenerativeEnabled || firstMatchingInvalid != null)
+
+    fun add(scenario: Scenario, httpRequest: HttpRequest): MatchingAccumulator {
+        if (isDone || !scenario.matchesRequest(httpRequest)) return this
+        return copy(
+            firstMatching = firstMatching ?: scenario,
+            firstMatchingInvalid = firstMatchingInvalid ?: scenario.takeIf { it.status in invalidRequestStatuses }
+        )
+    }
+
+    private fun Scenario.matchesRequest(httpRequest: HttpRequest): Boolean {
+        return httpRequestPattern
+            .matchesPathStructureMethodAndContentType(httpRequest, resolver)
+            .isSuccess()
+    }
+
+    fun toFeatureContext(feature: Feature, specmaticConfig: SpecmaticConfig): FeatureContext? {
+        val firstMatching = firstMatching ?: return null
+        val isStrictModeEnabled = specmaticConfig.getStubStrictMode(File(feature.path)) ?: false
+
+        if (isGenerativeEnabled && firstMatchingInvalid != null) {
+            return FeatureContext.Generative(
+                feature = feature,
+                firstMatching = firstMatching,
+                isStrictModeEnabled = isStrictModeEnabled,
+                firstMatchingInvalid = firstMatchingInvalid,
+            )
+        }
+
+        return FeatureContext.Default(
+            feature = feature,
+            firstMatching = firstMatching,
+            isStrictModeEnabled = isStrictModeEnabled,
+        )
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubKtTest.kt
@@ -53,11 +53,15 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
 import java.nio.file.Files
 import java.security.KeyStore
 import java.util.*
 import java.util.function.Consumer
+import java.util.stream.Stream
 
 internal class HttpStubKtTest {
 
@@ -776,6 +780,62 @@ Feature: Test
         assertThat(response.body).isInstanceOf(StringValue::class.java)
         assertThat(response.body.toStringLiteral()).contains("STRICT MODE ON")
         assertThat(response.body.toStringLiteral()).contains("No matching REST stub")
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("strictGenerativeCases")
+    fun `strict and generative behavior should be stable regardless of headers`(testName: String, strictMode: Boolean, generative: Boolean, request: HttpRequest, assertion: Consumer<HttpResponse>) {
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.3
+        info:
+          title: Strict and generative matrix
+          version: 1.0.0
+        paths:
+          /hello:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required:
+                        - number
+                      properties:
+                        number:
+                          type: number
+              responses:
+                '200':
+                  description: OK
+                  content:
+                    text/plain:
+                      schema:
+                        type: string
+                '400':
+                  description: Bad request
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required:
+                          - message
+                        properties:
+                          message:
+                            type: string
+        """.trimIndent(), "").toFeature()
+
+        val result = getHttpResponse(
+            httpRequest = request,
+            features = listOf(feature),
+            httpExpectations = HttpExpectations(mutableListOf()),
+            strictMode = strictMode,
+            specmaticConfig = SpecmaticConfigV1V2Common(stub = StubConfiguration(generative = generative))
+        )
+
+        assertThat(result).isInstanceOf(NotStubbed::class.java)
+        val response = (result as NotStubbed).response.response
+        assertThat(response.status).isEqualTo(400)
+        assertion.accept(response)
     }
 
     @Test
@@ -2216,5 +2276,61 @@ paths:
 
         assertThat(results.success()).withFailMessage(results.report()).isTrue()
         assertThat(results.testCount).isEqualTo(1)
+    }
+
+    companion object {
+        private val withAccept: (HttpRequest) -> HttpRequest = { it.addHeaderIfMissing("Accept", "text/plain") }
+        private val withResponseCode: (HttpRequest) -> HttpRequest = { it.addHeaderIfMissing(SPECMATIC_RESPONSE_CODE_HEADER, "200") }
+        private val baseRequest = HttpRequest(method = "POST", path = "/hello", headers = emptyMap(), body = parsedJSON("""{"number":"not-a-number"}"""))
+
+        @JvmStatic
+        fun strictGenerativeCases(): Stream<Arguments> {
+            return listOf(
+                // strict ON, generative ON
+                Arguments.of("strict ON, generative ON, base request", true, true, baseRequest, generativeAssertion()),
+                Arguments.of("strict ON, generative ON, accept header", true, true, withAccept(baseRequest), generativeAssertion()),
+                Arguments.of("strict ON, generative ON, response code header", true, true, withResponseCode(baseRequest), generativeAssertion()),
+                Arguments.of("strict ON, generative ON, both headers", true, true, withAccept(withResponseCode(baseRequest)), generativeAssertion()),
+
+                // strict ON, generative OFF
+                Arguments.of("strict ON, generative OFF, base request", true, false, baseRequest, strictModeAssertion()),
+                Arguments.of("strict ON, generative OFF, accept header", true, false, withAccept(baseRequest), strictModeAssertion()),
+                Arguments.of("strict ON, generative OFF, response code header", true, false, withResponseCode(baseRequest), strictModeAssertion()),
+                Arguments.of("strict ON, generative OFF, both headers", true, false, withAccept(withResponseCode(baseRequest)), strictModeAssertion()),
+
+                // strict OFF, generative ON
+                Arguments.of("strict OFF, generative ON, base request", false, true, baseRequest, generativeAssertion()),
+                Arguments.of("strict OFF, generative ON, accept header", false, true, withAccept(baseRequest), generativeAssertion()),
+                Arguments.of("strict OFF, generative ON, response code header", false, true, withResponseCode(baseRequest), generativeAssertion()),
+                Arguments.of("strict OFF, generative ON, both headers", false, true, withAccept(withResponseCode(baseRequest)), generativeAssertion()),
+
+                // strict OFF, generative OFF
+                Arguments.of("strict OFF, generative OFF, base request", false, false, baseRequest, defaultAssertion()),
+                Arguments.of("strict OFF, generative OFF, accept header", false, false, withAccept(baseRequest), defaultAssertion()),
+                Arguments.of("strict OFF, generative OFF, response code header", false, false, withResponseCode(baseRequest), defaultAssertion()),
+                Arguments.of("strict OFF, generative OFF, both headers", false, false, withAccept(withResponseCode(baseRequest)), defaultAssertion()),
+            ).stream()
+        }
+
+        private fun generativeAssertion() = Consumer<HttpResponse> { response ->
+            assertThat(response.body).isInstanceOf(JSONObjectValue::class.java)
+            val message = (response.body as JSONObjectValue).jsonObject["message"]?.toStringLiteral().orEmpty()
+            assertThat(message).isNotBlank()
+            assertThat(message).doesNotContain("STRICT MODE ON")
+        }
+
+        private fun strictModeAssertion() = Consumer<HttpResponse> { response ->
+            assertThat(response.body).isInstanceOf(StringValue::class.java)
+            val text = response.body.toStringLiteral()
+            assertThat(text).isNotBlank()
+            assertThat(text).contains("STRICT MODE ON")
+        }
+
+        private fun defaultAssertion() = Consumer<HttpResponse> { response ->
+            assertThat(response.body).isInstanceOf(StringValue::class.java)
+            val text = response.body.toStringLiteral()
+            assertThat(text).isNotBlank()
+            assertThat(text).doesNotContain("STRICT MODE ON")
+        }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/stub/StubMatchingContextTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/StubMatchingContextTest.kt
@@ -1,0 +1,126 @@
+package io.specmatic.stub
+
+import io.mockk.every
+import io.mockk.mockk
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.core.SpecmaticConfig
+import io.specmatic.stub.StubMatchingContext.Companion.toStubMatchingContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class StubMatchingContextTest {
+    @Test
+    fun `should create generative context from invalid matching scenario when generative is enabled`() {
+        val feature = featureWithResponses(contractPath = "contracts/generative-enabled.yaml", invalidResponseCode = 422)
+        val config = configFor(generativePaths = setOf(feature.path))
+        val request = HttpRequest(method = "POST", path = "/hello")
+
+        val context = listOf(feature).toStubMatchingContext(request, config)
+        val generativeContext = context.toGenerativeContextOrNull()
+        assertThat(generativeContext).isNotNull
+
+        val stubResponse = generativeContext!!.toStubResponse { scenario -> HttpResponse(scenario.status) }
+        assertThat(stubResponse.contractPath).isEqualTo(feature.path)
+        assertThat(stubResponse.scenario?.status).isEqualTo(422)
+        assertThat(stubResponse.response.status).isEqualTo(422)
+    }
+
+    @Test
+    fun `should not create generative context when generative is disabled`() {
+        val config = configFor(generativePaths = emptySet())
+        val request = HttpRequest(method = "POST", path = "/hello")
+        val feature = featureWithResponses(contractPath = "contracts/generative-disabled.yaml", invalidResponseCode = 422)
+
+        val context = listOf(feature).toStubMatchingContext(request, config)
+        assertThat(context.toGenerativeContextOrNull()).isNull()
+
+        val stubResponse = context.toStubResponse(HttpResponse(499))
+        assertThat(stubResponse.contractPath).isEqualTo(feature.path)
+        assertThat(stubResponse.scenario?.status).isEqualTo(200)
+    }
+
+    @Test
+    fun `strict mode context should retain only strict matching features`() {
+        val nonStrictFeature = featureWithResponses(contractPath = "contracts/non-strict.yaml", successCode = 201)
+        val strictFeature = featureWithResponses(contractPath = "contracts/strict.yaml", successCode = 202)
+        val config = configFor(strictPaths = setOf(strictFeature.path))
+        val request = HttpRequest(method = "POST", path = "/hello")
+
+        val context = listOf(nonStrictFeature, strictFeature).toStubMatchingContext(request, config)
+        assertThat(context.isStrictModePossible()).isTrue()
+
+        val strictContext = context.toStrictModeContextOrDefault()
+        val stubResponse = strictContext.toStubResponse(HttpResponse(499))
+        assertThat(stubResponse.contractPath).isEqualTo(strictFeature.path)
+        assertThat(stubResponse.scenario?.status).isEqualTo(202)
+    }
+
+    @Test
+    fun `strict mode context should fallback to original pool when no strict matching feature exists`() {
+        val firstFeature = featureWithResponses(contractPath = "contracts/first.yaml", successCode = 201)
+        val secondFeature = featureWithResponses(contractPath = "contracts/second.yaml", successCode = 202)
+        val config = configFor(strictPaths = emptySet())
+        val request = HttpRequest(method = "POST", path = "/hello")
+
+        val context = listOf(firstFeature, secondFeature).toStubMatchingContext(request, config)
+        assertThat(context.isStrictModePossible()).isFalse()
+
+        val strictContext = context.toStrictModeContextOrDefault()
+        val stubResponse = strictContext.toStubResponse(HttpResponse(499))
+        assertThat(stubResponse.contractPath).isEqualTo(firstFeature.path)
+        assertThat(stubResponse.scenario?.status).isEqualTo(201)
+    }
+
+    @Test
+    fun `empty matching pool should produce empty stub response metadata`() {
+        val config = configFor()
+        val request = HttpRequest(method = "GET", path = "/unknown")
+        val feature = featureWithResponses(contractPath = "contracts/no-match.yaml")
+
+        val context = listOf(feature).toStubMatchingContext(request, config)
+        val stubResponse = context.toStubResponse(HttpResponse(418))
+
+        assertThat(context.isStrictModePossible()).isFalse()
+        assertThat(context.toGenerativeContextOrNull()).isNull()
+        assertThat(stubResponse.contractPath).isEmpty()
+        assertThat(stubResponse.scenario).isNull()
+        assertThat(stubResponse.feature).isNull()
+    }
+
+    private fun featureWithResponses(contractPath: String, successCode: Int = 200, invalidResponseCode: Int? = null) = OpenApiSpecification.fromYAML("""
+    openapi: 3.0.3
+    info:
+      title: Stub Matching Context
+      version: 1.0.0
+    paths:
+      /hello:
+        post:
+          responses:
+            '$successCode':
+              description: Success
+            ${invalidResponseCode?.let { "'$it':\n                  description: Invalid request" } ?: ""}
+    """.trimIndent(), contractPath).toFeature()
+
+    private fun configFor(generativePaths: Set<String> = emptySet(), strictPaths: Set<String> = emptySet()): SpecmaticConfig {
+        val config = mockk<SpecmaticConfig>(relaxed = true)
+        val normalizedGenerativePaths = generativePaths.map(::normalizePathSeparators).toSet()
+        val normalizedStrictPaths = strictPaths.map(::normalizePathSeparators).toSet()
+
+        every { config.getStubGenerative(any()) } answers {
+            val path = firstArg<File?>()?.path?.let(::normalizePathSeparators)
+            path != null && normalizedGenerativePaths.contains(path)
+        }
+
+        every { config.getStubStrictMode(any()) } answers {
+            val path = firstArg<File?>()?.path?.let(::normalizePathSeparators)
+            path != null && normalizedStrictPaths.contains(path)
+        }
+
+        return config
+    }
+
+    private fun normalizePathSeparators(path: String): String = path.replace('\\', '/')
+}


### PR DESCRIPTION
**What**: Fix generative response resolution for HttpStub

**Why**: 
- The Generative Stub should return a structured 4xx response whenever the requestContent is considered invalid, regardless of headers
- If the request included `Specmatic-Response-Code` or `Accept` header, generative resolution was based on the match result which would prevent any 400/422 scenarios that would lead to a non-structured response

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
