### PR TITLE
Performance improvements to backward compatibility check

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/AnyPattern.kt
@@ -6,6 +6,8 @@ import io.specmatic.core.Result.Failure
 import io.specmatic.core.discriminator.DiscriminatorBasedItem
 import io.specmatic.core.discriminator.DiscriminatorMetadata
 import io.specmatic.core.pattern.config.NegativePatternConfiguration
+import io.specmatic.core.utilities.EarlyResult
+import io.specmatic.core.utilities.firstSuccessOrFailures
 import io.specmatic.core.value.*
 import io.specmatic.test.asserts.toFailure
 
@@ -206,19 +208,22 @@ data class AnyPattern(
             return discriminator.matches(sampleData, pattern, key, resolver)
         }
 
-        val matchResults: List<AnyPatternMatch> =
-            pattern.map {
-                AnyPatternMatch(it, resolver.matchesPattern(key, it, sampleData ?: EmptyString))
-            }
+        val earlyResult  = pattern.firstSuccessOrFailures(
+            evaluate = { pattern ->
+                val result = resolver.matchesPattern(key, pattern, sampleData ?: EmptyString)
+                AnyPatternMatch(pattern, result)
+            },
+            isSuccess = { it.result.isSuccess() },
+            toFailure = { it },
+        )
 
-        val matchResult = matchResults.find { it.result is Result.Success }
-
-        if(matchResult != null)
-            return matchResult.result
+        val matchResults = when (earlyResult) {
+            is EarlyResult.FirstSuccess -> return earlyResult.value.result
+            is EarlyResult.Failures -> earlyResult.failures
+        }
 
         val failures = matchResults.map { it.result }.filterIsInstance<Failure>()
