### PR TITLE
Treat missing WSDL SOAP addresses like host-only addresses

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -240,10 +240,14 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         val endpoint = rootDefinition.getXMLNodeOrNull("service.endpoint")
 
         return when {
-            port != null -> Pair(port.getAttributeValueAtPath("address", "location"), SOAP11Parser(this))
-            endpoint != null -> Pair(endpoint.getAttributeValueAtPath("address", "location"), SOAP20Parser())
+            port != null -> Pair(port.addressLocationOrEmpty(), SOAP11Parser(this))
+            endpoint != null -> Pair(endpoint.addressLocationOrEmpty(), SOAP20Parser())
             else -> throw ContractException("Could not find the service endpoint")
         }
+    }
+
+    private fun XMLNode.addressLocationOrEmpty(): String {
+        return getXMLNodeOrNull("address")?.attributes?.get("location")?.toStringLiteral()?.takeIf { it.isNotBlank() }.orEmpty()
     }
 
     private fun findComplexType(

--- a/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
@@ -14,6 +14,79 @@ import java.util.stream.Stream
 
 class WSDLConversionTests {
     @Test
+    fun `missing soap address in service port behaves like a host only soap address`() {
+        fun wsdlContent(portContent: String) = """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:qr="http://specmatic.io/SOAPService/"
+                              targetNamespace="http://specmatic.io/SOAPService/">
+                <wsdl:types>
+                    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://specmatic.io/SOAPService/">
+                        <xsd:element name="SimpleRequest" type="xsd:string"/>
+                        <xsd:element name="SimpleResponse" type="xsd:string"/>
+                    </xsd:schema>
+                </wsdl:types>
+
+                <wsdl:message name="simpleInputMessage">
+                    <wsdl:part name="simpleInputPart" element="qr:SimpleRequest"/>
+                </wsdl:message>
+                <wsdl:message name="simpleOutputMessage">
+                    <wsdl:part name="simpleOutputPart" element="qr:SimpleResponse"/>
+                </wsdl:message>
+
+                <wsdl:portType name="simplePortType">
+                    <wsdl:operation name="SimpleOperation">
+                        <wsdl:input name="simpleInput" message="qr:simpleInputMessage"/>
+                        <wsdl:output name="simpleOutput" message="qr:simpleOutputMessage"/>
+                    </wsdl:operation>
+                </wsdl:portType>
+
+                <wsdl:binding name="simpleBinding" type="qr:simplePortType">
+                    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                    <wsdl:operation name="SimpleOperation">
+                        <soap:operation soapAction="http://specmatic.io/SOAPService/SimpleOperation"/>
+                        <wsdl:input name="simpleInput">
+                            <soap:body use="literal"/>
+                        </wsdl:input>
+                        <wsdl:output name="simpleOutput">
+                            <soap:body use="literal"/>
+                        </wsdl:output>
+                    </wsdl:operation>
+                </wsdl:binding>
+
+                <wsdl:service name="simpleService">
+                    $portContent
+                </wsdl:service>
+            </wsdl:definitions>
+        """
+
+        fun generatedRequestPath(wsdlContent: String): String? {
+            return WSDL(toXMLNode(wsdlContent), "/path/to/wsdl.xml")
+                .toFeature("/path/to/wsdl.xml")
+                .scenarios
+                .single()
+                .generateHttpRequest()
+                .path
+        }
+
+        val missingAddressPath = generatedRequestPath(
+            wsdlContent("""<wsdl:port name="simplePort" binding="qr:simpleBinding"/>""")
+        )
+        val hostOnlyAddressPath = generatedRequestPath(
+            wsdlContent(
+                """
+                <wsdl:port name="simplePort" binding="qr:simpleBinding">
+                    <soap:address location="http://localhost:9010"/>
+                </wsdl:port>
+                """.trimIndent()
+            )
+        )
+
+        assertThat(missingAddressPath).isEqualTo(hostOnlyAddressPath)
+        assertThat(missingAddressPath).isEqualTo("")
+    }
+
+    @Test
     fun `simple types in request body`() {
         val wsdlContent = """
             <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserMockBlackBoxTest.kt
@@ -1,17 +1,98 @@
 package io.specmatic.core.wsdl
 
 import io.ktor.http.ContentType
+import io.specmatic.conversions.wsdlContentToFeature
 import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpRequest
+import io.specmatic.core.Source
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.v2.SpecExecutionConfig
 import io.specmatic.core.parseContractFileToFeature
 import io.specmatic.core.value.StringValue
 import io.specmatic.core.wsdl.payload.emptySoapMessage
 import io.specmatic.stub.HttpStub
+import io.specmatic.stub.SpecmaticConfigSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.net.ServerSocket
 
 class WSDLParserMockBlackBoxTest {
+    @Test
+    fun `mock for wsdl without soap address serves root endpoint when configured baseUrl ends with slash`() {
+        val wsdlContent = """
+            <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                              xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                              xmlns:qr="http://specmatic.io/SOAPService/"
+                              targetNamespace="http://specmatic.io/SOAPService/">
+                <wsdl:types>
+                    <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://specmatic.io/SOAPService/">
+                        <xsd:element name="SimpleRequest" type="xsd:string"/>
+                        <xsd:element name="SimpleResponse" type="xsd:string"/>
+                    </xsd:schema>
+                </wsdl:types>
+
+                <wsdl:message name="simpleInputMessage">
+                    <wsdl:part name="simpleInputPart" element="qr:SimpleRequest"/>
+                </wsdl:message>
+                <wsdl:message name="simpleOutputMessage">
+                    <wsdl:part name="simpleOutputPart" element="qr:SimpleResponse"/>
+                </wsdl:message>
+
+                <wsdl:portType name="simplePortType">
+                    <wsdl:operation name="SimpleOperation">
+                        <wsdl:input name="simpleInput" message="qr:simpleInputMessage"/>
+                        <wsdl:output name="simpleOutput" message="qr:simpleOutputMessage"/>
+                    </wsdl:operation>
+                </wsdl:portType>
+
+                <wsdl:binding name="simpleBinding" type="qr:simplePortType">
+                    <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+                    <wsdl:operation name="SimpleOperation">
+                        <soap:operation soapAction="http://specmatic.io/SOAPService/SimpleOperation"/>
+                        <wsdl:input name="simpleInput">
+                            <soap:body use="literal"/>
+                        </wsdl:input>
+                        <wsdl:output name="simpleOutput">
+                            <soap:body use="literal"/>
+                        </wsdl:output>
+                    </wsdl:operation>
+                </wsdl:binding>
+
+                <wsdl:service name="simpleService">
+                    <wsdl:port name="simplePort" binding="qr:simpleBinding"/>
+                </wsdl:service>
+            </wsdl:definitions>
+        """
+        val feature = wsdlContentToFeature(wsdlContent, "root.wsdl")
+        val port = ServerSocket(0).use { it.localPort }
+        val baseUrl = "http://localhost:$port/"
+        val specmaticConfig = SpecmaticConfigV1V2Common(
+            sources = listOf(
+                Source(
+                    stub = listOf(
+                        SpecExecutionConfig.ObjectValue.FullUrl(
+                            baseUrl = baseUrl,
+                            specs = listOf(feature.path),
+                        )
+                    )
+                )
+            )
+        )
+
+        val response = HttpStub(
+            features = listOf(feature),
+            host = "localhost",
+            port = port,
+            specmaticConfigSource = SpecmaticConfigSource.fromConfigObject(specmaticConfig),
+            specToStubBaseUrlMap = mapOf(feature.path to baseUrl)
+        ).use { stub ->
+            stub.client.execute(feature.scenarios.single().generateHttpRequest())
+        }
+
+        assertThat(response.status).isEqualTo(200)
+    }
+
     @Test
     fun `mock for scalar choice wsdl without examples returns generated response values`() {
         val feature = parseContractFileToFeature(File("src/test/resources/wsdl/state_machine/scalar_choice.wsdl"))


### PR DESCRIPTION
## Summary
- When a WSDL `wsdl:port` or SOAP 1.2 endpoint omits `soap:address`, treat it like a host-only address and resolve the path to `""`.
- Keep the existing mock behavior unchanged; the fix is scoped to WSDL parsing and conversion.
- Add coverage for both the generated WSDL request path and the mock execution path.

## What
- Updated WSDL endpoint lookup to return an empty path when `soap:address/@location` is missing or blank.
- Added a conversion test showing missing-address WSDL ports behave the same as a host-only SOAP address.
- Added a black-box mock test proving a WSDL without `soap:address` still serves successfully when the configured mock `baseUrl` ends with `/`.

## Why
- Missing SOAP addresses should follow the current host-only address behavior rather than introducing a new root-path interpretation.
- This keeps the change narrow and avoids solving root-path normalization and missing-address handling in the same step.

## How
- Parse missing/blank SOAP address locations as `""` in `WSDL.kt`.
- Validate the resulting scenario path through `wsdlContentToFeature(...).toFeature(...).generateHttpRequest()`.
- Exercise the mock path through `HttpStub` with a configured base URL ending in `/`.