### PR TITLE
Tag expected conformance failures with x-specmatic-spec-ref

### DIFF
--- a/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/GenerateSummaryOfExpectedFailuresCommand.kt
+++ b/conformance-tests/src/main/kotlin/io/specmatic/conformance_test_support/GenerateSummaryOfExpectedFailuresCommand.kt
@@ -23,6 +23,7 @@ data class ExpectedFailureRecord(
     val testClass: String,
     val testMethod: String,
     val reason: String,
+    val specRef: String? = null,
 )
 
 @Command(
@@ -98,13 +99,14 @@ fun main(args: Array<String>) {
 private fun renderMarkdown(records: List<ExpectedFailureRecord>, totalTests: Int): String = buildString {
     appendLine("### Expected Failures")
     appendLine()
-    appendLine("| Display Name | Test Class | Test Method | Reason |")
-    appendLine("|--------------|------------|-------------|--------|")
+    appendLine("| Display Name | Test Class | Test Method | Reason | Spec Reference |")
+    appendLine("|--------------|------------|-------------|--------|----------------|")
     for (record in records) {
         val simpleClass = record.testClass.substringAfterLast('.')
         appendLine(
             "| ${escapeCell(record.displayName)} | ${escapeCell(simpleClass)} | " +
-                "${escapeCell(record.testMethod)} | ${escapeCell(record.reason)} |"
+                "${escapeCell(record.testMethod)} | ${escapeCell(record.reason)} | " +
+                "${escapeCell(record.specRef.orEmpty())} |"
         )
     }
     appendLine()

--- a/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/ExpectedFailureExtension.kt
+++ b/conformance-tests/src/test/kotlin/io/specmatic/conformance_tests/ExpectedFailureExtension.kt
@@ -9,7 +9,7 @@ import org.opentest4j.AssertionFailedError
 import org.slf4j.LoggerFactory
 import java.lang.reflect.Method
 
-class ExpectedFailureExtension(private val findFailureReason: (String) -> String?) : InvocationInterceptor {
+class ExpectedFailureExtension(private val findExtension: (String) -> String?) : InvocationInterceptor {
     override fun interceptTestMethod(
         invocation: InvocationInterceptor.Invocation<Void>,
         invocationContext: ReflectiveInvocationContext<Method>,
@@ -26,7 +26,7 @@ class ExpectedFailureExtension(private val findFailureReason: (String) -> String
             return
         }
 
-        val failureReason = findFailureReason(annotation.tag)
+        val failureReason = findExtension(annotation.tag)
 
         if (failureReason == null) {
             invocation.proceed()
@@ -39,6 +39,8 @@ class ExpectedFailureExtension(private val findFailureReason: (String) -> String
             )
         }
 
+        val specRef = findExtension(SPEC_REF_KEY)?.takeIf { it.isNotBlank() }
+
         try {
             invocation.proceed()
         } catch (_: Throwable) {
@@ -48,6 +50,7 @@ class ExpectedFailureExtension(private val findFailureReason: (String) -> String
                 testClass = extensionContext.requiredTestClass.name,
                 testMethod = extensionContext.displayName,
                 reason = failureReason,
+                specRef = specRef,
             )
             expectedFailuresLogger.info(jsonMapper.writeValueAsString(record))
             return
@@ -59,6 +62,7 @@ class ExpectedFailureExtension(private val findFailureReason: (String) -> String
     }
 
     companion object {
+        private const val SPEC_REF_KEY = "x-specmatic-spec-ref"
         private val jsonMapper = ObjectMapper()
         private val expectedFailuresLogger = LoggerFactory.getLogger("conformance.expected-failures")
     }

--- a/conformance-tests/src/test/resources/specs/003-query-parameters/011-with-object.yml
+++ b/conformance-tests/src/test/resources/specs/003-query-parameters/011-with-object.yml
@@ -3,6 +3,7 @@ info:
   title: ""
   version: "1.0"
 x-specmatic-expect-failure-query-parameters: "object query parameters are not yet supported by Specmatic"
+x-specmatic-spec-ref: "Object query parameter serialization (form/deepObject styles). See OAS 3.0.3 § Style Values: https://spec.openapis.org/oas/v3.0.3.html#style-values"
 paths:
   /my-day-details:
     get:

--- a/conformance-tests/src/test/resources/specs/007-formats/003-time.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/003-time.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 3339 time"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 3339 time"
+x-specmatic-spec-ref: "JSON Schema \"time\" format (RFC 3339 partial-time): https://json-schema.org/draft/2020-12/json-schema-validation#name-dates-times-and-duration"
 info:
   title: "Format - time (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/004-duration.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/004-duration.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid ISO 8601 duration"
 x-specmatic-expect-failure-response-bodies: "invalid ISO 8601 duration"
+x-specmatic-spec-ref: "JSON Schema \"duration\" format (RFC 3339 Appendix A): https://json-schema.org/draft/2020-12/json-schema-validation#name-dates-times-and-duration"
 info:
   title: "Format - duration (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/006-idn-email.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/006-idn-email.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 6531 Mailbox"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 6531 Mailbox"
+x-specmatic-spec-ref: "JSON Schema \"idn-email\" format (RFC 6531 mailbox): https://json-schema.org/draft/2020-12/json-schema-validation#name-email-addresses"
 info:
   title: "Format - idn-email (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/008-idn-hostname.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/008-idn-hostname.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 5890 internationalized hostname"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 5890 internationalized hostname"
+x-specmatic-spec-ref: "JSON Schema \"idn-hostname\" format (RFC 5890 IDN): https://json-schema.org/draft/2020-12/json-schema-validation#name-hostnames"
 info:
   title: "Format - idn-hostname (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/009-ipv4.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/009-ipv4.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 2673 IP address"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 2673 IP address"
+x-specmatic-spec-ref: "JSON Schema \"ipv4\" format (RFC 2673 §3.2 dotted-quad): https://json-schema.org/draft/2020-12/json-schema-validation#name-ip-addresses"
 info:
   title: "Format - ipv4 (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/010-ipv6.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/010-ipv6.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 4291 IP address"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 4291 IP address"
+x-specmatic-spec-ref: "JSON Schema \"ipv6\" format (RFC 4291): https://json-schema.org/draft/2020-12/json-schema-validation#name-ip-addresses"
 info:
   title: "Format - ipv6 (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/011-uri.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/011-uri.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 3986 URI"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 3986 URI"
+x-specmatic-spec-ref: "JSON Schema \"uri\" format (RFC 3986): https://json-schema.org/draft/2020-12/json-schema-validation#name-resource-identifiers"
 info:
   title: "Format - uri (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/014-iri.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/014-iri.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 3987 IRI"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 3987 IRI"
+x-specmatic-spec-ref: "JSON Schema \"iri\" format (RFC 3987 internationalized): https://json-schema.org/draft/2020-12/json-schema-validation#name-resource-identifiers"
 info:
   title: "Format - iri (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/016-json-pointer.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/016-json-pointer.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid RFC 6901 JSON Pointer"
 x-specmatic-expect-failure-response-bodies: "invalid RFC 6901 JSON Pointer"
+x-specmatic-spec-ref: "JSON Schema \"json-pointer\" format (RFC 6901): https://json-schema.org/draft/2020-12/json-schema-validation#name-uri-template-and-json-pointer"
 info:
   title: "Format - json-pointer (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/017-relative-json-pointer.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/017-relative-json-pointer.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid IETF Relative JSON Pointer"
 x-specmatic-expect-failure-response-bodies: "invalid IETF Relative JSON Pointer"
+x-specmatic-spec-ref: "JSON Schema \"relative-json-pointer\" format: https://json-schema.org/draft/2020-12/json-schema-validation#name-uri-template-and-json-pointer"
 info:
   title: "Format - relative-json-pointer (JSON Schema)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/007-formats/022-binary.yaml
+++ b/conformance-tests/src/test/resources/specs/007-formats/022-binary.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed. Tests didn't send binary content."
 x-specmatic-expect-failure-operations: "loop test failed. Tests didn't send binary content."
 x-specmatic-expect-failure-response-bodies: "loop test failed. Tests didn't send binary content."
+x-specmatic-spec-ref: "OpenAPI 3.0.3 built-in \"binary\" format on type:string for octet streams. See OAS 3.0.3 § Data Types: https://spec.openapis.org/oas/v3.0.3.html#data-types"
 info:
   title: "Format - binary (OpenAPI)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/008-constraints/009-integer-multipleof.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/009-integer-multipleof.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid request/response body because integer-multipleof constraint not respected"
 x-specmatic-expect-failure-response-bodies: "invalid request/response body because integer-multipleof constraint not respected"
+x-specmatic-spec-ref: "Schema \"multipleOf\" numeric constraint. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 info:
   title: "Constraint - integer multipleOf"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/008-constraints/012-array-minitems.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/012-array-minitems.yaml
@@ -1,5 +1,6 @@
 x-specmatic-expect-failure-request-bodies: "invalid request/response body because array-minItems/array-maxItems constraint not respected"
 x-specmatic-expect-failure-response-bodies: "invalid request/response body because array-minItems/array-maxItems constraint not respected"
+x-specmatic-spec-ref: "Array minItems/maxItems/uniqueItems. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 openapi: 3.0.3
 info:
   title: "Constraint - array minItems"

--- a/conformance-tests/src/test/resources/specs/008-constraints/013-array-maxitems.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/013-array-maxitems.yaml
@@ -1,5 +1,6 @@
 x-specmatic-expect-failure-request-bodies: "invalid request/response body because array-minItems/array-maxItems constraint not respected"
 x-specmatic-expect-failure-response-bodies: "invalid request/response body because array-minItems/array-maxItems constraint not respected"
+x-specmatic-spec-ref: "Array minItems/maxItems/uniqueItems. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 openapi: 3.0.3
 info:
   title: "Constraint - array maxItems"

--- a/conformance-tests/src/test/resources/specs/008-constraints/015-object-minproperties.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/015-object-minproperties.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "Object minProperties. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 info:
   title: "Constraint - object minProperties"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/008-constraints/019-combined-numeric-constraints.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/019-combined-numeric-constraints.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "invalid request/response body because integer-multipleof constraint not respected"
 x-specmatic-expect-failure-response-bodies: "invalid request/response body because integer-multipleof constraint not respected"
+x-specmatic-spec-ref: "Schema \"multipleOf\" numeric constraint. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 info:
   title: "Constraint - combined numeric constraints (minimum + maximum + multipleOf)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/008-constraints/020-combined-array-constraints.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/020-combined-array-constraints.yaml
@@ -1,5 +1,6 @@
 x-specmatic-expect-failure-request-bodies: "invalid request/response body because array-minItems/array-maxItems constraint not respected"
 x-specmatic-expect-failure-response-bodies: "invalid request/response body because array-minItems/array-maxItems constraint not respected"
+x-specmatic-spec-ref: "Array minItems/maxItems/uniqueItems. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 openapi: 3.0.3
 info:
   title: "Constraint - combined array constraints (minItems + maxItems + uniqueItems)"

--- a/conformance-tests/src/test/resources/specs/008-constraints/021-object-minproperties-with-additional.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/021-object-minproperties-with-additional.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "Object minProperties. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 info:
   title: "Object minProperties with additionalProperties typed"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/008-constraints/024-minproperties-three.yaml
+++ b/conformance-tests/src/test/resources/specs/008-constraints/024-minproperties-three.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "Object minProperties. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 info:
   title: "Object minProperties 3 with fixed and additional properties"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/003-multipart-basic.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/003-multipart-basic.yaml
@@ -1,5 +1,6 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "Limitation of conformance test harness. Cannot validate multipart bodies."
+x-specmatic-spec-ref: "multipart/form-data with simple field properties. See OAS 3.0.3 § Special Considerations for multipart Content: https://spec.openapis.org/oas/v3.0.3.html#special-considerations-for-multipart-content"
 info:
   title: "Multipart form data - basic fields"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/004-multipart-file-upload.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/004-multipart-file-upload.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "File upload via type:string format:binary in multipart/form-data. See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Multipart single file upload"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/005-multipart-file-with-metadata.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/005-multipart-file-with-metadata.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "File upload via type:string format:binary in multipart/form-data. See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Multipart file upload with metadata fields"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/006-multipart-image-upload.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/006-multipart-image-upload.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "File upload via type:string format:binary in multipart/form-data. See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Multipart image upload with content type"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/007-multipart-multiple-files.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/007-multipart-multiple-files.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "File upload via type:string format:binary in multipart/form-data. See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Multipart multiple file upload via array"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/008-multipart-binary-octet-stream.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/008-multipart-binary-octet-stream.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "Per-part content type via Encoding Object. See OAS 3.0.3 § Encoding Object: https://spec.openapis.org/oas/v3.0.3.html#encoding-object"
 info:
   title: "Multipart binary with octet-stream encoding"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/009-multipart-with-json-part.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/009-multipart-with-json-part.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "Per-part content type via Encoding Object. See OAS 3.0.3 § Encoding Object: https://spec.openapis.org/oas/v3.0.3.html#encoding-object"
 info:
   title: "Multipart with JSON-encoded part"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/010-raw-binary-body.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/010-raw-binary-body.yaml
@@ -1,5 +1,6 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "Limitation of conformance test harness. Cannot validate application/octet-stream bodies."
+x-specmatic-spec-ref: "Raw binary request body (non-multipart). See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Raw binary request body (octet-stream)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/011-raw-image-body.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/011-raw-image-body.yaml
@@ -1,5 +1,6 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-request-bodies: "Limitation of conformance test harness. Cannot validate image/png bodies."
+x-specmatic-spec-ref: "Raw binary request body (non-multipart). See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Raw image request body (image/png)"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/012-multipart-optional-file.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/012-multipart-optional-file.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "File upload via type:string format:binary in multipart/form-data. See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Multipart with optional file upload"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/014-multipart-pdf-upload.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/014-multipart-pdf-upload.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "File upload via type:string format:binary in multipart/form-data. See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Multipart PDF file upload with content type"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/009-forms-and-multipart/015-multipart-multiple-named-files.yaml
+++ b/conformance-tests/src/test/resources/specs/009-forms-and-multipart/015-multipart-multiple-named-files.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "loop test failed because tests sent invalid requests that were rejected by the mock"
 x-specmatic-expect-failure-operations: "loop test failed because tests sent invalid requests that were rejected by the mock"
+x-specmatic-spec-ref: "File upload via type:string format:binary in multipart/form-data. See OAS 3.0.3 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.0.3.html#considerations-for-file-uploads"
 info:
   title: "Multipart with multiple named file fields"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/002-xml-response.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/002-xml-response.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "Mock fails to load with error: Could not determine name for an xml node"
 x-specmatic-expect-failure-operations: "Mock fails to load with error: Could not determine name for an xml node"
+x-specmatic-spec-ref: "XML response serialization. See OAS 3.0.3 § XML Object: https://spec.openapis.org/oas/v3.0.3.html#xml-object"
 info:
   title: "Content negotiation - XML response"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/003-multiple-response-types.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/003-multiple-response-types.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "Mock fails to load with error: Could not determine name for an xml node"
 x-specmatic-expect-failure-operations: "Mock fails to load with error: Could not determine name for an xml node"
+x-specmatic-spec-ref: "Multiple media types per response. See OAS 3.0.3 § Media Type Object: https://spec.openapis.org/oas/v3.0.3.html#media-type-object"
 info:
   title: "Content negotiation - multiple response content types"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/004-multiple-request-types.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/004-multiple-request-types.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "Mock fails to load with error: Could not determine name for an xml node"
 x-specmatic-expect-failure-operations: "Mock fails to load with error: Could not determine name for an xml node"
+x-specmatic-spec-ref: "Multiple media types per request. See OAS 3.0.3 § Media Type Object: https://spec.openapis.org/oas/v3.0.3.html#media-type-object"
 info:
   title: "Content negotiation - multiple request content types"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/012-content-negotiation/006-different-request-response-types.yaml
+++ b/conformance-tests/src/test/resources/specs/012-content-negotiation/006-different-request-response-types.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "Mock fails to load with error: Could not determine name for an xml node"
 x-specmatic-expect-failure-operations: "Mock fails to load with error: Could not determine name for an xml node"
+x-specmatic-spec-ref: "Multiple media types per request and response. See OAS 3.0.3 § Media Type Object: https://spec.openapis.org/oas/v3.0.3.html#media-type-object"
 info:
   title: "Content negotiation - different request and response types"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/014-nullable-and-optional/007-nullable-enum.yaml
+++ b/conformance-tests/src/test/resources/specs/014-nullable-and-optional/007-nullable-enum.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.3
 x-specmatic-expect-failure-loop: "tests fail with error: Enum values must contain null if the enum is marked nullable, adding null value"
 x-specmatic-expect-failure-operations: "tests fail with error: Enum values must contain null if the enum is marked nullable, adding null value"
+x-specmatic-spec-ref: "nullable:true with enum must include null. See OAS 3.0.3 § Schema Object (nullable): https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 info:
   title: "Nullable enum property"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/015-additional-properties/007-additional-properties-default-is-true.yaml
+++ b/conformance-tests/src/test/resources/specs/015-additional-properties/007-additional-properties-default-is-true.yaml
@@ -4,6 +4,7 @@ info:
   version: "1.0"
 x-specmatic-expect-failure-loop: "Specmatic treats unspecified additionalProperties as false when the schema declares properties; per OpenAPI 3.0 the default is true. See OpenApiSpecification.kt:additionalPropertiesFrom"
 x-specmatic-expect-failure-operations: "loop fails before any traffic is sent, so no operations are exercised"
+x-specmatic-spec-ref: "additionalProperties defaults to true when omitted. See OAS 3.0.3 § Schema Object: https://spec.openapis.org/oas/v3.0.3.html#schema-object"
 paths:
   /configs:
     get:

--- a/conformance-tests/src/test/resources/specs/020-openapi-3-1/005-if-then-else.yaml
+++ b/conformance-tests/src/test/resources/specs/020-openapi-3-1/005-if-then-else.yaml
@@ -1,5 +1,6 @@
 openapi: 3.1.0
 x-specmatic-expect-failure-request-bodies: "invalid request bodies: error=[: required property 'cardNumber' not found, : required property 'bankAccount' not found]"
+x-specmatic-spec-ref: "JSON Schema if/then/else conditional subschemas (3.1 aligns with JSON Schema 2020-12). See OAS 3.1 § Schema Object: https://spec.openapis.org/oas/v3.1.0.html#schema-object"
 info:
   title: "OpenAPI 3.1 - if/then/else conditional schema"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/020-openapi-3-1/012-discriminator-const-type.yaml
+++ b/conformance-tests/src/test/resources/specs/020-openapi-3-1/012-discriminator-const-type.yaml
@@ -1,6 +1,7 @@
 openapi: 3.1.0
 x-specmatic-expect-failure-loop: "Loop tests fail with: Expected \"circle\", actual was \"Circle\""
 x-specmatic-expect-failure-operations: "Loop tests fail with: Expected \"circle\", actual was \"Circle\""
+x-specmatic-spec-ref: "Discriminator with const-typed branches. See OAS 3.1 § Discriminator Object: https://spec.openapis.org/oas/v3.1.0.html#discriminator-object"
 info:
   title: "OpenAPI 3.1 - discriminator with const type values"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/020-openapi-3-1/013-multipart-file-upload.yaml
+++ b/conformance-tests/src/test/resources/specs/020-openapi-3-1/013-multipart-file-upload.yaml
@@ -1,5 +1,6 @@
 openapi: 3.1.0
 x-specmatic-expect-failure-request-bodies: "EXPECTED FAILURE"
+x-specmatic-spec-ref: "File upload via contentMediaType/contentEncoding (3.1 replaces format:binary). See OAS 3.1 § Considerations for File Uploads: https://spec.openapis.org/oas/v3.1.0.html#considerations-for-file-uploads"
 info:
   title: "OpenAPI 3.1 - multipart file upload with contentMediaType"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/020-openapi-3-1/015-prefix-items.yaml
+++ b/conformance-tests/src/test/resources/specs/020-openapi-3-1/015-prefix-items.yaml
@@ -1,6 +1,7 @@
 openapi: 3.1.0
 x-specmatic-expect-failure-request-bodies: "invalid request/responses that don't respect prefixItems type"
 x-specmatic-expect-failure-response-bodies: "invalid request/responses that don't respect prefixItems type"
+x-specmatic-spec-ref: "JSON Schema prefixItems for tuple validation: https://json-schema.org/draft/2020-12/json-schema-core#name-prefixitems"
 info:
   title: "OpenAPI 3.1 - prefixItems tuple validation"
   version: "1.0"

--- a/conformance-tests/src/test/resources/specs/020-openapi-3-1/018-contains.yaml
+++ b/conformance-tests/src/test/resources/specs/020-openapi-3-1/018-contains.yaml
@@ -1,6 +1,7 @@
 openapi: 3.1.0
 x-specmatic-expect-failure-request-bodies: "invalid request/response error=[/members: must contain at least 1 element(s) that passes these validations: {\"type\":\"object\",\"required\":[\"role\"],\"properties\":{\"role\":{\"const\":\"lead\"}}}]"
 x-specmatic-expect-failure-response-bodies: "invalid request/response error=[/members: must contain at least 1 element(s) that passes these validations: {\"type\":\"object\",\"required\":[\"role\"],\"properties\":{\"role\":{\"const\":\"lead\"}}}]"
+x-specmatic-spec-ref: "JSON Schema contains / minContains / maxContains: https://json-schema.org/draft/2020-12/json-schema-core#name-contains"
 
 info:
   title: "OpenAPI 3.1 - contains and minContains"


### PR DESCRIPTION
## Summary

- Adds an `x-specmatic-spec-ref` tag to every spec that currently declares an `x-specmatic-expect-failure-*`. Each ref is a short note + link pointing at the OpenAPI 3.0.3 / 3.1 section or JSON Schema 2020-12 vocabulary the test exercises, so the gap is traceable to the spec.
- Threads the tag through `ExpectedFailureExtension` into the JSONL record (`specRef` field).
- Adds a `Spec Reference` column to the markdown summary emitted by `generateSummaryOfExpectedFailures`.