-
-        if(failures.any { it.reasonIs { it.objectMatchOccurred } }) {
+        if (failures.any { it.reasonIs { it.objectMatchOccurred } }) {
             val failureMatchResults = matchResults.filter {
                 it.result is Failure && it.result.reasonIs { it.objectMatchOccurred }
             }

--- a/core/src/main/kotlin/io/specmatic/core/pattern/regex/RegexBasedStringGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/pattern/regex/RegexBasedStringGenerator.kt
@@ -7,35 +7,26 @@ import io.specmatic.core.log.logger
 import kotlin.random.Random
 import kotlin.random.asJavaRandom
 
-class RegexBasedStringGenerator(
-    val regex: String,
-) {
-    val isInfinite: Boolean
-        get() {
-            return !isFinite
-        }
-    val isFinite: Boolean
-        get() {
-            return RegExp(regex).toAutomaton().isFinite
-        }
-
+class RegexBasedStringGenerator(val regex: String) {
     init {
         check(!regex.startsWith("/") && !regex.endsWith("/")) {
             "Invalid regex $regex. OpenAPI follows ECMA-262 regular expressions, which do not support / / delimiters like those used in many programming languages"
         }
     }
 
+    private val automaton = RegExp(regex, 0).toAutomaton()
+    val isInfinite: Boolean = !automaton.isFinite
+    val isFinite: Boolean = automaton.isFinite
+
     fun random(
         minLength: Int? = 1,
         maxLength: Int? = REASONABLE_STRING_LENGTH,
     ): String {
-        val state = RegExp(regex, 0).toAutomaton().initialState
-        val executionStack =
-            ExecutionStack(Stage(StringBuilder(), state))
+        val executionStack = ExecutionStack(Stage(StringBuilder(), automaton.initialState))
         return generate(executionStack, minLength ?: 1, maxLength ?: REASONABLE_STRING_LENGTH)
     }
 
-    fun generateShortest(): String = RegExp(regex).toAutomaton().getShortestExample(true)
+    fun generateShortest(): String = automaton.getShortestExample(true)
 
     /**
      * Recursively computes the longest accepted string (using at most [remaining] transitions)
@@ -45,7 +36,7 @@ class RegexBasedStringGenerator(
      */
     fun generateLongest(
         remaining: Int,
-        state: State = RegExp(regex).toAutomaton().initialState,
+        state: State = automaton.initialState,
         memo: MutableMap<Pair<State, Int>, String?> = mutableMapOf(),
     ): String? {
         val key = state to remaining

--- a/core/src/main/kotlin/io/specmatic/core/utilities/EarlyResult.kt
+++ b/core/src/main/kotlin/io/specmatic/core/utilities/EarlyResult.kt
@@ -15,3 +15,15 @@ sealed interface EarlyResult<out Value, out Failure> {
 fun <Value, Failure> EarlyResult<Value, Failure>.getOrElse(orElse: (List<Failure>) -> Value): Value {
     return this.fold(onSuccess = { value -> value }, onFailure = { failure -> orElse(failure) })
 }
+
+inline fun <Item, Value, Failure> Iterable<Item>.firstSuccessOrFailures(evaluate: (Item) -> Value, isSuccess: (Value) -> Boolean, toFailure: (Value) -> Failure): EarlyResult<Value, Failure> {
+    val failures = mutableListOf<Failure>()
+
+    for (item in this) {
+        val value = evaluate(item)
+        if (isSuccess(value)) return EarlyResult.FirstSuccess(value)
+        toFailure(value).let(failures::add)
+    }
+
+    return EarlyResult.Failures(failures)
+}

--- a/core/src/test/kotlin/io/specmatic/core/pattern/regex/RegexBasedStringGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/pattern/regex/RegexBasedStringGeneratorTest.kt
@@ -1,5 +1,6 @@
 package io.specmatic.core.pattern.regex
 
+import dk.brics.automaton.Automaton
 import io.specmatic.conversions.REASONABLE_STRING_LENGTH
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -32,5 +33,11 @@ internal class RegexBasedStringGeneratorTest {
         val message = generator.warningMessage(0, 10).toString()
 
         assertThat(message).isEqualTo("WARNING: Could not generate a string based on $regex with maxLength 10")
+    }
+
+    @Test
+    fun `automaton allow mutate should always be disabled`() {
+        RegexBasedStringGenerator("[a-z]+")
+        assertThat(Automaton.setAllowMutate(false)).isFalse()
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/utilities/EarlyResultTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/utilities/EarlyResultTest.kt
@@ -45,4 +45,31 @@ class EarlyResultTest {
 
         assertThat(value).isEqualTo("fallback:one,two")
     }
+
+    @Test
+    fun `firstSuccessOrFailures should return first success and stop evaluating items`() {
+        val evaluated = mutableListOf<Int>()
+        val result = listOf(1, 2, 3).firstSuccessOrFailures(
+            evaluate = { item ->
+                evaluated.add(item)
+                item * 10
+            },
+            isSuccess = { value -> value == 20 },
+            toFailure = { value -> "failure:$value" }
+        )
+
+        assertThat(result).isEqualTo(EarlyResult.FirstSuccess(20))
+        assertThat(evaluated).containsExactly(1, 2)
+    }
+
+    @Test
+    fun `firstSuccessOrFailures should collect failures when no item succeeds`() {
+        val result = listOf(1, 2, 3).firstSuccessOrFailures(
+            evaluate = { item -> item * 10 },
+            isSuccess = { false },
+            toFailure = { value -> "failure:$value" }
+        )
+
+        assertThat(result).isEqualTo(EarlyResult.Failures(listOf("failure:10", "failure:20", "failure:30")))
+    }
 }


### PR DESCRIPTION
**What**: Performance improvements to backward compatibility check
 
**How**:
Prevent Recreating Automaton
- Refrain from creating a new Automaton, as this is an expensive operation
- Instead, instantiate it once and reuse it per instance.

Use Early return when matching against a list
- Use EarlyReturn when matching within a SubSchema AnyPattern

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)