### PR TITLE
Fix uncaught exception during stub shutdown with in-flight delay

### DIFF
--- a/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
+++ b/core/src/main/kotlin/io/specmatic/stub/HttpStub.kt
@@ -125,6 +125,7 @@ import java.time.Instant
 import java.util.*
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
+import kotlin.math.max
 import kotlin.text.toCharArray
 
 const val SPECMATIC_RESPONSE_CODE_HEADER = "Specmatic-Response-Code"
@@ -148,6 +149,7 @@ class HttpStub(
     val workingDirectory: WorkingDirectory? = null,
     specmaticConfigSource: SpecmaticConfigSource = SpecmaticConfigSource.None,
     private val timeoutMillis: Long = 0,
+    private val forceTimeoutMillis: Long = 0,
     private val specToStubBaseUrlMap: Map<String, String?> = features.associate {
         it.path to endPointFromHostAndPort(host, port, keyDataRegistry.hasAny())
     },
@@ -1159,8 +1161,8 @@ class HttpStub(
     override fun close() {
         val protocols = features.map { it.protocol }.distinct()
         if (SpecmaticProtocol.HTTP in protocols) generateReports()
-        logger.debug("Stopping the server with grace period of $timeoutMillis")
-        server.stop(gracePeriodMillis = timeoutMillis, timeoutMillis = timeoutMillis)
+        logger.debug("Stopping the server with grace period of $timeoutMillis and force timeout of $forceTimeoutMillis")
+        server.stop(gracePeriodMillis = timeoutMillis, timeoutMillis = max(timeoutMillis, forceTimeoutMillis))
     }
 
     private fun generateReports() {
@@ -1462,7 +1464,7 @@ suspend fun respondToKtorHttpResponse(
 
     val delayInMs = delayInMilliSeconds ?: specmaticConfig?.getStubDelayInMilliseconds(specificationPath?.let(::File))
     if (delayInMs != null) {
-        delay(delayInMs)
+        withContext(Dispatchers.IO) { delay(delayInMs) }
     }
 
     val contentType = httpResponse.contentType() ?: httpResponse.body.httpContentType

--- a/core/src/test/kotlin/io/specmatic/stub/HttpStubDelayTest.kt
+++ b/core/src/test/kotlin/io/specmatic/stub/HttpStubDelayTest.kt
@@ -4,14 +4,27 @@ import io.ktor.server.application.*
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.utilities.Flags.Companion.SPECMATIC_STUB_DELAY
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.getForEntity
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.system.measureTimeMillis
 
 class HttpStubDelayTest {
@@ -36,6 +49,11 @@ class HttpStubDelayTest {
         fun tearDown() {
             clearMocks(applicationCall, httpResponse)
         }
+    }
+
+    @AfterEach
+    fun resetResponseBodyMock() {
+        every { httpResponse.body.toStringLiteral() } returns "response body"
     }
 
     @Test
@@ -119,5 +137,86 @@ class HttpStubDelayTest {
             timeTaken <= maxDelayInMs,
             "Expected minimum delay within $maxDelayInMs but actual delay was $timeTaken ms"
         )
+    }
+
+    @Test
+    fun `should not throw uncaught exceptions when cancelled during delayed response`() = runBlocking {
+        val job = launch {
+            respondToKtorHttpResponse(
+                call = applicationCall,
+                httpResponse = httpResponse,
+                delayInMilliSeconds = 5_000L,
+                specmaticConfig = SpecmaticConfig()
+            )
+        }
+
+        delay(50L)
+        job.cancel()
+        job.join()
+
+        assertTrue(job.isCancelled || job.isCompleted)
+    }
+
+    @Test
+    fun `closing http stub with many in-flight delayed openapi responses should not crash`(@TempDir tempDir: File) {
+        val openApiSpec = tempDir.resolve("http-stub-delay.yaml").apply {
+            writeText("""
+            openapi: 3.0.1
+            info:
+              title: Delay Test
+              version: "1.0"
+            paths:
+              /data:
+                get:
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        text/plain:
+                          schema:
+                            type: string
+                            example: ok
+            """.trimIndent())
+        }
+
+        val uncaughtExceptionSeen = CountDownLatch(1)
+        val uncaughtExceptions = CopyOnWriteArrayList<Throwable>()
+        val previousUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, throwable ->
+            uncaughtExceptions.add(throwable)
+            uncaughtExceptionSeen.countDown()
+        }
+
+        try {
+            System.setProperty(SPECMATIC_STUB_DELAY, "1500")
+            val feature = parseContractFileToFeature(openApiSpec.absolutePath)
+            val executor = Executors.newFixedThreadPool(4)
+
+            try {
+                HttpStub(features = listOf(feature), timeoutMillis = 100).use { stub ->
+                    repeat(4) {
+                        executor.submit {
+                            try {
+                                RestTemplate().getForEntity<String>(stub.endPoint + "/data")
+                            } catch (_: Throwable) {
+                                // expected client-side failure
+                            }
+                        }
+                    }
+                    Thread.sleep(250)
+                }
+            } finally {
+                executor.shutdown()
+                executor.awaitTermination(10, TimeUnit.SECONDS)
+            }
+
+            assertFalse(
+                uncaughtExceptionSeen.await(2, TimeUnit.SECONDS),
+                "Expected no uncaught exception during stop-vs-delay race, got: ${uncaughtExceptions.joinToString(separator = "\n") { it.stackTraceToString() }}"
+            )
+        } finally {
+            System.clearProperty(SPECMATIC_STUB_DELAY)
+            Thread.setDefaultUncaughtExceptionHandler(previousUncaughtExceptionHandler)
+        }
     }
 }


### PR DESCRIPTION
**What**: Move configurable stub response delay off the Netty dispatcher to prevent uncaught exceptions during shutdown with in-flight delayed responses

**Why**:
Response delays were executed on Netty’s server executor. When `HttpStub.close()` was invoked while a delayed response was still in-flight. This resulted in uncaught exceptions during server termination

**How**: Run only the delay suspension inside Dispatchers.IO, so the delay continuation is not tied to the Netty event executor lifecycle. The request remains part of the normal Ktor lifecycle, so shutdown can still cancel it cleanly.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)