### PR TITLE
chore: pass before and after fixture execution details to CtrfTestMetadata in ctrf report

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ContractTest.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.Result
 import io.specmatic.core.Scenario
 import io.specmatic.core.filters.HasScenarioMetadata
 import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.ctrf.model.FixtureExecutionResult
 import io.specmatic.reporter.model.SpecType
 
 interface ResponseValidator {
@@ -39,5 +40,13 @@ interface ContractTest : HasScenarioMetadata {
 data class ContractTestExecutionResult(
     val result: Result,
     val request: HttpRequest? = null,
-    val response: HttpResponse? = null
+    val response: HttpResponse? = null,
+    val beforeFixtureExecutionResult: List<FixtureExecutionResult>? = null,
+    val afterFixtureExecutionResult: List<FixtureExecutionResult>? = null
 )
+
+data class FixtureExecutionDetails(
+    val combinedResult: Result,
+    val fixtureExecutionResults: List<FixtureExecutionResult>? = null
+)
+

--- a/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
+++ b/core/src/main/kotlin/io/specmatic/test/ScenarioAsTest.kt
@@ -58,7 +58,7 @@ data class ScenarioAsTest(
     override fun toScenarioMetadata() = scenario.toScenarioMetadata()
 
     override fun testResultRecord(executionResult: ContractTestExecutionResult): TestResultRecord {
-        val (result, request, response) = executionResult
+        val (result, request, response,beforeFixtureExecutionResult, afterFixtureExecutionResult) = executionResult
         val scenario = result.scenario as? Scenario ?: updateBasedOnResponseIfNegativeGeneration(scenario, response)
         val path = convertPathParameterStyle(scenario.path)
 
@@ -91,7 +91,9 @@ data class ScenarioAsTest(
             isResponseInSpecification = response?.let {
                 if (result.isSuccess() || scenario.matchesStatusAndContentType(it)) return@let true
                 feature.isResponsePossible(scenario, it)
-            }
+            },
+            beforeFixtureExecutionResult = beforeFixtureExecutionResult,
+            afterFixtureExecutionResult = afterFixtureExecutionResult
         )
     }
 
@@ -142,8 +144,11 @@ data class ScenarioAsTest(
     ): ContractTestExecutionResult {
         try {
             val beforeFixtureExecutionResult = fixtureExecutionResult(BEFORE_FIXTURE_DISCRIMINATOR_KEY)
-            if (beforeFixtureExecutionResult.isSuccess().not()) {
-                return ContractTestExecutionResult(result = beforeFixtureExecutionResult.updateScenario(testScenario))
+            if (beforeFixtureExecutionResult.combinedResult.isSuccess().not()) {
+                return ContractTestExecutionResult(
+                    result = beforeFixtureExecutionResult.combinedResult.updateScenario(testScenario),
+                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
+                )
             }
             val request = testScenario.generateHttpRequest(flagsBased).let {
                 workflow.updateRequest(it, originalScenario).adjustPayloadForContentType()
@@ -166,7 +171,8 @@ data class ScenarioAsTest(
                         return ContractTestExecutionResult(
                             result = matchesResult.withBindings(testScenario.bindings, response),
                             request = request,
-                            response = response
+                            response = response,
+                            beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
                         )
                     }
                 }
@@ -180,7 +186,8 @@ data class ScenarioAsTest(
                 return ContractTestExecutionResult(
                     result = validatorResult.withBindings(testScenario.bindings, response),
                     request = request,
-                    response = response
+                    response = response,
+                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
                 )
             }
 
@@ -190,7 +197,8 @@ data class ScenarioAsTest(
                 return ContractTestExecutionResult(
                     result = testResult.withBindings(testScenario.bindings, response),
                     request = request,
-                    response = response
+                    response = response,
+                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
                 )
             }
 
@@ -205,7 +213,8 @@ data class ScenarioAsTest(
                             return ContractTestExecutionResult(
                                 result = handlerResult.result.withBindings(testScenario.bindings, bindingResponse),
                                 request = request,
-                                response = bindingResponse
+                                response = bindingResponse,
+                                beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
                             )
                         }
                     }
@@ -220,18 +229,24 @@ data class ScenarioAsTest(
 
             if(result !is Result.Failure) {
                 val afterFixtureExecutionResult = fixtureExecutionResult(AFTER_FIXTURE_DISCRIMINATOR_KEY)
-                if (afterFixtureExecutionResult.isSuccess().not()) {
-                    return ContractTestExecutionResult(
-                        result = afterFixtureExecutionResult.withBindings(testScenario.bindings, response),
-                        request = request,
-                        response = response
-                    )
+
+                val contractTestResult = when {
+                    afterFixtureExecutionResult.combinedResult.isSuccess().not() -> afterFixtureExecutionResult.combinedResult
+                    else -> result
                 }
+                return ContractTestExecutionResult(
+                    result = contractTestResult.withBindings(testScenario.bindings, response),
+                    request = request,
+                    response = response,
+                    beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults,
+                    afterFixtureExecutionResult = afterFixtureExecutionResult.fixtureExecutionResults
+                )
             }
             return ContractTestExecutionResult(
                 result = result.withBindings(testScenario.bindings, response),
                 request = request,
-                response = response
+                response = response,
+                beforeFixtureExecutionResult = beforeFixtureExecutionResult.fixtureExecutionResults
             )
         } catch (exception: Throwable) {
             return ContractTestExecutionResult(
@@ -258,10 +273,10 @@ data class ScenarioAsTest(
         }
     }
 
-    private fun fixtureExecutionResult(fixtureDiscriminatorKey: String): Result {
-        if (scenario.isNegative) return Result.Success()
-        val row = scenario.exampleRow ?: return Result.Success()
-        val scenarioStub = row.scenarioStub ?: return Result.Success()
+    private fun fixtureExecutionResult(fixtureDiscriminatorKey: String): FixtureExecutionDetails {
+        if (scenario.isNegative) return FixtureExecutionDetails(Result.Success())
+        val row = scenario.exampleRow ?: return FixtureExecutionDetails(Result.Success())
+        val scenarioStub = row.scenarioStub ?: return FixtureExecutionDetails(Result.Success())
         val id = scenarioStub.id.orEmpty()
         val fixtures = when (fixtureDiscriminatorKey) {
             BEFORE_FIXTURE_DISCRIMINATOR_KEY -> scenarioStub.beforeFixtures
@@ -269,7 +284,7 @@ data class ScenarioAsTest(
         }
 
         return ServiceLoader.load(OpenAPIFixtureExecutor::class.java)
-            .firstOrNull()?.execute(id, fixtures, fixtureDiscriminatorKey) ?: Result.Success()
+            .firstOrNull()?.execute(id, fixtures, fixtureDiscriminatorKey) ?: FixtureExecutionDetails(Result.Success())
     }
 
     private fun testResult(

--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -14,6 +14,7 @@ import io.specmatic.reporter.ctrf.model.CtrfTestOutput
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.ctrf.model.CtrfTestQualifiers
 import io.specmatic.reporter.ctrf.model.CtrfTestResultRecord
+import io.specmatic.reporter.ctrf.model.FixtureExecutionResult
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
 import io.specmatic.reporter.internal.dto.operation.APIOperation
 import io.specmatic.reporter.model.OpenAPIOperation
@@ -69,6 +70,8 @@ data class TestResultRecord(
         expectedType = responseContentType,
         actualType = actualResponseContentType
     ),
+    val beforeFixtureExecutionResult: List<FixtureExecutionResult>? = null,
+    val afterFixtureExecutionResult: List<FixtureExecutionResult>? = null,
 ): CtrfTestResultRecord {
     val isExercised = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
     val isCovered = result !in setOf(TestResult.MissingInSpec, TestResult.NotCovered)
@@ -94,7 +97,9 @@ data class TestResultRecord(
             match = matchesResponseIdentifiers,
             input = request?.toLogString().orEmpty(),
             inputTime = requestTime?.toEpochMilli() ?: 0L,
-            reasons = reasoning.toCtrfSnapshots()
+            reasons = reasoning.toCtrfSnapshots(),
+            beforeFixtureExecutionResults = beforeFixtureExecutionResult,
+            afterFixtureExecutionResults = afterFixtureExecutionResult
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
+++ b/core/src/main/kotlin/io/specmatic/test/fixtures/OpenAPIFixtureExecutor.kt
@@ -1,8 +1,8 @@
 package io.specmatic.test.fixtures
 
-import io.specmatic.core.Result
 import io.specmatic.core.value.Value
+import io.specmatic.test.FixtureExecutionDetails
 
 interface OpenAPIFixtureExecutor {
-    fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String): Result
+    fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String): FixtureExecutionDetails
 }

--- a/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
+++ b/core/src/test/kotlin/io/specmatic/test/ScenarioAsTestTest.kt
@@ -311,9 +311,9 @@ class ScenarioAsTestTest {
 }
 
 class ServiceLoaderTestFixtureExecutor : OpenAPIFixtureExecutor {
-    override fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String): Result {
+    override fun execute(id: String, fixtures: List<Value>, fixtureDiscriminatorKey: String): FixtureExecutionDetails {
         calls.add(fixtureDiscriminatorKey)
-        return Result.Success()
+        return FixtureExecutionDetails(combinedResult = Result.Success())
     }
 
     companion object {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.45.2-SNAPSHOT
 specmaticGradlePluginVersion=0.15.6
-specmaticReporterVersion=0.3.17
+specmaticReporterVersion=0.3.18-SNAPSHOT
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.45.2-SNAPSHOT
 specmaticGradlePluginVersion=0.15.6
-specmaticReporterVersion=0.3.18-SNAPSHOT
+specmaticReporterVersion=0.3.18
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
Reason to change: 
Pass fixture execution results to the CTRF report so they can be rendered in the HTML reporter, keeping the html-reporter output in sync with Studio, which already displays fixture execution results.