### PR TITLE
Extern command options for validate and backward compatibility

### DIFF
--- a/application/src/main/kotlin/application/StubCommand.kt
+++ b/application/src/main/kotlin/application/StubCommand.kt
@@ -142,7 +142,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     )
     var useCurrentBranchForCentralRepo: Boolean? = null
 
-    @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false, hidden = true)
+    @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean? = null
 
     private var contractSources: List<ContractPathData> = emptyList()

--- a/application/src/main/kotlin/application/TestCommand.kt
+++ b/application/src/main/kotlin/application/TestCommand.kt
@@ -128,7 +128,7 @@ https://docs.specmatic.io/documentation/contract_tests.html#supported-filters--o
     )
     var useCurrentBranchForCentralRepo: Boolean? = null
 
-    @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false, hidden = true)
+    @Option(names = ["--lenient"], description = ["Parse the OpenAPI Specification with leniency"], required = false)
     var lenientMode: Boolean = false
 
     @Spec

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -10,7 +10,6 @@ import io.specmatic.core.git.SystemGit
 import io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault
 import io.specmatic.core.log.configureLogging
 import io.specmatic.core.log.logger
-import io.specmatic.core.utilities.SystemExit
 import io.specmatic.license.core.LicenseResolver
 import io.specmatic.license.core.LicensedProduct
 import io.specmatic.license.core.SpecmaticFeature
@@ -27,12 +26,7 @@ import kotlin.collections.ArrayDeque
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 
-abstract class BackwardCompatibilityCheckBaseCommand : Callable<Int> {
-    protected val specmaticConfig: SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault()
-    protected val backwardCompConfig = specmaticConfig.getBackwardCompatibilityConfig()
-    private val newLine = System.lineSeparator()
-    private var areLocalChangesStashed = false
-
+class BackwardCompatibilityCheckOptions {
     @Option(
         names = ["--base-branch"],
         description = ["Base branch to compare the changes against", "Default value is the local origin HEAD of the current branch"],
@@ -66,12 +60,22 @@ abstract class BackwardCompatibilityCheckBaseCommand : Callable<Int> {
         ]
     )
     var strictMode: Boolean? = null
+}
 
-    protected val effectiveRepoDir: String by lazy { repoDir ?: backwardCompConfig?.repoDirectory ?: "." }
+abstract class BackwardCompatibilityCheckBaseCommand(
+    @field:picocli.CommandLine.Mixin
+    val options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()
+): Callable<Int> {
+    protected val specmaticConfig: SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault()
+    protected val backwardCompConfig = specmaticConfig.getBackwardCompatibilityConfig()
+    private val newLine = System.lineSeparator()
+    private var areLocalChangesStashed = false
+
+    protected val effectiveRepoDir: String by lazy { options.repoDir ?: backwardCompConfig?.repoDirectory ?: "." }
     protected val gitCommand: GitCommand by lazy { SystemGit(workingDirectory = Paths.get(effectiveRepoDir).absolutePathString()) }
-    protected val effectiveBaseBranch: String by lazy { baseBranch ?: backwardCompConfig?.baseBranch ?: gitCommand.currentRemoteBranch() }
-    protected val effectiveTargetPath: String by lazy { targetPath ?: backwardCompConfig?.targetPath.orEmpty() }
-    protected val effectiveStrictMode: Boolean by lazy { strictMode ?: backwardCompConfig?.strictMode ?: false }
+    protected val effectiveBaseBranch: String by lazy { options.baseBranch ?: backwardCompConfig?.baseBranch ?: gitCommand.currentRemoteBranch() }
+    protected val effectiveTargetPath: String by lazy { options.targetPath ?: backwardCompConfig?.targetPath.orEmpty() }
+    protected val effectiveStrictMode: Boolean by lazy { options.strictMode ?: backwardCompConfig?.strictMode ?: false }
 
     abstract fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): Results
     abstract fun File.isValidFileFormat(): Boolean
@@ -87,7 +91,7 @@ abstract class BackwardCompatibilityCheckBaseCommand : Callable<Int> {
     open fun getUnusedExamples(feature: IFeature): Set<String> = emptySet()
 
     final override fun call(): Int {
-        configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = debugLog))
+        configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = options.debugLog))
         addShutdownHook()
 
         val filteredSpecs = getChangedSpecs()

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -22,7 +22,7 @@ import kotlin.io.path.pathString
     description = ["Checks backward compatibility of OpenAPI specifications"]
 )
 @Category("Specmatic core")
