### PR TITLE
Improve reporting for dropped or modified request content-type

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -85,8 +85,12 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
 
     private fun requestMatches(request: HttpRequest, variationFromOldScenario: Scenario): List<ResultWithScenario> {
         if (newFeature.scenarios.isEmpty()) throw EmptyContract()
+        val candidates = newScenariosByMethodAndReqContentType.findExactOrSingle(
+            first = variationFromOldScenario.method,
+            second = variationFromOldScenario.requestContentType,
+            valueFilter = { it.matchesPathStructureAndMethod(request) }
+        )
 
-        val candidates = newScenariosByMethodAndReqContentType.findExactOrByFirst(variationFromOldScenario.method, variationFromOldScenario.requestContentType)
         val identifierMatches = candidates.filter { candidate -> candidate.matchesPathStructureAndMethod(request) }
         if (identifierMatches.isEmpty()) {
             val result = Result.Failure("This API exists in the old contract but not in the new contract")
@@ -115,7 +119,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         val newScenariosByStatusAndResContentType = newScenarios.groupBy { it.status to it.responseContentType }
 
         return oldScenarios.flatMap { oldScenario ->
-            val identifierMatches = newScenariosByStatusAndResContentType.findExactOrByFirst(oldScenario.status, oldScenario.responseContentType)
+            val identifierMatches = newScenariosByStatusAndResContentType.findExactOrSingle(oldScenario.status, oldScenario.responseContentType)
             if (identifierMatches.isEmpty()) {
                 val result = Result.Failure("This API exists in the old contract but not in the new contract")
                 return@flatMap listOf(ResultWithScenario(result.updateScenario(oldScenario), oldScenario))
@@ -162,14 +166,16 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         logger.log("[Compatibility Check] Verdict: ${if (failures.isNotEmpty()) "FAIL" else "PASS"}")
     }
 
-    private fun <First, Second, Item> Map<Pair<First, Second>, List<Item>>.findExactOrByFirst(first: First, second: Second): List<Item> {
-        val exact = this[first to second]
+    private fun <First, Second, Item> Map<Pair<First, Second?>, List<Item>>.findExactOrSingle(
+        first: First,
+        second: Second?,
+        valueFilter: (Item) -> Boolean = { true },
+    ): List<Item> {
+        val exact = this[first to second]?.filter(valueFilter)
         if (!exact.isNullOrEmpty()) return exact
-        return buildList {
-            for ((key, value) in this@findExactOrByFirst) {
-                if (key.first == first) addAll(value)
-            }
-        }
+
+        val fallBackEntries = entries.asSequence().filter { it.key.first == first }.flatMap { it.value.asSequence() }
+        return fallBackEntries.singleOrNull(valueFilter)?.let(::listOf).orEmpty()
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -3547,6 +3547,310 @@ paths:
     }
 
     @Test
+    fun `should fail when request is changed from some-body to no-body with appropriate error message`() {
+        val olderContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              requestBody:
+                description: Product to add
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val newerContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.1.9
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        assertBackwardCompatibilityFailure(
+            results,
+            """
+            In scenario "Create a product. Response: Created"
+            API: POST /products -> 201
+            
+              >> REQUEST.BODY
+              
+                  R1002: Value mismatch
+                  Documentation: https://docs.specmatic.io/rules#r1002
+                  Summary: The value does not match the expected value defined in the specification
+              
+                  This is no body in the new specification, but json object in the old specification
+            """
+        )
+    }
+
+    @Test
+    fun `should fail when request content-type has been changes from one to another`() {
+        val olderContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              requestBody:
+                description: Product to add
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val newerContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              requestBody:
+                description: Product to add
+                required: true
+                content:
+                  application/custom+json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        assertBackwardCompatibilityFailure(
+            results = results,
+            expectedReport = """
+            In scenario "Create a product. Response: Created"
+            API: POST /products -> 201
+            
+              >> REQUEST.PARAMETERS.HEADER.Content-Type
+              
+                  R1002: Value mismatch
+                  Documentation: https://docs.specmatic.io/rules#r1002
+                  Summary: The value does not match the expected value defined in the specification
+              
+                  This is application/custom+json in the new specification, but application/json in the old specification
+            """
+        )
+    }
+
+    @Test
+    fun `should fail when request content-type has been changes from one to another but another path with same method and content-type exists`() {
+        val olderContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              requestBody:
+                description: Product to add
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+          /orders:
+            post:
+              summary: Create an order
+              description: Create a new order entry
+              requestBody:
+                description: Order to add
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val newerContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              requestBody:
+                description: Product to add
+                required: true
+                content:
+                  application/custom+json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+          /orders:
+            post:
+              summary: Create an order
+              description: Create a new order entry
+              requestBody:
+                description: Order to add
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        assertBackwardCompatibilityFailure(
+            results = results,
+            expectedReport = """
+            In scenario "Create a product. Response: Created"
+            API: POST /products -> 201
+            
+              >> REQUEST.PARAMETERS.HEADER.Content-Type
+              
+                  R1002: Value mismatch
+                  Documentation: https://docs.specmatic.io/rules#r1002
+                  Summary: The value does not match the expected value defined in the specification
+              
+                  This is application/custom+json in the new specification, but application/json in the old specification
+            """
+        )
+    }
+
+    @Test
+    fun `should fail when request content-type has been changes from one to another but multiple content-type exists making the change ambiguous`() {
+        val olderContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              requestBody:
+                description: Product to add
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val newerContract: Feature = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 0.2.0
+        paths:
+          /products:
+            post:
+              summary: Create a product
+              description: Create a new product entry
+              requestBody:
+                description: Product to add
+                required: true
+                content:
+                  application/custom+json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                  application/custom2+json:
+                    schema:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+              responses:
+                '201':
+                  description: Created
+        """.trimIndent().openAPIToContract()
+
+        val results: Results = testBackwardCompatibility(olderContract, newerContract)
+        assertBackwardCompatibilityFailure(
+            results = results,
+            expectedReport = """
+            In scenario "Create a product. Response: Created"
+            API: POST /products -> 201
+            
+                  This API exists in the old contract but not in the new contract
+            """
+        )
+    }
+
+    @Test
     fun `example-only changes do not break backward compatibility for anyOf nullable response schema`() {
         val oldSpec = """
 openapi: 3.1.0


### PR DESCRIPTION
**What**: Improve reporting for dropped or modified request content-type

**Why**:
- When the requestBody is removed in the newer specification, we report the specific error instead of indicating that it is missing from the new version.  
- When the content-Type changes, we can provide the exact error if there is only one content-type in the new version, otherwise, it becomes ambiguous.

**Checklist**:

- [x] Unit Tests
- [ ] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
