### PR TITLE
Add WSDL attributeGroup support

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/WSDL.kt
@@ -305,6 +305,11 @@ data class WSDL(private val rootDefinition: XMLNode, val definitions: Map<String
         }
     }
 
+    fun findAttributeGroup(fullyQualifiedName: FullyQualifiedName, localSchema: XMLNode? = null): XMLNode {
+        val schema = findSchema(fullyQualifiedName.namespace, localSchema)
+        return schema.findByNodeNameAndAttribute("attributeGroup", "name", fullyQualifiedName.localName)
+    }
+
     private fun findSchema(namespace: String, schema: XMLNode?): XMLNode {
         val resolvedNamespace: String? = namespaceOrSchemaNamespace(namespace, schema)
         if(resolvedNamespace.isNullOrBlank())

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/AttributeElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/AttributeElement.kt
@@ -1,10 +1,14 @@
 package io.specmatic.core.wsdl.parser.message
 
+import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
+import io.specmatic.core.pattern.Pattern
 import io.specmatic.core.pattern.XML_ATTR_OPTIONAL_SUFFIX
+import io.specmatic.core.pattern.withoutOptionality
 import io.specmatic.core.value.Value
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.value.localName
+import io.specmatic.core.wsdl.parser.WSDL
 
 class AttributeElement(xmlNode: XMLNode) {
     val name: String = fromNameAttribute(xmlNode)
@@ -25,4 +29,52 @@ fun isMandatory(element: XMLNode): Boolean? {
 
 fun fromNameAttribute(element: XMLNode): String? {
     return element.attributes["name"]?.toStringLiteral()?.localName()
+}
+
+fun attributesFrom(complexType: XMLNode, wsdl: WSDL): List<AttributeElement> {
+    return expandAttributes(complexType, wsdl, emptySet())
+}
+
+fun attributePatternMap(attributes: List<AttributeElement>): Map<String, Pattern> {
+    val duplicateAttribute = attributes
+        .groupBy { withoutOptionality(it.nameWithOptionality) }
+        .filterValues { it.size > 1 }
+        .keys
+        .firstOrNull()
+
+    if (duplicateAttribute != null)
+        throw ContractException("Duplicate attribute $duplicateAttribute found while expanding attributeGroup")
+
+    return attributes.associate { it.nameWithOptionality to it.type.exactMatchElseType() }
+}
+
+private fun expandAttributes(
+    parentNode: XMLNode,
+    wsdl: WSDL,
+    visitedAttributeGroups: Set<String>
+): List<AttributeElement> {
+    return parentNode.childNodes.filterIsInstance<XMLNode>().flatMap { childNode ->
+        when (childNode.name) {
+            "attribute" -> listOf(AttributeElement(childNode))
+            "attributeGroup" -> expandAttributeGroup(childNode, wsdl, visitedAttributeGroups)
+            else -> emptyList()
+        }
+    }
+}
+
+private fun expandAttributeGroup(
+    attributeGroupReference: XMLNode,
+    wsdl: WSDL,
+    visitedAttributeGroups: Set<String>
+): List<AttributeElement> {
+    val fullyQualifiedName = attributeGroupReference.fullyQualifiedNameFromAttribute("ref")
+    val groupKey = "${fullyQualifiedName.namespace}:${fullyQualifiedName.localName}"
+
+    if (groupKey in visitedAttributeGroups) {
+        logger.debug("Recursive attributeGroup reference ${fullyQualifiedName.qName} already seen; ignoring recursive branch")
+        return emptyList()
+    }
+
+    val attributeGroup = wsdl.findAttributeGroup(fullyQualifiedName, attributeGroupReference.schema)
+    return expandAttributes(attributeGroup, wsdl, visitedAttributeGroups.plus(groupKey))
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElement.kt
@@ -19,9 +19,17 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
         if(specmaticTypeName in typeStack)
             return WSDLTypeInfo(types = existingTypes)
 
-        val childTypeInfos = try {
-            val complexType = wsdl.getComplexTypeNode(element)
+        val complexType = try {
+            wsdl.getComplexTypeNode(element)
+        } catch(e: ContractException) {
+            logger.debug(e, "Error getting type for WSDL type \"$wsdlTypeReference\", ${element.oneLineDescription}")
+            throw e
+        }
 
+        val attributes = complexType.getAttributes()
+        val attributePatterns = attributePatternMap(attributes)
+
+        val childTypeInfos = try {
             complexType.generateChildren(
                 specmaticTypeName,
                 existingTypes,
@@ -42,8 +50,8 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
             accumulated.plus(childTypeInfo.types)
         }
         val resolvedPattern: Pattern = when (childTypeInfos.size) {
-            1 -> XMLPattern(childTypeInfos.single().xmlTypeData)
-            else -> AnyPattern(pattern = childTypeInfos.map { XMLPattern(it.xmlTypeData) }, extensions = emptyMap())
+            1 -> XMLPattern(childTypeInfos.single().xmlTypeData.copy(attributes = attributePatterns))
+            else -> AnyPattern(pattern = childTypeInfos.map { XMLPattern(it.xmlTypeData.copy(attributes = attributePatterns)) }, extensions = emptyMap())
         }
         val types = childTypes.plus(specmaticTypeName to resolvedPattern)
 
@@ -71,7 +79,7 @@ data class ComplexElement(val wsdlTypeReference: String, val element: XMLNode, v
     }
 
     private fun eliminateAnnotationsAndAttributes(childNodes: List<XMLNode>) =
-        childNodes.filterNot { it.name == "annotation" || it.name == "attribute" }
+        childNodes.filterNot { it.name == "annotation" || it.name == "attribute" || it.name == "attributeGroup" }
 
     override fun getSOAPPayload(
         soapMessageType: SOAPMessageType,
@@ -96,9 +104,7 @@ data class ComplexType(val complexType: XMLNode, val wsdl: WSDL) {
     }
 
     fun getAttributes(): List<AttributeElement> {
-        return complexType.childNodes.filterIsInstance<XMLNode>().filter {
-            it.name == "attribute"
-        }.map { AttributeElement(it) }
+        return attributesFrom(complexType, wsdl)
     }
 }
 
@@ -117,7 +123,7 @@ internal fun generateChildren(
 }
 
 private fun eliminateAnnotationsAndAttributes(childNodes: List<XMLNode>) =
-    childNodes.filterNot { it.name == "annotation" || it.name == "attribute" }
+    childNodes.filterNot { it.name == "annotation" || it.name == "attribute" || it.name == "attributeGroup" }
 
 fun complexTypeChildNode(child: XMLNode, wsdl: WSDL, parentTypeName: String): ComplexTypeChild {
     return when (child.name) {

--- a/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/WSDLConversionTests.kt
@@ -616,7 +616,7 @@ class WSDLConversionTests {
                 Scenario: SimpleOperation
                     Given type SimpleOperation_SOAPPayload_Input
                     ""${'"'}
-                    <SPECMATIC_TYPE>
+                    <SPECMATIC_TYPE $optionalAttribute.opt="(number)">
                       <Id>(number)</Id>
                       <Name>(string)</Name>
                     </SPECMATIC_TYPE>
@@ -717,7 +717,7 @@ class WSDLConversionTests {
                 Scenario: SimpleOperation
                     Given type SimpleOperation_SOAPPayload_Input
                     ""${'"'}
-                    <SPECMATIC_TYPE>
+                    <SPECMATIC_TYPE $mandatoryAttribute="(number)">
                       <Id>(number)</Id>
                       <Name>(string)</Name>
                     </SPECMATIC_TYPE>

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/WSDLWiringCharacterizationTest.kt
@@ -3,6 +3,7 @@ package io.specmatic.core.wsdl.parser
 import io.specmatic.core.Resolver
 import io.specmatic.core.Result
 import io.specmatic.core.pattern.AnyPattern
+import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.XMLChoiceGroupPattern
 import io.specmatic.core.pattern.TYPE_ATTRIBUTE_NAME
 import io.specmatic.core.pattern.XMLPattern
@@ -15,6 +16,7 @@ import io.specmatic.core.wsdl.parser.message.OCCURS_ATTRIBUTE_NAME
 import io.specmatic.core.wsdl.parser.message.OPTIONAL_ATTRIBUTE_VALUE
 import io.specmatic.core.wsdl.payload.RequestHeaders
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -422,6 +424,78 @@ class WSDLWiringCharacterizationTest {
         assertThat(requestBody).contains("<ImportedPerson specmatic_type=\"ImportedPersonType\"/>")
     }
 
+    @Test
+    fun `attribute group wiring expands direct and nested groups into complex type attributes`() {
+        val wsdl = loadWsdl("src/test/resources/wsdl/attribute_group.wsdl")
+
+        val soapElement = wsdl.getSOAPElement(
+            FullyQualifiedName("tns", "http://example.com/attribute-group", "Person")
+        )
+
+        val typeInfo = soapElement.deriveSpecmaticTypes("PersonType", emptyMap(), emptySet())
+        val personPattern = typeInfo.types.getValue("PersonType") as XMLPattern
+
+        assertXmlAttribute(personPattern, "traceId", "(string)")
+        assertXmlAttribute(personPattern, "createdBy.opt", "(string)")
+        assertXmlAttribute(personPattern, "requestNumber.opt", "(number)")
+    }
+
+    @Test
+    fun `attribute group wiring expands groups on nested complex children`() {
+        val wsdl = loadWsdl("src/test/resources/wsdl/attribute_group.wsdl")
+
+        val soapElement = wsdl.getSOAPElement(
+            FullyQualifiedName("tns", "http://example.com/attribute-group", "Account")
+        )
+
+        val typeInfo = soapElement.deriveSpecmaticTypes("AccountType", emptyMap(), emptySet())
+        val ownerPattern = typeInfo.types.getValue("AccountType_Owner") as XMLPattern
+
+        assertXmlAttribute(ownerPattern, "traceId", "(string)")
+        assertXmlAttribute(ownerPattern, "createdBy.opt", "(string)")
+        assertXmlAttribute(ownerPattern, "requestNumber.opt", "(number)")
+    }
+
+    @Test
+    fun `attribute group wiring resolves groups from imported schemas`() {
+        val wsdl = loadWsdl("src/test/resources/wsdl/attribute_group_import.wsdl")
+
+        val soapElement = wsdl.getSOAPElement(
+            FullyQualifiedName("tns", "http://example.com/attribute-group-import", "ImportedPerson")
+        )
+
+        val typeInfo = soapElement.deriveSpecmaticTypes("ImportedPersonType", emptyMap(), emptySet())
+        val importedPersonPattern = typeInfo.types.getValue("ImportedPersonType") as XMLPattern
+
+        assertXmlAttribute(importedPersonPattern, "externalTrace", "(string)")
+        assertXmlAttribute(importedPersonPattern, "externalTenant.opt", "(string)")
+    }
+
+    @Test
+    fun `attribute group wiring rejects duplicate expanded attribute names`() {
+        val wsdl = loadWsdl("src/test/resources/wsdl/attribute_group.wsdl")
+        val soapElement = wsdl.getSOAPElement(
+            FullyQualifiedName("tns", "http://example.com/attribute-group", "DuplicatePerson")
+        )
+
+        assertThatThrownBy {
+            soapElement.deriveSpecmaticTypes("DuplicatePersonType", emptyMap(), emptySet())
+        }.hasMessageContaining("Duplicate attribute traceId")
+    }
+
+    @Test
+    fun `attribute group wiring ignores recursive groups`() {
+        val wsdl = loadWsdl("src/test/resources/wsdl/attribute_group.wsdl")
+        val soapElement = wsdl.getSOAPElement(
+            FullyQualifiedName("tns", "http://example.com/attribute-group", "RecursivePerson")
+        )
+
+        val typeInfo = soapElement.deriveSpecmaticTypes("RecursivePersonType", emptyMap(), emptySet())
+        val recursivePersonPattern = typeInfo.types.getValue("RecursivePersonType") as XMLPattern
+
+        assertXmlAttribute(recursivePersonPattern, "safe.opt", "(string)")
+    }
+
     private fun loadWsdl(path: String): WSDL {
         val wsdlFile = File(path)
         return WSDL(toXMLNode(wsdlFile.readText()), wsdlFile.canonicalPath)
@@ -442,5 +516,16 @@ class WSDLWiringCharacterizationTest {
             namespaces,
             typeInfo,
         ).specmaticStatement(RequestHeaders()).single()
+    }
+
+    private fun assertXmlAttribute(xmlPattern: XMLPattern, name: String, expectedPattern: String) {
+        val attributePattern = xmlPattern.pattern.attributes[name]
+
+        assertThat(attributePattern)
+            .withFailMessage("Expected XML attribute $name in ${xmlPattern.pattern.attributes.keys}")
+            .isInstanceOf(DeferredPattern::class.java)
+
+        attributePattern as DeferredPattern
+        assertThat(attributePattern.pattern).isEqualTo(expectedPattern)
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElementTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/parser/message/ComplexElementTest.kt
@@ -35,6 +35,9 @@ internal class ComplexElementTest {
             complexType2.generateChildren(any(), any(), any())
         } returns listOf(WSDLTypeInfo(listOf(toXMLNode("<data>(string)</data>"))))
         every {
+            complexType2.getAttributes()
+        } returns emptyList()
+        every {
             wsdl.getComplexTypeNode(element)
         } returns complexType2
 
@@ -73,6 +76,9 @@ internal class ComplexElementTest {
         every {
             complexType2.generateChildren(any(), any(), any())
         } returns listOf(WSDLTypeInfo(listOf(toXMLNode("<data>(string)</data>"))))
+        every {
+            complexType2.getAttributes()
+        } returns emptyList()
         every {
             wsdl.getComplexTypeNode(element)
         } returns complexType2

--- a/core/src/test/resources/wsdl/attribute_group.wsdl
+++ b/core/src/test/resources/wsdl/attribute_group.wsdl
@@ -1,0 +1,71 @@
+<definitions name="AttributeGroupRoutes"
+             targetNamespace="http://example.com/attribute-group"
+             xmlns:tns="http://example.com/attribute-group"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns="http://schemas.xmlsoap.org/wsdl/">
+    <types>
+        <xsd:schema targetNamespace="http://example.com/attribute-group" elementFormDefault="qualified">
+            <xsd:attributeGroup name="AuditAttrs">
+                <xsd:attribute name="createdBy" type="xsd:string"/>
+            </xsd:attributeGroup>
+
+            <xsd:attributeGroup name="CommonAttrs">
+                <xsd:attributeGroup ref="tns:AuditAttrs"/>
+                <xsd:attribute name="traceId" type="xsd:string" use="required"/>
+                <xsd:attribute name="requestNumber" type="xsd:int"/>
+            </xsd:attributeGroup>
+
+            <xsd:complexType name="PersonType">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string"/>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="tns:CommonAttrs"/>
+            </xsd:complexType>
+
+            <xsd:element name="Person" type="tns:PersonType"/>
+
+            <xsd:complexType name="AccountType">
+                <xsd:sequence>
+                    <xsd:element name="Owner">
+                        <xsd:complexType>
+                            <xsd:sequence>
+                                <xsd:element name="Name" type="xsd:string"/>
+                            </xsd:sequence>
+                            <xsd:attributeGroup ref="tns:CommonAttrs"/>
+                        </xsd:complexType>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:element name="Account" type="tns:AccountType"/>
+
+            <xsd:attributeGroup name="DuplicateAttrs">
+                <xsd:attribute name="traceId" type="xsd:string"/>
+                <xsd:attributeGroup ref="tns:CommonAttrs"/>
+            </xsd:attributeGroup>
+
+            <xsd:complexType name="DuplicatePersonType">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string"/>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="tns:DuplicateAttrs"/>
+            </xsd:complexType>
+
+            <xsd:element name="DuplicatePerson" type="tns:DuplicatePersonType"/>
+
+            <xsd:attributeGroup name="RecursiveAttrs">
+                <xsd:attribute name="safe" type="xsd:string"/>
+                <xsd:attributeGroup ref="tns:RecursiveAttrs"/>
+            </xsd:attributeGroup>
+
+            <xsd:complexType name="RecursivePersonType">
+                <xsd:sequence>
+                    <xsd:element name="Name" type="xsd:string"/>
+                </xsd:sequence>
+                <xsd:attributeGroup ref="tns:RecursiveAttrs"/>
+            </xsd:complexType>
+
+            <xsd:element name="RecursivePerson" type="tns:RecursivePersonType"/>
+        </xsd:schema>
+    </types>
+</definitions>

--- a/core/src/test/resources/wsdl/attribute_group_import.wsdl
+++ b/core/src/test/resources/wsdl/attribute_group_import.wsdl
@@ -1,0 +1,13 @@
+<definitions name="AttributeGroupImportRoutes"
+             targetNamespace="http://example.com/attribute-group-import"
+             xmlns:tns="http://example.com/attribute-group-import"
+             xmlns:imp="http://example.com/imported-attribute-group"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns="http://schemas.xmlsoap.org/wsdl/">
+    <types>
+        <xsd:schema targetNamespace="http://example.com/attribute-group-import">
+            <xsd:import schemaLocation="attribute_group_imported_types.xsd" namespace="http://example.com/imported-attribute-group"/>
+            <xsd:element name="ImportedPerson" type="imp:ImportedPersonType"/>
+        </xsd:schema>
+    </types>
+</definitions>

--- a/core/src/test/resources/wsdl/attribute_group_imported_types.xsd
+++ b/core/src/test/resources/wsdl/attribute_group_imported_types.xsd
@@ -1,0 +1,15 @@
+<schema targetNamespace="http://example.com/imported-attribute-group"
+        xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:imp="http://example.com/imported-attribute-group">
+    <attributeGroup name="ImportedAttrs">
+        <attribute name="externalTrace" type="string" use="required"/>
+        <attribute name="externalTenant" type="string"/>
+    </attributeGroup>
+
+    <complexType name="ImportedPersonType">
+        <sequence>
+            <element name="name" type="string"/>
+        </sequence>
+        <attributeGroup ref="imp:ImportedAttrs"/>
+    </complexType>
+</schema>


### PR DESCRIPTION
## Summary
- Added WSDL `attributeGroup` lookup and recursive expansion into complex type attributes.
- Wired expanded attributes into complex type pattern generation, including nested and imported schema references.
- Added characterization coverage for direct groups, nested groups, duplicate attribute detection, and recursive group handling.
- Updated WSDL conversion expectations to reflect generated attributes on complex types.

## What
- Resolve `attributeGroup` definitions from the relevant schema and expand them into `AttributeElement` values.
- Include expanded attributes when assembling XML patterns for complex types.
- Keep recursive group references from looping indefinitely by skipping already-seen groups.
- Add targeted WSDL fixtures for local, imported, duplicate, and recursive attribute group cases.

## Why
- Specmatic previously handled attributes directly on complex types, but not reusable `attributeGroup` references.
- This change allows WSDL/XSD schemas that factor attributes into shared groups to be parsed and represented correctly.

## How
- Added `WSDL.findAttributeGroup(...)` for schema-scoped group lookup.
- Expanded attributes from both direct `<attribute>` nodes and nested `<attributeGroup ref=...>` nodes.
- Applied the expanded attribute map when constructing `XMLPattern` instances.
- Added helper-based assertions in tests so attribute presence is checked directly rather than by string matching.