-class BackwardCompatibilityCheckCommandV2 : BackwardCompatibilityCheckBaseCommand() {
+class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()): BackwardCompatibilityCheckBaseCommand(options) {
 
     override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): Results {
         return testBackwardCompatibility(oldFeature as Feature, newFeature as Feature)

--- a/application/src/main/kotlin/application/validate/OpenApiValidator.kt
+++ b/application/src/main/kotlin/application/validate/OpenApiValidator.kt
@@ -13,6 +13,8 @@ import io.specmatic.test.asserts.toFailure
 import java.io.File
 
 class OpenApiValidator: Validator<Feature> {
+    override val name: String = "OpenAPI"
+
     override fun validateSpecification(specification: File, specmaticConfig: SpecmaticConfig): SpecValidationResult<Feature> {
         if (specification.extension in OPENAPI_FILE_EXTENSIONS) {
             val (feature, result) = OpenApiSpecification.fromFile(specification.canonicalPath, specmaticConfig).toFeatureLenient()

--- a/application/src/main/kotlin/application/validate/ValidateCommand.kt
+++ b/application/src/main/kotlin/application/validate/ValidateCommand.kt
@@ -1,6 +1,5 @@
 package application.validate
 
-import io.specmatic.core.CONTRACT_EXTENSIONS
 import io.specmatic.core.config.LoggingConfiguration
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault
@@ -15,36 +14,39 @@ import picocli.CommandLine.Command
 import java.io.File
 import java.util.concurrent.Callable
 
+class ValidateCommandOptions {
+    @CommandLine.Option(names = ["--debug"], description = ["Enable debug logs"])
+    var debug: Boolean? = null
+
+    @CommandLine.Option(names = ["--dir", "--directory"], description = ["Directory to validate"])
+    var directory: File? = null
+
+    @CommandLine.Option(names = ["--spec-file"], description = ["Specification to validate, along with respective examples"])
+    var file: File? = null
+}
+
 @Command(name = "validate", hidden = true, mixinStandardHelpOptions = true, description = ["Lint & Validate specification and external examples"])
 class ValidateCommand(
     private val validator: Validator<out Any?> = OpenApiValidator(),
     specCompatibilityChecker: SpecCompatibilityChecker = OpenApiSpecCompatibilityChecker(),
     specmaticConfig: io.specmatic.core.SpecmaticConfig = loadSpecmaticConfigIfAvailableElseDefault(),
     configBackedSpecificationLoader: ConfigBackedSpecificationLoader? = null,
-    private val currentDirectoryProvider: () -> File = { File(".").canonicalFile }
+    private val currentDirectoryProvider: () -> File = { File(".").canonicalFile },
+    @field:CommandLine.Mixin val validateOptions: ValidateCommandOptions = ValidateCommandOptions()
 ) : Callable<Int> {
-    @CommandLine.Option(names = ["--debug"], description = ["Enable debug logs"])
-    var debug: Boolean? = null
-
-    @CommandLine.Option(names = ["--dir"], description = ["Directory to validate"])
-    var directory: File? = null
-
-    @CommandLine.Option(names = ["--spec-file"], description = ["Specification to validate, along with respective examples"])
-    var file: File? = null
-
     private val recursiveSpecificationAndExampleClassifier =
         RecursiveSpecificationAndExampleClassifier(specmaticConfig, specCompatibilityChecker, setOf(".specmatic"))
     private val effectiveConfigBackedSpecificationLoader =
         configBackedSpecificationLoader ?: ConfigBackedSpecificationLoader(specmaticConfig, recursiveSpecificationAndExampleClassifier)
 
     override fun call(): Int {
-        configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = debug))
+        configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = validateOptions.debug))
         validateArguments()
 
         val data = loadSpecificationData()
 
         if (data.isEmpty()) {
-            println("No specifications found to validate.")
+            println("No ${validator.name} specifications found to validate.")
             return 0
         }
 
@@ -54,16 +56,16 @@ class ValidateCommand(
     }
 
     private fun loadSpecificationData(): List<SpecificationWithExamples> {
-        if (file != null) {
-            val specification = resolvePath(file ?: return emptyList())
+        if (validateOptions.file != null) {
+            val specification = resolvePath(validateOptions.file ?: return emptyList())
             val normalizedSpecification = specification.canonicalFile
             val entryDirectory = normalizedSpecification.parentFile ?: currentDirectoryProvider()
             val loadedData = recursiveSpecificationAndExampleClassifier.load(normalizedSpecification, entryDirectory) ?: return emptyList()
             return listOf(loadedData)
         }
 
-        if (directory != null) {
-            val resolvedDirectory = resolvePath(directory ?: return emptyList())
+        if (validateOptions.directory != null) {
+            val resolvedDirectory = resolvePath(validateOptions.directory ?: return emptyList())
             return recursiveSpecificationAndExampleClassifier.loadAll(resolvedDirectory)
         }
 
@@ -76,15 +78,15 @@ class ValidateCommand(
     }
 
     private fun validateArguments() {
-        if (file != null) {
-            val specification = resolvePath(file ?: return)
+        if (validateOptions.file != null) {
+            val specification = resolvePath(validateOptions.file ?: return)
             if (!specification.isFile)  throw ContractException("Specification is not a file ${specification.path}")
             if (!specification.exists()) throw ContractException("Specification ${specification.path} does not exist")
             if (!specification.canRead())  throw ContractException("Specification ${specification.path} cannot be read")
         }
 
-        if (directory != null) {
-            val directory = resolvePath(directory ?: return)
+        if (validateOptions.directory != null) {
+            val directory = resolvePath(validateOptions.directory ?: return)
             if (!directory.isDirectory)  throw ContractException("${directory.path} is not a directory")
             if (!directory.exists()) throw ContractException("Directory ${directory.path} does not exist")
         }

--- a/application/src/main/kotlin/application/validate/Validator.kt
+++ b/application/src/main/kotlin/application/validate/Validator.kt
@@ -19,6 +19,8 @@ sealed interface ExampleValidationResult {
 }
 
 interface Validator<Feature> {
+    val name: String
+
     fun validateSpecification(specification: File, specmaticConfig: SpecmaticConfig): SpecValidationResult<Feature>
     fun validateInlineExamples(specification: File, feature: Feature, specmaticConfig: SpecmaticConfig): Map<String, ExampleValidationResult>
     fun validateExample(feature: Feature, file: File, specmaticConfig: SpecmaticConfig): ExampleValidationResult

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -145,7 +145,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             apiFile.copyTo(tempDir.resolve("contract.yaml"))
 
             val (stdOut, exitCode) = captureStandardOutput {
-                BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+                BackwardCompatibilityCheckCommandV2().apply { options.repoDir = tempDir.canonicalPath }.call()
             }
 
             assertThat(exitCode).isEqualTo(0)
@@ -171,7 +171,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             apiFile.copyTo(tempDir.resolve("contract.yaml"))
 
             val (stdOut, exitCode) = captureStandardOutput {
-                BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+                BackwardCompatibilityCheckCommandV2().apply { options.repoDir = tempDir.canonicalPath }.call()
             }
 
             assertThat(exitCode).isEqualTo(0)
@@ -198,7 +198,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             File("src/test/resources/specifications/spec_with_external_reference/").copyRecursively(tempDir)
 
             val (stdOut, exitCode) = captureStandardOutput {
-                BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+                BackwardCompatibilityCheckCommandV2().apply { options.repoDir = tempDir.canonicalPath }.call()
             }
 
             assertThat(exitCode).isEqualTo(0)
@@ -250,8 +250,8 @@ class BackwardCompatibilityCheckCommandV2Test {
 
             val (stdOut, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
                 BackwardCompatibilityCheckCommandV2().apply {
-                    repoDir = tempDir.canonicalPath
-                    targetPath = "${tempDir.canonicalPath}/other-api.yaml"
+                    options.repoDir = tempDir.canonicalPath
+                    options.targetPath = "${tempDir.canonicalPath}/other-api.yaml"
                 }.call()
             }
 
@@ -411,7 +411,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             exampleFile.writeText(exampleFile.readText().replace("john", "jane"))
 
             val (stdOut, exitCode) = captureStandardOutput {
-                BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+                BackwardCompatibilityCheckCommandV2().apply { options.repoDir = tempDir.canonicalPath }.call()
             }
 
             assertThat(exitCode).isEqualTo(0)
@@ -438,7 +438,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             exampleFile.writeText("""{"id":2}""")
 
             val (stdOut, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
-                BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+                BackwardCompatibilityCheckCommandV2().apply { options.repoDir = tempDir.canonicalPath }.call()
             }
 
             assertThat(exitCode).isEqualTo(1)
@@ -477,7 +477,7 @@ class BackwardCompatibilityCheckCommandV2Test {
         gitApiFile.writeText(gitApiFile.readText().replace("endpoint", "modified endpoint"))
 
         val (stdOut, exitCode) = captureStandardOutput {
-            BackwardCompatibilityCheckCommandV2().apply { repoDir = tempDir.canonicalPath }.call()
+            BackwardCompatibilityCheckCommandV2().apply { options.repoDir = tempDir.canonicalPath }.call()
         }
 
         assertThat(exitCode).isEqualTo(0)

--- a/application/src/test/kotlin/application/ValidateCommandTest.kt
+++ b/application/src/test/kotlin/application/ValidateCommandTest.kt
@@ -2,6 +2,7 @@ package application
 
 import application.validate.ConfigBackedSpecificationLoader
 import application.validate.ExampleValidationResult
+import application.validate.OpenApiValidator
 import application.validate.SpecValidationResult
 import application.validate.ValidateCommand
 import application.validate.Validator
@@ -257,7 +258,45 @@ class ValidateCommandTest {
         }
 
         assertThat(exitCode).isZero()
-        assertThat(output).contains("No specifications found to validate.")
+        assertThat(output).contains("No Tracking specifications found to validate.")
+    }
+
+    @Test
+    fun `when no specs found validate command should mention validator name`(@TempDir tempDir: File) {
+        writeSpecmaticYaml(tempDir, "version: 3")
+        val (output, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+            CommandLine(
+                ValidateCommand(validator = OpenApiValidator(), specmaticConfig = loadedConfig(tempDir), currentDirectoryProvider = { tempDir.canonicalFile })
+            ).execute()
+        }
+
+        assertThat(exitCode).isZero()
+        assertThat(output).contains("No OpenAPI specifications found to validate.")
+    }
+
+    @Test
+    fun `validate command parses debug spec file and directory options`(@TempDir tempDir: File) {
+        val specFile = writeOpenApiFile(tempDir.resolve("specs/pets.yaml"))
+        val directorySpec = writeOpenApiFile(tempDir.resolve("contracts/orders.yaml"))
+        writeSpecmaticYaml(tempDir, "version: 3")
+
+        val specValidator = TrackingValidator()
+        val specCommand = ValidateCommand(validator = specValidator, specmaticConfig = loadedConfig(tempDir), currentDirectoryProvider = { tempDir.canonicalFile })
+        val specExitCode = CommandLine(specCommand).execute("--debug", "--spec-file", specFile.canonicalPath)
+
+        val directoryValidator = TrackingValidator()
+        val directoryCommand = ValidateCommand(validator = directoryValidator, specmaticConfig = loadedConfig(tempDir), currentDirectoryProvider = { tempDir.canonicalFile })
+        val directoryExitCode = CommandLine(directoryCommand).execute("--debug", "--directory", tempDir.resolve("contracts").canonicalPath)
+
+        assertThat(specExitCode).isZero()
+        assertThat(specCommand.validateOptions.debug).isTrue()
+        assertThat(specCommand.validateOptions.file?.canonicalPath).isEqualTo(specFile.canonicalPath)
+        assertThat(specValidator.validatedSpecifications).containsExactly(specFile.canonicalPath)
+
+        assertThat(directoryExitCode).isZero()
+        assertThat(directoryCommand.validateOptions.debug).isTrue()
+        assertThat(directoryCommand.validateOptions.directory?.canonicalPath).isEqualTo(tempDir.resolve("contracts").canonicalPath)
+        assertThat(directoryValidator.validatedSpecifications).containsExactly(directorySpec.canonicalPath)
     }
 
     @Test
@@ -326,7 +365,7 @@ class ValidateCommandTest {
         )
     }
 
-    private fun loadedConfig(baseDir: File): io.specmatic.core.SpecmaticConfig {
+    private fun loadedConfig(baseDir: File): SpecmaticConfig {
         val configFile = baseDir.resolve("specmatic.yaml")
         System.setProperty(CONFIG_FILE_PATH, configFile.canonicalPath)
         return io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault(configFile.canonicalPath)
@@ -353,6 +392,7 @@ class ValidateCommandTest {
     private class TrackingValidator(
         private val invalidSpecifications: Set<String> = emptySet()
     ) : Validator<String> {
+        override val name: String = "Tracking"
         val validatedSpecifications = mutableListOf<String>()
 
         override fun validateSpecification(specification: File, specmaticConfig: SpecmaticConfig): SpecValidationResult<String> {

--- a/application/src/test/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommandTest.kt
+++ b/application/src/test/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommandTest.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import picocli.CommandLine
 import java.io.File
 
 class BackwardCompatibilityCheckBaseCommandTest {
@@ -42,10 +43,10 @@ class BackwardCompatibilityCheckBaseCommandTest {
 
         val cmd = Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
             TestBackwardCompatibilityCommand().apply {
-                baseBranch = "feature/foo"
-                targetPath = "apis"
-                repoDir = tempDir.resolve("CLI").also { it.mkdirs() }.canonicalPath
-                strictMode = true
+                options.baseBranch = "feature/foo"
+                options.targetPath = "apis"
+                options.repoDir = tempDir.resolve("CLI").also { it.mkdirs() }.canonicalPath
+                options.strictMode = true
             }
         }
 
@@ -92,12 +93,34 @@ class BackwardCompatibilityCheckBaseCommandTest {
         """.trimIndent())
 
         val cmd = Flags.using(CONFIG_FILE_PATH to configFile.canonicalPath) {
-            TestBackwardCompatibilityCommand().apply { targetPath = "from-cli" }
+            TestBackwardCompatibilityCommand().apply { options.targetPath = "from-cli" }
         }
 
         assertThat(cmd.repoDir()).isEqualTo(repoDirFromConfig.canonicalPath.toString())
         assertThat(cmd.baseBranch()).isEqualTo("origin/main")
         assertThat(cmd.targetPath()).isEqualTo("from-cli")
+        assertThat(cmd.strictMode()).isTrue()
+    }
+
+    @Test
+    fun `parses backward compatibility options from cli`(@TempDir tempDir: File) {
+        val cmd = TestBackwardCompatibilityCommand()
+        CommandLine(cmd).parseArgs(
+            "--debug",
+            "--strict",
+            "--base-branch", "feature/foo",
+            "--target-path", "contracts",
+            "--repo-dir", tempDir.canonicalPath
+        )
+
+        assertThat(cmd.options.debugLog).isTrue()
+        assertThat(cmd.options.strictMode).isTrue()
+        assertThat(cmd.options.baseBranch).isEqualTo("feature/foo")
+        assertThat(cmd.options.targetPath).isEqualTo("contracts")
+        assertThat(cmd.options.repoDir).isEqualTo(tempDir.canonicalPath)
+        assertThat(cmd.repoDir()).isEqualTo(tempDir.canonicalPath)
+        assertThat(cmd.baseBranch()).isEqualTo("feature/foo")
+        assertThat(cmd.targetPath()).isEqualTo("contracts")
         assertThat(cmd.strictMode()).isTrue()
     }
 


### PR DESCRIPTION
**What**: Externalize CLI options into reusable mixins, for `ValidateCommand` and `BackwardCompatibilityCheckBaseCommand`

**Why**: These commands need to expose their options cleanly in `--help` while also letting different implementations reuse the same option definitions


**Checklist**:
- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)