### PR TITLE
Add operation verdict to Backward Compatibility Check

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -17,12 +17,15 @@ fun testBackwardCompatibility(older: Feature, newer: Feature): Results {
         val (fullApiDescription, scenarios) = entry
         logger.boundary()
         logger.log("[Compatibility Check] Executing ${scenarios.size} scenarios for $fullApiDescription")
-        scenarios.withIndex().fold(acc) { results, indexedScenario ->
+        val operationResults = scenarios.withIndex().fold(Results()) { results, indexedScenario ->
             val current = indexedScenario.index + 1
             val scenarioResults: List<Result> = testBackwardCompatibility(indexedScenario.value, newer)
             if (exceedsStandardSize && (current % 100 == 0 || current == scenarios.size)) logger.log("[Compatibility Check] Completed $current/${scenarios.size}")
             results.copy(results = results.results.plus(scenarioResults))
         }
+
+        logger.log("[Compatibility Check] Verdict: ${if (operationResults.success()) "PASS" else "FAIL"}")
+        acc.plus(operationResults)
     }
 
     println()

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -3141,6 +3141,75 @@ paths:
     }
 
     @Test
+    fun `should log pass verdict after completing all scenarios for an API`() {
+        val feature = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 1.0.0
+        paths:
+          /products:
+            get:
+              responses:
+                '200':
+                  description: OK
+        """.trimIndent(), "sample.yaml").toFeature()
+
+        val groupedFeature = feature.copy(scenarios = listOf(feature.scenarios.first(), feature.scenarios.first().copy()))
+        val (stdout, _) = captureStandardOutput {
+            testBackwardCompatibility(groupedFeature, groupedFeature)
+        }
+
+        assertThat(stdout).contains("[Compatibility Check] Executing 2 scenarios for GET /products -> 200")
+        assertThat(stdout).contains("[Compatibility Check] Verdict: PASS")
+    }
+
+    @Test
+    fun `should log fail verdict after completing all scenarios for an API`() {
+        val olderContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.1.9
+        paths:
+          /products:
+            get:
+              responses:
+                '200':
+                  description: OK
+        """.trimIndent().openAPIToContract()
+
+        val newerContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '200':
+                  description: OK
+        """.trimIndent().openAPIToContract()
+
+        val (stdout, _) = captureStandardOutput {
+            testBackwardCompatibility(olderContract, newerContract)
+        }
+
+        assertThat(stdout).contains("[Compatibility Check] Executing 1 scenarios for GET /products -> 200")
+        assertThat(stdout).contains("[Compatibility Check] Verdict: FAIL")
+    }
+
+    @Test
     fun `should fail when request is changed from no-body to some body`() {
         val olderContract: Feature =
             """


### PR DESCRIPTION
**What**: Add operation verdict to Backward Compatibility Check

**Checklist**:
- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
