### PR TITLE
Add conformance tests for query params and validate that query params as objects are not supported

### DIFF
--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/OpenApiSpec.kt
@@ -9,11 +9,14 @@ import com.networknt.schema.SchemaLocation
 import com.networknt.schema.SchemaRegistry
 import com.networknt.schema.dialect.Dialects
 import io.swagger.parser.OpenAPIParser
+import io.swagger.v3.core.util.Json
 import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.SpecVersion
+import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.parser.core.models.ParseOptions
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.net.URI
 import java.net.URLDecoder
 import io.swagger.v3.oas.models.Operation as SwaggerOperation
 
@@ -123,6 +126,74 @@ class OpenApiSpec(private val specFile: File) {
         return requestBodySchema(operation).validate(jsonNode)
     }
 
+    fun validateQueryParameters(url: String, operation: Operation): List<String> {
+        val swaggerOp = swaggerOperation(operation) ?: return emptyList()
+        val queryParams = swaggerOp.parameters.orEmpty().filter { it.`in` == "query" }
+        if (queryParams.isEmpty()) return emptyList()
+
+        val queryPairs = parseQueryString(URI(url).rawQuery.orEmpty())
+        return queryParams.flatMap { validateQueryParameter(it, queryPairs) }
+    }
+
+    private fun validateQueryParameter(
+        parameter: Parameter,
+        queryPairs: Map<String, List<String>>
+    ): List<String> {
+        val name = parameter.name
+        val values = queryPairs[name].orEmpty()
+
+        if (values.isEmpty()) {
+            return if (parameter.required == true) listOf("/$name: required query parameter is missing")
+            else emptyList()
+        }
+
+        val schemaType = parameter.schema?.type ?: parameter.schema?.types?.firstOrNull { it != "null" }
+        val schemaAllowsNull = parameter.schema?.nullable == true
+                || parameter.schema?.types?.contains("null") == true
+        val itemsType = if (schemaType == "array") {
+            parameter.schema?.items?.type ?: parameter.schema?.items?.types?.firstOrNull { it != "null" }
+        } else null
+
+        val node = try {
+            when {
+                // Empty value on the wire conventionally represents null for nullable params
+                // (e.g. `?minPrice=` for a `[number, "null"]` schema).
+                values.size == 1 && values.first().isEmpty() && schemaAllowsNull ->
+                    jsonMapper.nullNode()
+
+                schemaType == "array" -> jsonMapper.createArrayNode().apply {
+                    values.forEach { add(parseFormValue(it, itemsType)) }
+                }
+
+                else -> parseFormValue(values.first(), schemaType)
+            }
+        } catch (e: Exception) {
+            return listOf("/$name: cannot parse '${values.first()}' as $schemaType: ${e.message}")
+        }
+
+        val schemaNode: JsonNode = swaggerJsonMapper.valueToTree(parameter.schema)
+        val schema = schemaRegistry.getSchema(parameterSchemaLocation, schemaNode)
+        return schema.validate(node).map { "/$name${it.instanceLocation}: ${it.message}" }
+    }
+
+    private fun swaggerOperation(operation: Operation): SwaggerOperation? {
+        val pathItem = openApi.paths[operation.path] ?: return null
+        return pathItem.readOperationsMap()[PathItem.HttpMethod.valueOf(operation.method.uppercase())]
+    }
+
+    private fun parseQueryString(queryString: String): Map<String, List<String>> {
+        if (queryString.isEmpty()) return emptyMap()
+        val result = mutableMapOf<String, MutableList<String>>()
+        queryString.split("&").forEach { pair ->
+            if (pair.isEmpty()) return@forEach
+            val parts = pair.split("=", limit = 2)
+            val key = URLDecoder.decode(parts[0], Charsets.UTF_8)
+            val value = if (parts.size == 2) URLDecoder.decode(parts[1], Charsets.UTF_8) else ""
+            result.getOrPut(key) { mutableListOf() }.add(value)
+        }
+        return result
+    }
+
     fun validateResponseBody(
         body: String, operation: Operation, responseContentType: String
     ): List<Error> {
@@ -154,10 +225,8 @@ class OpenApiSpec(private val specFile: File) {
     }
 
     private fun requestBodyProperties(operation: Operation): Map<String, io.swagger.v3.oas.models.media.Schema<*>> {
-        val pathItem = openApi.paths[operation.path] ?: return emptyMap()
-        val swaggerOp = pathItem.readOperationsMap()[PathItem.HttpMethod.valueOf(operation.method.uppercase())]
-            ?: return emptyMap()
-        val schema = swaggerOp.requestBody?.content?.get(operation.requestContentType)?.schema
+        val schema = swaggerOperation(operation)
+            ?.requestBody?.content?.get(operation.requestContentType)?.schema
             ?: return emptyMap()
         return schema.properties.orEmpty()
     }
@@ -249,5 +318,10 @@ class OpenApiSpec(private val specFile: File) {
 
         private val yamlMapper = ObjectMapper(YAMLFactory())
         private val jsonMapper = ObjectMapper()
+
+        // Synthetic location used when building a Schema directly from a swagger Schema model
+        // (no $refs to resolve, since swagger-parser already inlined them via isResolveFully).
+        private val parameterSchemaLocation = SchemaLocation.of("urn:specmatic:query-parameter")
+        private val swaggerJsonMapper: ObjectMapper = Json.mapper()
     }
 }

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/AbstractConformanceTest.kt
@@ -87,6 +87,29 @@ abstract class AbstractConformanceTest(
     }
 
     @Test
+    @Order(3)
+    @ExpectFailureTag("x-specmatic-expect-failure-query-parameters")
+    fun `should send valid query parameters`() {
+        val errors = httpExchanges
+            // requests in the test that produce 4xx, 5xx may contain invalid query parameters by design
+            .filter(HttpExchange::isSuccessful)
+            // Only validate query parameters for operations defined in the spec.
+            .filterNot { it.toOperation(spec) == null }
+            .flatMap {
+                spec.validateQueryParameters(
+                    url = it.url,
+                    operation = it.toOperation(spec)!!
+                )
+            }
+
+        assertThat(errors)
+            .withFailMessage {
+                "errors=$errors\n\nurls=${httpExchanges.joinToString("\n") { it.url }}\n\n$allLogs"
+            }
+            .isEmpty()
+    }
+
+    @Test
     @Order(4)
     @ExpectFailureTag("x-specmatic-expect-failure-request-bodies")
     fun `should send valid request bodies`() {

--- a/conformance-tests/src/test/resources/specs/003-query-parameters/011-with-object.yml
+++ b/conformance-tests/src/test/resources/specs/003-query-parameters/011-with-object.yml
@@ -1,0 +1,34 @@
+openapi: 3.0.3
+info:
+  title: ""
+  version: "1.0"
+x-specmatic-expect-failure-query-parameters: "object query parameters are not yet supported by Specmatic"
+paths:
+  /my-day-details:
+    get:
+      operationId: getmydayDetails
+      parameters:
+        - name: params
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/params'
+        - name: mydayId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/params'
+components:
+  schemas:
+    params:
+      type: object
+      properties:
+        status:
+          type: integer


### PR DESCRIPTION
Add conformance tests for query params and validate that query params as objects are not supported. 