### PR TITLE
Add SOAP response header support for WSDL

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/SOAP11Parser.kt
@@ -25,6 +25,21 @@ private data class QualifiedMessageName(
     val nodeName: String,
 )
 
+private data class SOAPHeadersInfo(
+    val headers: RequestHeaders,
+    val types: Map<String, Pattern>,
+)
+
+private data class SOAPHeaderAccumulator(
+    val headers: List<RequestHeaders.Header>,
+    val types: Map<String, Pattern>,
+)
+
+private data class SOAPHeaderInfo(
+    val header: RequestHeaders.Header,
+    val types: Map<String, Pattern>,
+)
+
 class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
     override fun convertToGherkin(url: String): String {
         val operationsTypeInfo = operationsTypeInfo(url)
@@ -56,10 +71,15 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
         }
     }
 
-    private fun headerRequired(portType: XMLNode, operationName: String, bindingPartName: String): NodeOccurrence? {
+    private fun headerRequired(
+        portType: XMLNode,
+        operationName: String,
+        soapMessageType: SOAPMessageType,
+        bindingPartName: String
+    ): NodeOccurrence? {
         val portOperation = portType.findByNodeNameAndAttributeOrNull("operation", "name", operationName) ?: return null
-        val portInput = portOperation.findFirstChildByName("input") ?: return null
-        val portHeader = portInput.findByNodeNameAndAttributeOrNull("header", "part", bindingPartName) ?: return null
+        val portMessage = portOperation.findFirstChildByName(soapMessageType.messageTypeName) ?: return null
+        val portHeader = portMessage.findByNodeNameAndAttributeOrNull("header", "part", bindingPartName) ?: return null
         return when (portHeader.attributes["required"]?.toStringLiteral()) {
             "true" -> NodeOccurrence.Once
             "false" -> NodeOccurrence.Optional
@@ -98,57 +118,154 @@ class SOAP11Parser(private val wsdl: WSDL): SOAPParser {
 
         val path = URI(url).path
 
-        val soapHeaders = bindingOperationNode
-            .findFirstChildByName("input")
-            ?.findChildrenByName("header")
-            .orEmpty()
+        val requestHeadersInfo = parseSoapHeaders(
+            bindingOperationNode = bindingOperationNode,
+            portType = portType,
+            operationName = operationName,
+            soapMessageType = SOAPMessageType.Input,
+            existingTypes = responseTypeInfo.types
+        )
 
-        val requestHeaders: Map<String, RequestHeaders.HeaderDetails> =
-            soapHeaders
-                .mapNotNull { soapHeader ->
-                    try {
-                        val bindingMessageRef = soapHeader.attributes["message"]?.toStringLiteral() ?: return@mapNotNull null
-                        val bindingPartName = soapHeader.attributes["part"]?.toStringLiteral() ?: return@mapNotNull null
-                        val bindingNamespace = soapHeader.attributes["namespace"]?.toStringLiteral()
-                            ?: soapHeader.resolveNamespace(bindingMessageRef)
-                        val bindingOccurrence = soapHeader.attributes["minOccurs"]?.toStringLiteral().let {
-                            when (it) {
-                                "0" -> NodeOccurrence.Optional
-                                "1" -> NodeOccurrence.Once
-                                null -> null
-                                else -> {
-                                    if (it.toIntOrNull() != null) NodeOccurrence.Multiple else null
-                                }
-                            }
-                        }
-
-                        val headerRequired = headerRequired(portType, operationName, bindingPartName)
-
-                        val messageName = bindingMessageRef.substringAfter(":")
-                        val prefix = bindingMessageRef.substringBefore(":")
-                        val messageNode = wsdl.findMessageNode(FullyQualifiedName(prefix, bindingNamespace, messageName))
-
-                        val partNode = messageNode.findByNodeNameAndAttribute("part", "name", bindingPartName)
-
-                        val type = elementTypeValue(partNode)
-
-                        val occurrence = bindingOccurrence ?: headerRequired ?: NodeOccurrence.Once
-
-                        bindingPartName to RequestHeaders.HeaderDetails(type.toStringLiteral(), occurrence)
-                    } catch (e: Throwable) {
-                        throw e
-                    }
-                }.toMap()
+        val responseHeadersInfo = parseSoapHeaders(
+            bindingOperationNode = bindingOperationNode,
+            portType = portType,
+            operationName = operationName,
+            soapMessageType = SOAPMessageType.Output,
+            existingTypes = requestHeadersInfo.types
+        )
 
         return SOAPOperationTypeInfo(
             path = path,
             operationName = operationName,
             soapAction = soapAction,
             soapVersion = soapVersion,
-            types = responseTypeInfo.types.mapKeys { it.key.trim() },
+            types = responseHeadersInfo.types.mapKeys { it.key.trim() },
             requestPayload = requestTypeInfo.soapPayload,
-            requestHeaders = RequestHeaders(requestHeaders),
-            responsePayload = responseTypeInfo.soapPayload
+            requestHeaders = requestHeadersInfo.headers,
+            responsePayload = responseTypeInfo.soapPayload,
+            responseHeaders = responseHeadersInfo.headers
+        )
+    }
+
+    private fun parseSoapHeaders(
+        bindingOperationNode: XMLNode,
+        portType: XMLNode,
+        operationName: String,
+        soapMessageType: SOAPMessageType,
+        existingTypes: Map<String, Pattern>
+    ): SOAPHeadersInfo {
+        val soapHeaders = bindingOperationNode
+            .findFirstChildByName(soapMessageType.messageTypeName)
+            ?.findChildrenByName("header")
+            .orEmpty()
+
+        val parsedHeaders = soapHeaders.fold(SOAPHeaderAccumulator(emptyList(), existingTypes)) { accumulator, soapHeader ->
+            val parsedHeader = parseSoapHeader(
+                soapHeader = soapHeader,
+                portType = portType,
+                operationName = operationName,
+                soapMessageType = soapMessageType,
+                existingTypes = accumulator.types
+            )
+
+            accumulator.copy(
+                headers = accumulator.headers.plus(parsedHeader.header),
+                types = parsedHeader.types
+            )
+        }
+
+        return SOAPHeadersInfo(
+            headers = RequestHeaders.fromHeaders(parsedHeaders.headers),
+            types = parsedHeaders.types
+        )
+    }
+
+    private fun parseSoapHeader(
+        soapHeader: XMLNode,
+        portType: XMLNode,
+        operationName: String,
+        soapMessageType: SOAPMessageType,
+        existingTypes: Map<String, Pattern>
+    ): SOAPHeaderInfo {
+        val bindingMessageRef = soapHeader.attributes["message"]?.toStringLiteral()
+            ?: throw ContractException("SOAP header in operation $operationName does not have a message attribute.")
+        val bindingPartName = soapHeader.attributes["part"]?.toStringLiteral()
+            ?: throw ContractException("SOAP header in operation $operationName does not have a part attribute.")
+        val bindingNamespace = soapHeader.attributes["namespace"]?.toStringLiteral()
+            ?: soapHeader.resolveNamespace(bindingMessageRef)
+        val bindingOccurrence = bindingOccurrence(soapHeader)
+        val headerRequired = headerRequired(portType, operationName, soapMessageType, bindingPartName)
+        val occurrence = bindingOccurrence ?: headerRequired ?: NodeOccurrence.Once
+
+        val messageName = bindingMessageRef.substringAfter(":")
+        val prefix = bindingMessageRef.substringBefore(":")
+        val messageNode = wsdl.findMessageNode(FullyQualifiedName(prefix, bindingNamespace, messageName))
+        val partNode = messageNode.findByNodeNameAndAttribute("part", "name", bindingPartName)
+
+        return when {
+            partNode.attributes.containsKey("element") -> parseElementReferencedHeader(
+                partNode = partNode,
+                bindingPartName = bindingPartName,
+                soapMessageType = soapMessageType,
+                operationName = operationName,
+                existingTypes = existingTypes,
+                occurrence = occurrence
+            )
+            partNode.attributes.containsKey("type") -> parseTypeReferencedHeader(
+                partNode = partNode,
+                bindingPartName = bindingPartName,
+                occurrence = occurrence,
+                existingTypes = existingTypes
+            )
+            else -> throw ContractException(
+                "Part node $bindingPartName of SOAP header message $messageName should contain either an element attribute or a type attribute."
+            )
+        }
+    }
+
+    private fun bindingOccurrence(soapHeader: XMLNode): NodeOccurrence? {
+        return soapHeader.attributes["minOccurs"]?.toStringLiteral().let {
+            when (it) {
+                "0" -> NodeOccurrence.Optional
+                "1" -> NodeOccurrence.Once
+                null -> null
+                else -> {
+                    if (it.toIntOrNull() != null) NodeOccurrence.Multiple else null
+                }
+            }
+        }
+    }
+
+    private fun parseTypeReferencedHeader(
+        partNode: XMLNode,
+        bindingPartName: String,
+        occurrence: NodeOccurrence,
+        existingTypes: Map<String, Pattern>
+    ): SOAPHeaderInfo {
+        val type = elementTypeValue(partNode)
+        val header = RequestHeaders.primitiveHeader(bindingPartName, type.toStringLiteral(), occurrence)
+        return SOAPHeaderInfo(header = header, types = existingTypes)
+    }
+
+    private fun parseElementReferencedHeader(
+        partNode: XMLNode,
+        bindingPartName: String,
+        soapMessageType: SOAPMessageType,
+        operationName: String,
+        existingTypes: Map<String, Pattern>,
+        occurrence: NodeOccurrence
+    ): SOAPHeaderInfo {
+        val fullyQualifiedName = partNode.fullyQualifiedNameFromAttribute("element")
+        val topLevelElement = wsdl.getSOAPElement(fullyQualifiedName)
+        val specmaticTypeName =
+            "${operationName.replace(":", "_")}_SOAPHeader_${soapMessageType.messageTypeName.capitalizeFirstChar()}_$bindingPartName"
+        val typeInfo = topLevelElement.deriveSpecmaticTypes(specmaticTypeName, existingTypes, emptySet())
+        val headerNode = RequestHeaders.withOccurrence(typeInfo.nodes.first() as XMLNode, occurrence)
+        val namespaces = wsdl.getNamespaces(typeInfo)
+
+        return SOAPHeaderInfo(
+            header = RequestHeaders.Header(headerNode, namespaces),
+            types = typeInfo.types
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfo.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPOperationTypeInfo.kt
@@ -26,8 +26,15 @@ data class SOAPOperationTypeInfo(val operationName: String, val soapVersion: SOA
         types: Map<String, Pattern>,
         requestPayload: SOAPPayload,
         requestHeaders: RequestHeaders,
-        responsePayload: SOAPPayload
-    ) : this(operationName, soapVersion = soapVersion, SOAPRequest(path, operationName, soapAction, requestHeaders, requestPayload), SOAPResponse(responsePayload), SOAPTypes(types))
+        responsePayload: SOAPPayload,
+        responseHeaders: RequestHeaders = RequestHeaders()
+    ) : this(
+        operationName,
+        soapVersion = soapVersion,
+        request = SOAPRequest(path, operationName, soapAction, requestHeaders, requestPayload),
+        response = SOAPResponse(responsePayload, responseHeaders),
+        types = SOAPTypes(types)
+    )
 
     fun expandedVariants(): List<SOAPOperationTypeInfo> {
         return types.expandedVariants().map { expandedTypes ->
@@ -70,7 +77,7 @@ data class SOAPOperationTypeInfo(val operationName: String, val soapVersion: SOA
                 headersPattern = HttpHeadersPattern(
                     contentType = soapVersion.header(response.responsePayload),
                 ),
-                body = response.responsePayload.toPattern(RequestHeaders()),
+                body = response.responsePayload.toPattern(response.responseHeaders),
             ),
             patterns = types.types.mapKeys { (typeName, _) -> withPatternDelimiters(typeName) },
             isGherkinScenario = false,

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPResponse.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/parser/operation/SOAPResponse.kt
@@ -3,10 +3,10 @@ package io.specmatic.core.wsdl.parser.operation
 import io.specmatic.core.wsdl.payload.RequestHeaders
 import io.specmatic.core.wsdl.payload.SOAPPayload
 
-data class SOAPResponse(val responsePayload: SOAPPayload) {
+data class SOAPResponse(val responsePayload: SOAPPayload, val responseHeaders: RequestHeaders = RequestHeaders()) {
     fun statements(): List<String> {
         val statusStatement = listOf("Then status 200")
-        val responseBodyStatement = responsePayload.specmaticStatement(RequestHeaders())
+        val responseBodyStatement = responsePayload.specmaticStatement(responseHeaders)
         return statusStatement.plus(responseBodyStatement)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/ComplexTypedSOAPPayload.kt
@@ -15,18 +15,18 @@ data class ComplexTypedSOAPPayload(
     val namespaces: Map<String, String>,
     val attributes: List<AttributeElement> = emptyList()
 ) : SOAPPayload {
-    override fun specmaticStatement(requestHeaders: RequestHeaders): List<String> {
-        val body = toEnvelope(requestHeaders)
+    override fun specmaticStatement(headers: RequestHeaders): List<String> {
+        val body = toEnvelope(headers)
         return listOf("And ${soapMessageType.specmaticBodyType}-body\n\"\"\"\n${body.toPrettyStringValue()}\n\"\"\"")
     }
 
-    override fun toPattern(requestHeaders: RequestHeaders): Pattern {
-        return XMLPattern(toEnvelope(requestHeaders), isSOAP = true)
+    override fun toPattern(headers: RequestHeaders): Pattern {
+        return XMLPattern(toEnvelope(headers), isSOAP = true)
     }
 
-    private fun toEnvelope(requestHeaders: RequestHeaders): XMLNode {
+    private fun toEnvelope(headers: RequestHeaders): XMLNode {
         val xml = buildXmlDataForComplexElement(nodeName, specmaticTypeName, attributes)
-        return soapMessage(toXMLNode(xml), namespaces, requestHeaders)
+        return soapMessage(toXMLNode(xml), namespaces, headers)
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/EmptyHTTPBodyPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/EmptyHTTPBodyPayload.kt
@@ -4,11 +4,11 @@ import io.specmatic.core.pattern.EmptyStringPattern
 import io.specmatic.core.pattern.Pattern
 
 class EmptyHTTPBodyPayload : SOAPPayload {
-    override fun specmaticStatement(requestHeaders: RequestHeaders): List<String> {
+    override fun specmaticStatement(headers: RequestHeaders): List<String> {
         return emptyList()
     }
 
-    override fun toPattern(requestHeaders: RequestHeaders): Pattern {
+    override fun toPattern(headers: RequestHeaders): Pattern {
         return EmptyStringPattern
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/EmptySOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/EmptySOAPPayload.kt
@@ -7,12 +7,12 @@ import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.SOAPMessageType
 
 data class EmptySOAPPayload(private val soapMessageType: SOAPMessageType): SOAPPayload {
-    override fun specmaticStatement(requestHeaders: RequestHeaders): List<String> {
+    override fun specmaticStatement(headers: RequestHeaders): List<String> {
         val body = emptySoapMessage()
         return listOf("And ${soapMessageType.specmaticBodyType}-body\n\"\"\"\n$body\n\"\"\"")
     }
 
-    override fun toPattern(requestHeaders: RequestHeaders): Pattern {
+    override fun toPattern(headers: RequestHeaders): Pattern {
         return XMLPattern(emptySoapMessage(), isSOAP = true)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/RequestHeaders.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/RequestHeaders.kt
@@ -1,6 +1,7 @@
 package io.specmatic.core.wsdl.payload
 
 import io.specmatic.core.pattern.NodeOccurrence
+import io.specmatic.core.value.StringValue
 import io.specmatic.core.value.XMLNode
 import io.specmatic.core.value.toXMLNode
 import io.specmatic.core.wsdl.parser.message.MULTIPLE_ATTRIBUTE_VALUE
@@ -9,31 +10,52 @@ import io.specmatic.core.wsdl.parser.message.OPTIONAL_ATTRIBUTE_VALUE
 
 private const val HEADER_NODE_NAME = "soapenv:Header"
 
-class RequestHeaders(
-    private val headers: Map<String, HeaderDetails> = emptyMap()
+class RequestHeaders private constructor(
+    private val headers: List<Header>
 ) {
     data class HeaderDetails(
         val type: String,
         val occurrence: NodeOccurrence,
     )
 
+    data class Header(
+        val node: XMLNode,
+        val namespaces: Map<String, String> = emptyMap(),
+    )
+
+    constructor(headers: Map<String, HeaderDetails> = emptyMap()) : this(
+        headers.map { entry ->
+            primitiveHeader(entry.key, entry.value.type, entry.value.occurrence)
+        }
+    )
+
+    val namespaces: Map<String, String>
+        get() = headers.fold(emptyMap()) { namespaces, header ->
+            namespaces.plus(header.namespaces)
+        }
+
     fun toHeaderNode(): XMLNode? {
         if (headers.isEmpty()) return null
 
-        val headerChildNode =
-            headers.entries.joinToString("") { (key, details) ->
-                val (headerType, occurrence) = details
+        return toXMLNode("<$HEADER_NODE_NAME/>").copy(childNodes = headers.map { it.node })
+    }
 
-                val occurrenceClause =
-                    when (occurrence) {
-                        NodeOccurrence.Optional -> " $OCCURS_ATTRIBUTE_NAME=\"$OPTIONAL_ATTRIBUTE_VALUE\""
-                        NodeOccurrence.Multiple -> " $OCCURS_ATTRIBUTE_NAME=\"$MULTIPLE_ATTRIBUTE_VALUE\""
-                        else -> ""
-                    }
+    companion object {
+        fun fromHeaders(headers: List<Header>): RequestHeaders = RequestHeaders(headers)
 
-                "<$key$occurrenceClause>$headerType</$key>"
-            }
+        fun primitiveHeader(name: String, type: String, occurrence: NodeOccurrence): Header {
+            return Header(withOccurrence(toXMLNode("<$name>$type</$name>"), occurrence))
+        }
 
-        return toXMLNode("<$HEADER_NODE_NAME>$headerChildNode</$HEADER_NODE_NAME>")
+        fun withOccurrence(node: XMLNode, occurrence: NodeOccurrence): XMLNode {
+            return node.copy(attributes = node.attributes.plus(occurrenceAttributes(occurrence)))
+        }
+
+        private fun occurrenceAttributes(occurrence: NodeOccurrence) =
+            when (occurrence) {
+                NodeOccurrence.Optional -> mapOf(OCCURS_ATTRIBUTE_NAME to OPTIONAL_ATTRIBUTE_VALUE)
+                NodeOccurrence.Multiple -> mapOf(OCCURS_ATTRIBUTE_NAME to MULTIPLE_ATTRIBUTE_VALUE)
+                else -> emptyMap()
+            }.mapValues { (_, value) -> StringValue(value) }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SOAPPayload.kt
@@ -3,6 +3,6 @@ package io.specmatic.core.wsdl.payload
 import io.specmatic.core.pattern.Pattern
 
 interface SOAPPayload {
-    fun specmaticStatement(requestHeaders: RequestHeaders): List<String>
-    fun toPattern(requestHeaders: RequestHeaders): Pattern
+    fun specmaticStatement(headers: RequestHeaders): List<String>
+    fun toPattern(headers: RequestHeaders): Pattern
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SimpleTypedSOAPPayload.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SimpleTypedSOAPPayload.kt
@@ -7,12 +7,12 @@ import io.specmatic.core.wsdl.parser.SOAPMessageType
 
 data class SimpleTypedSOAPPayload(val soapMessageType: SOAPMessageType, val node: XMLNode, val namespaces: Map<String, String>) :
     SOAPPayload {
-    override fun specmaticStatement(requestHeaders: RequestHeaders): List<String> {
-        val body = soapMessage(node, namespaces, requestHeaders)
+    override fun specmaticStatement(headers: RequestHeaders): List<String> {
+        val body = soapMessage(node, namespaces, headers)
         return listOf("And ${soapMessageType.specmaticBodyType}-body\n\"\"\"\n$body\n\"\"\"")
     }
 
-    override fun toPattern(requestHeaders: RequestHeaders): Pattern {
-        return XMLPattern(soapMessage(node, namespaces, requestHeaders), isSOAP = true)
+    override fun toPattern(headers: RequestHeaders): Pattern {
+        return XMLPattern(soapMessage(node, namespaces, headers), isSOAP = true)
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SoapMessage.kt
+++ b/core/src/main/kotlin/io/specmatic/core/wsdl/payload/SoapMessage.kt
@@ -6,10 +6,10 @@ import io.specmatic.core.wsdl.parser.message.OCCURS_ATTRIBUTE_NAME
 import io.specmatic.core.wsdl.parser.message.OPTIONAL_ATTRIBUTE_VALUE
 import io.specmatic.core.wsdl.parser.message.primitiveNamespace
 
-fun soapMessage(bodyPayload: XMLNode, namespaces: Map<String, String>, requestHeaders: RequestHeaders): XMLNode {
-    val payload = soapSkeleton(namespaces)
+fun soapMessage(bodyPayload: XMLNode, namespaces: Map<String, String>, headers: RequestHeaders): XMLNode {
+    val payload = soapSkeleton(namespaces.plus(headers.namespaces))
 
-    val headerNode: XMLNode? = requestHeaders.toHeaderNode()
+    val headerNode: XMLNode? = headers.toHeaderNode()
 
     val bodyNode: XMLNode = toXMLNode("<soapenv:Body/>").let {
         it.copy(childNodes = it.childNodes.plus(bodyPayload))

--- a/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/wsdl/WSDLParserContractBlackBoxTest.kt
@@ -5,6 +5,9 @@ import io.specmatic.core.CONTENT_TYPE
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.HttpResponse
 import io.specmatic.core.parseContractFileToFeature
+import io.specmatic.core.pattern.parsedValue
+import io.specmatic.core.value.toXMLNode
+import io.specmatic.core.wsdl.parser.WSDL
 import io.specmatic.core.wsdl.payload.emptySoapMessage
 import io.specmatic.stub.HttpStub
 import io.specmatic.test.TestExecutor
@@ -332,6 +335,85 @@ class WSDLParserContractBlackBoxTest {
 
         assertThat(result.success()).withFailMessage(result.report()).isTrue()
         assertThat(result.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `contract test for wsdl element backed header parts supports response soap header`() {
+        val feature = parseContractFileToFeature(File("src/test/resources/wsdl/state_machine/response_header_part.wsdl"))
+        val responseWithSoapHeader = HttpResponse(
+            200,
+            body = parsedValue(
+                """
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://specmatic.io/response-header-part" xmlns:rh="http://specmatic.io/response-header-part/headers">
+                    <soapenv:Header>
+                        <rh:ResponseHeader>
+                            <rh:Headers>tracking-id</rh:Headers>
+                        </rh:ResponseHeader>
+                    </soapenv:Header>
+                    <soapenv:Body>
+                        <tns:HeaderPartResponse>done</tns:HeaderPartResponse>
+                    </soapenv:Body>
+                </soapenv:Envelope>
+                """.trimIndent()
+            )
+        )
+
+        val result = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                assertThat(request.path).isEqualTo("/response-header-part")
+                assertThat(request.body.toStringLiteral())
+                    .contains("soapenv:Header")
+                    .contains("ClientHeader")
+                    .contains("ClientId")
+                    .contains("soapenv:Body")
+                    .contains("HeaderPartRequest")
+                return responseWithSoapHeader
+            }
+        })
+
+        assertThat(result.success()).withFailMessage(result.report()).isTrue()
+        assertThat(result.successCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `contract test fails when mandatory wsdl response soap header is missing`() {
+        val feature = parseContractFileToFeature(File("src/test/resources/wsdl/state_machine/response_header_part.wsdl"))
+        val responseWithoutSoapHeader = HttpResponse(
+            200,
+            body = parsedValue(
+                """
+                <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://specmatic.io/response-header-part">
+                    <soapenv:Body>
+                        <tns:HeaderPartResponse>done</tns:HeaderPartResponse>
+                    </soapenv:Body>
+                </soapenv:Envelope>
+                """.trimIndent()
+            )
+        )
+
+        val result = feature.executeTests(object : TestExecutor {
+            override fun execute(request: HttpRequest): HttpResponse {
+                return responseWithoutSoapHeader
+            }
+        })
+
+        assertThat(result.success()).isFalse()
+        assertThat(result.failureCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `wsdl gherkin generation includes response soap header part`() {
+        val wsdlPath = "src/test/resources/wsdl/state_machine/response_header_part.wsdl"
+        val wsdl = WSDL(toXMLNode(File(wsdlPath).readText()), wsdlPath)
+
+        val gherkin = wsdl.convertToGherkin()
+
+        assertThat(gherkin)
+            .contains("And response-body")
+            .contains("soapenv:Header")
+            .contains("ResponseHeader")
+            .contains("Headers")
+            .contains("HeaderPartResponse")
     }
 
     private fun scalarRequestBranch(body: String): String {

--- a/core/src/test/resources/wsdl/state_machine/response_header_part.wsdl
+++ b/core/src/test/resources/wsdl/state_machine/response_header_part.wsdl
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:tns="http://specmatic.io/response-header-part"
+    xmlns:rh="http://specmatic.io/response-header-part/headers"
+    targetNamespace="http://specmatic.io/response-header-part">
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://specmatic.io/response-header-part" elementFormDefault="qualified">
+            <xsd:element name="HeaderPartRequest" type="xsd:string"/>
+            <xsd:element name="HeaderPartResponse" type="xsd:string"/>
+        </xsd:schema>
+
+        <xsd:schema targetNamespace="http://specmatic.io/response-header-part/headers" elementFormDefault="qualified">
+            <xsd:element name="ClientHeader" type="rh:ClientHeaderType"/>
+            <xsd:complexType name="ClientHeaderType">
+                <xsd:sequence>
+                    <xsd:element name="ClientId" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+
+            <xsd:element name="ResponseHeader" type="rh:ResponseHeaderType"/>
+            <xsd:complexType name="ResponseHeaderType">
+                <xsd:sequence>
+                    <xsd:element name="Headers" minOccurs="0" maxOccurs="unbounded" type="xsd:string"/>
+                </xsd:sequence>
+            </xsd:complexType>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="HeaderPartRequestMessage">
+        <wsdl:part name="payload" element="tns:HeaderPartRequest"/>
+    </wsdl:message>
+
+    <wsdl:message name="HeaderPartResponseMessage">
+        <wsdl:part name="payload" element="tns:HeaderPartResponse"/>
+    </wsdl:message>
+
+    <wsdl:message name="ClientHeaderMessage">
+        <wsdl:part name="ClientHeader" element="rh:ClientHeader"/>
+    </wsdl:message>
+
+    <wsdl:message name="ResponseHeaderMessage">
+        <wsdl:part name="ResponseHeader" element="rh:ResponseHeader"/>
+    </wsdl:message>
+
+    <wsdl:portType name="ResponseHeaderPartPortType">
+        <wsdl:operation name="ResponseHeaderPartOperation">
+            <wsdl:input message="tns:HeaderPartRequestMessage"/>
+            <wsdl:output message="tns:HeaderPartResponseMessage"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="ResponseHeaderPartBinding" type="tns:ResponseHeaderPartPortType">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="ResponseHeaderPartOperation">
+            <soap:operation soapAction="/response-header-part/operation"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+                <soap:header message="tns:ClientHeaderMessage" part="ClientHeader" use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+                <soap:header message="tns:ResponseHeaderMessage" part="ResponseHeader" use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="ResponseHeaderPartService">
+        <wsdl:port name="ResponseHeaderPartPort" binding="tns:ResponseHeaderPartBinding">
+            <soap:address location="http://specmatic.io/response-header-part"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
## What
- Parse `soap:header` entries from WSDL responses, not just requests.
- Carry SOAP header namespaces through envelope generation so element-backed headers render correctly.
- Add coverage for both the success case and the missing-mandatory-header failure case.

## Why
- WSDLs can declare SOAP headers on both `input` and `output`.
- Response headers were previously ignored, which made generated scenarios and contract validation incomplete for services that return SOAP headers.

## How
- Extend `SOAP11Parser` to parse headers for both `SOAPMessageType.Input` and `SOAPMessageType.Output`.
- Represent SOAP headers as ordered XML nodes so response headers can be emitted in the envelope.
- Thread response headers through `SOAPResponse` and `SOAPOperationTypeInfo` so generated patterns include them.
- Update the shared SOAP payload API to use neutral `headers` naming since the same path is used for request and response.
- Add a WSDL fixture modeled on a response-header binding and black-box tests for:
  - response header generation
  - missing mandatory response header failure
  - Gherkin generation including the response header
