### PR TITLE
Support form-exploded object query params with additionalProperties

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiLintViolations.kt
@@ -48,6 +48,12 @@ enum class OpenApiLintViolations(override val id: String, override val title: St
         summary = "All path template segments must be defined as parameters"
     ),
 
+    REQUIRED_QUERY_OBJECT_CONFLICT(
+        id = "OAS0012",
+        title = "Required query object conflict",
+        summary = "A required form-exploded object query parameter must have at least one required schema property to make a concrete query parameter mandatory"
+    ),
+
     /* -------- Security -------- */
     SECURITY_PROPERTY_REDEFINED(
         id = "OAS0020",

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2700,7 +2700,7 @@ class OpenApiSpecification(
         if (parameter.required == true && requiredProperties.isEmpty()) {
             parameterContext.at("required").record(
                 message = "Query parameter ${parameter.name} is a required form-exploded object, but its schema does not define any required properties. Since form-exploded object parameters are represented by their properties, no property is made mandatory.",
-                ruleViolation = OpenApiLintViolations.SCHEMA_UNCLEAR,
+                ruleViolation = OpenApiLintViolations.REQUIRED_QUERY_OBJECT_CONFLICT,
                 isWarning = true
             )
         }

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2604,34 +2604,160 @@ class OpenApiSpecification(
 
     private fun toSpecmaticQueryParam(parameters: List<Parameter>, collectorContext: CollectorContext, extensibleQueryParams: Boolean): HttpQueryParamPattern {
         val queryParameters = parameters.safeFilter<QueryParameter>(collectorContext)
-        val queryPattern: Map<String, Pattern> = queryParameters.associate { queryParamWithContext ->
-            val parameter = queryParamWithContext.parameter
-            logger.debug("Processing query parameter ${parameter.name}")
-            val queryParamContext = queryParamWithContext.collectorContext
-            val (resolvedSchema, paramContext) = resolveSchemaIfRefElseAtSchema(parameter.schema, collectorContext = queryParamContext)
-            val specmaticPattern: Pattern? = if (resolvedSchema.isSchema(ARRAY_TYPE)) {
-                val itemsSchema = paramContext.requirePojo(extract = { resolvedSchema.items }, createDefault = { Schema<Any>() }, message = { "No items schema defined for array schema defaulting to empty schema" })
-                QueryParameterArrayPattern(listOf(toSpecmaticPattern(schema = itemsSchema, typeStack = emptyList(), collectorContext = paramContext.at("items"))), parameter.name)
-            } else if (!resolvedSchema.isSchema(OBJECT_TYPE)) {
-                QueryParameterScalarPattern(toSpecmaticPattern(schema = parameter.schema, typeStack = emptyList(), collectorContext = queryParamContext.at("schema")))
-            } else {
-                queryParamContext.at("schema").record(
-                    message = "Query parameter ${parameter.name} is an object, and not yet supported",
-                    ruleViolation = OpenApiLintViolations.UNSUPPORTED_FEATURE,
-                    isWarning = true
-                )
-                null
-            }
+        val parsedQueryParameters = queryParameters.map(::toQueryParameterParseResult)
+        val queryPatternEntries = parsedQueryParameters.flatMap(QueryParameterParseResult::entries)
+        val objectPropertyEntries = queryPatternEntries.filter { it.source.isFormExplodedObjectProperty }
+        val objectPropertyEntriesByWireKey = objectPropertyEntries.groupBy(QueryParameterPatternEntry::wireKey)
 
-            val queryParamKey = if (parameter.required == true) parameter.name else "${parameter.name}?"
-            queryParamKey to specmaticPattern
-        }.filterValues { it != null }.mapValues { it.value!! }
+        val filteredQueryPatternEntries = queryPatternEntries.filter { entry ->
+            if (!entry.source.isFormExplodedObjectProperty && entry.wireKey in objectPropertyEntriesByWireKey) {
+                recordQueryParameterCollision(entry, objectPropertyEntriesByWireKey.getValue(entry.wireKey).first())
+                false
+            } else {
+                true
+            }
+        }
+
+        val queryPattern: Map<String, Pattern> = filteredQueryPatternEntries.associate { it.key to it.pattern }
 
         val additionalProperties = additionalPropertiesInQueryParam(queryParameters)
         return HttpQueryParamPattern(
             queryPattern,
             additionalProperties,
-            extensibleQueryParams = extensibleQueryParams
+            extensibleQueryParams = extensibleQueryParams,
+            formExplodedObjectQueryParams = parsedQueryParameters.mapNotNull(QueryParameterParseResult::formExplodedObjectQueryParam)
+        )
+    }
+
+    private data class QueryParameterPatternSource(val parameterName: String, val propertyName: String? = null) {
+        val isFormExplodedObjectProperty: Boolean = propertyName != null
+        val displayName: String = propertyName?.let { "$parameterName.$it" } ?: parameterName
+    }
+
+    private data class QueryParameterPatternEntry(
+        val key: String,
+        val wireKey: String,
+        val pattern: Pattern,
+        val source: QueryParameterPatternSource,
+        val collectorContext: CollectorContext
+    )
+
+    private data class QueryParameterParseResult(
+        val entries: List<QueryParameterPatternEntry>,
+        val formExplodedObjectQueryParam: FormExplodedObjectQueryParam? = null
+    )
+
+    private fun toQueryParameterParseResult(queryParamWithContext: ParameterWithContext<QueryParameter>): QueryParameterParseResult {
+        val parameter = queryParamWithContext.parameter
+        logger.debug("Processing query parameter ${parameter.name}")
+        val queryParamContext = queryParamWithContext.collectorContext
+        val (resolvedSchema, paramContext) = resolveSchemaIfRefElseAtSchema(parameter.schema, collectorContext = queryParamContext)
+
+        return if (resolvedSchema.isSchema(OBJECT_TYPE)) {
+            toFormExplodedObjectQueryParameterParseResult(parameter, resolvedSchema, paramContext, queryParamContext)
+        } else {
+            val specmaticPattern = toQueryParameterPattern(
+                parameterName = parameter.name,
+                schema = parameter.schema,
+                resolvedSchema = resolvedSchema,
+                resolvedSchemaContext = paramContext,
+                schemaContext = queryParamContext.at("schema")
+            )
+            val queryParamKey = if (parameter.required == true) parameter.name else "${parameter.name}?"
+            QueryParameterParseResult(
+                entries = listOf(
+                    QueryParameterPatternEntry(
+                        key = queryParamKey,
+                        wireKey = parameter.name,
+                        pattern = specmaticPattern,
+                        source = QueryParameterPatternSource(parameter.name),
+                        collectorContext = queryParamContext
+                    )
+                )
+            )
+        }
+    }
+
+    private fun toFormExplodedObjectQueryParameterParseResult(
+        parameter: QueryParameter,
+        resolvedSchema: Schema<*>,
+        schemaContext: CollectorContext,
+        parameterContext: CollectorContext
+    ): QueryParameterParseResult {
+        if (!parameter.isFormExploded()) {
+            parameterContext.at("schema").record(
+                message = "Query parameter ${parameter.name} is an object, and only style form with explode true is supported",
+                ruleViolation = OpenApiLintViolations.UNSUPPORTED_FEATURE,
+                isWarning = true
+            )
+            return QueryParameterParseResult(emptyList())
+        }
+
+        val requiredProperties = resolvedSchema.required.orEmpty().toSet()
+        val schemaProperties = resolvedSchema.properties.orEmpty()
+        val entries = schemaProperties.map { (propertyName, propertySchema) ->
+            val propertyContext = schemaContext.at("properties").at(propertyName)
+            val (resolvedPropertySchema, resolvedPropertyContext) = resolveSchemaIfRefElseAtSchema(
+                schema = propertySchema,
+                collectorContext = propertyContext
+            )
+            val optional = parameter.required != true || propertyName !in requiredProperties
+            QueryParameterPatternEntry(
+                key = toSpecmaticParamName(optional, propertyName),
+                wireKey = propertyName,
+                pattern = toQueryParameterPattern(
+                    parameterName = propertyName,
+                    schema = propertySchema,
+                    resolvedSchema = resolvedPropertySchema,
+                    resolvedSchemaContext = resolvedPropertyContext,
+                    schemaContext = propertyContext
+                ),
+                source = QueryParameterPatternSource(parameter.name, propertyName),
+                collectorContext = propertyContext
+            )
+        }
+
+        return QueryParameterParseResult(
+            entries = entries,
+            formExplodedObjectQueryParam = FormExplodedObjectQueryParam(
+                parameterName = parameter.name,
+                required = parameter.required == true,
+                propertyKeys = schemaProperties.keys,
+                requiredPropertyKeys = requiredProperties
+            )
+        )
+    }
+
+    private fun QueryParameter.isFormExploded(): Boolean {
+        return (style == null || style == Parameter.StyleEnum.FORM) && explode != false
+    }
+
+    private fun toQueryParameterPattern(
+        parameterName: String,
+        schema: Schema<*>,
+        resolvedSchema: Schema<*>,
+        resolvedSchemaContext: CollectorContext,
+        schemaContext: CollectorContext
+    ): Pattern {
+        return if (resolvedSchema.isSchema(ARRAY_TYPE)) {
+            val itemsSchema = resolvedSchemaContext.requirePojo(
+                extract = { resolvedSchema.items },
+                createDefault = { Schema<Any>() },
+                message = { "No items schema defined for array schema defaulting to empty schema" }
+            )
+            QueryParameterArrayPattern(
+                listOf(toSpecmaticPattern(schema = itemsSchema, typeStack = emptyList(), collectorContext = resolvedSchemaContext.at("items"))),
+                parameterName
+            )
+        } else {
+            QueryParameterScalarPattern(toSpecmaticPattern(schema = schema, typeStack = emptyList(), collectorContext = schemaContext))
+        }
+    }
+
+    private fun recordQueryParameterCollision(entry: QueryParameterPatternEntry, objectPropertyEntry: QueryParameterPatternEntry) {
+        entry.collectorContext.record(
+            message = "Query parameter ${entry.source.displayName} conflicts with form-exploded object query parameter ${objectPropertyEntry.source.displayName}; ignoring ${entry.source.displayName}",
+            ruleViolation = OpenApiLintViolations.INVALID_PARAMETER_DEFINITION
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2696,6 +2696,15 @@ class OpenApiSpecification(
 
         val requiredProperties = resolvedSchema.required.orEmpty().toSet()
         val schemaProperties = resolvedSchema.properties.orEmpty()
+
+        if (parameter.required == true && requiredProperties.isEmpty()) {
+            parameterContext.at("required").record(
+                message = "Query parameter ${parameter.name} is a required form-exploded object, but its schema does not define any required properties. Since form-exploded object parameters are represented by their properties, no property is made mandatory.",
+                ruleViolation = OpenApiLintViolations.SCHEMA_UNCLEAR,
+                isWarning = true
+            )
+        }
+
         val entries = schemaProperties.map { (propertyName, propertySchema) ->
             val propertyContext = schemaContext.at("properties").at(propertyName)
             val (resolvedPropertySchema, resolvedPropertyContext) = resolveSchemaIfRefElseAtSchema(

--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -2620,7 +2620,7 @@ class OpenApiSpecification(
 
         val queryPattern: Map<String, Pattern> = filteredQueryPatternEntries.associate { it.key to it.pattern }
 
-        val additionalProperties = additionalPropertiesInQueryParam(queryParameters)
+        val additionalProperties = additionalPropertiesInQueryParam(parsedQueryParameters)
         return HttpQueryParamPattern(
             queryPattern,
             additionalProperties,
@@ -2644,7 +2644,8 @@ class OpenApiSpecification(
 
     private data class QueryParameterParseResult(
         val entries: List<QueryParameterPatternEntry>,
-        val formExplodedObjectQueryParam: FormExplodedObjectQueryParam? = null
+        val formExplodedObjectQueryParam: FormExplodedObjectQueryParam? = null,
+        val additionalProperties: Pattern? = null
     )
 
     private fun toQueryParameterParseResult(queryParamWithContext: ParameterWithContext<QueryParameter>): QueryParameterParseResult {
@@ -2724,7 +2725,8 @@ class OpenApiSpecification(
                 required = parameter.required == true,
                 propertyKeys = schemaProperties.keys,
                 requiredPropertyKeys = requiredProperties
-            )
+            ),
+            additionalProperties = additionalPropertiesInQueryParam(resolvedSchema, schemaContext)
         )
     }
 
@@ -2761,13 +2763,20 @@ class OpenApiSpecification(
         )
     }
 
-    private fun additionalPropertiesInQueryParam(queryParameters: List<ParameterWithContext<QueryParameter>>): Pattern? {
-        val queryParamWithContext = queryParameters.firstOrNull {
-            it.parameter.schema.isSchema(OBJECT_TYPE, multi = false) && it.parameter.schema.extractAdditionalProperties() != null
-        } ?: return null
-        val additionalProperties = queryParamWithContext.parameter.schema.extractAdditionalProperties() ?: return null
+    private fun additionalPropertiesInQueryParam(parsedQueryParameters: List<QueryParameterParseResult>): Pattern? {
+        val additionalProperties = parsedQueryParameters.mapNotNull(QueryParameterParseResult::additionalProperties).distinct()
+        return when {
+            additionalProperties.isEmpty() -> null
+            additionalProperties.any { it is AnythingPattern } -> AnythingPattern
+            additionalProperties.size == 1 -> additionalProperties.single()
+            else -> AnyPattern(additionalProperties, extensions = emptyMap())
+        }
+    }
 
-        val additionalPropContext = queryParamWithContext.collectorContext.at("additionalProperties")
+    private fun additionalPropertiesInQueryParam(schema: Schema<*>, collectorContext: CollectorContext): Pattern? {
+        val additionalProperties = schema.extractAdditionalProperties() ?: return null
+
+        val additionalPropContext = collectorContext.at("additionalProperties")
         return when (additionalProperties) {
             true -> AnythingPattern
             is Schema<*> -> toSpecmaticPattern(additionalProperties, emptyList(), collectorContext = additionalPropContext)

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -38,23 +38,13 @@ data class HttpQueryParamPattern(
                         listOf(parameterName to generatedValue.toString())
                     }
                 }
-            }.let { queryParamPairs ->
-                if(additionalProperties == null)
-                    queryParamPairs
-                else
-                    queryParamPairs.plus(randomString(5) to additionalProperties.generate(resolver).toStringLiteral())
             }
         }
     }
 
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpQueryParamPattern>> {
         return attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {
-            val queryParams = effectiveQueryPatterns(row).let {
-                if(additionalProperties != null)
-                    it.plus(randomString(5) to additionalProperties)
-                else
-                    it
-            }
+            val queryParams = effectiveQueryPatterns(row)
             val patternMap = row.withoutOmittedKeys(queryParams, resolver.defaultExampleResolver)
 
             allOrNothingCombinationIn(patternMap, resolver.resolveRow(row)) { pattern ->
@@ -63,6 +53,7 @@ data class HttpQueryParamPattern(
                 it.ifValue {
                     HttpQueryParamPattern(
                         it.mapKeys { entry -> withoutOptionality(entry.key) },
+                        additionalProperties = additionalProperties,
                         extensibleQueryParams = extensibleQueryParams,
                         formExplodedObjectQueryParams = formExplodedObjectQueryParams
                     )
@@ -75,7 +66,7 @@ data class HttpQueryParamPattern(
         return addComplimentaryPatterns(
             basePatterns.map { rValue -> rValue.ifValue { it.queryPatterns } },
             queryPatterns,
-            additionalProperties,
+            null,
             row,
             resolver,
             breadCrumb = BreadCrumb.PARAM_QUERY.value
@@ -83,6 +74,7 @@ data class HttpQueryParamPattern(
             patternWithKeyCombinationDetailsFrom(it, QUERY_PARAM_KEY_ID_IN_TEST_DETAILS) { patternMap ->
                 HttpQueryParamPattern(
                     patternMap.mapKeys { entry -> withoutOptionality(entry.key) },
+                    additionalProperties = additionalProperties,
                     extensibleQueryParams = extensibleQueryParams,
                     formExplodedObjectQueryParams = formExplodedObjectQueryParams
                 )
@@ -151,12 +143,7 @@ data class HttpQueryParamPattern(
 
     fun newBasedOn(resolver: Resolver): Sequence<HttpQueryParamPattern> {
         return attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {
-            val queryParams = queryPatterns.let {
-                if(additionalProperties != null)
-                    it.plus(randomString(5) to additionalProperties)
-                else
-                    it
-            }
+            val queryParams = queryPatterns
 
             allOrNothingCombinationIn(
                 queryParams,
@@ -167,6 +154,7 @@ data class HttpQueryParamPattern(
             ).map {
                 HttpQueryParamPattern(
                     it.value,
+                    additionalProperties = additionalProperties,
                     extensibleQueryParams = extensibleQueryParams,
                     formExplodedObjectQueryParams = formExplodedObjectQueryParams
                 )
@@ -204,6 +192,7 @@ data class HttpQueryParamPattern(
                     patternWithKeyCombinationDetailsFrom(it, QUERY_PARAM_KEY_ID_IN_TEST_DETAILS) {
                         HttpQueryParamPattern(
                             it.mapKeys { entry -> withoutOptionality(entry.key) },
+                            additionalProperties = additionalProperties,
                             extensibleQueryParams = extensibleQueryParams,
                             formExplodedObjectQueryParams = formExplodedObjectQueryParams
                         )
@@ -228,6 +217,7 @@ data class HttpQueryParamPattern(
             pattern.ifValue {
                 HttpQueryParamPattern(
                     pattern.value,
+                    additionalProperties = additionalProperties,
                     extensibleQueryParams = extensibleQueryParams,
                     formExplodedObjectQueryParams = formExplodedObjectQueryParams
                 )
@@ -241,6 +231,9 @@ data class HttpQueryParamPattern(
     fun fixValue(queryParams: QueryParameters?, resolver: Resolver): QueryParameters {
         val queryParamsToFix = queryParams ?: QueryParameters(emptyMap())
         val effectivePatterns = effectiveQueryPatterns(queryParamsToFix)
+        val additionalQueryParams = matchingAdditionalQueryParams(queryParamsToFix, effectivePatterns, resolver)
+        val invalidAdditionalQueryPatterns = invalidAdditionalQueryParamPatterns(queryParamsToFix, effectivePatterns, resolver)
+        val patternsToFix = effectivePatterns + invalidAdditionalQueryPatterns
         val adjustedQueryParams = when {
             queryParamsToFix.paramPairs.isEmpty() -> QueryParameters(emptyMap())
             additionalProperties != null -> queryParamsToFix.withoutMatching(effectivePatterns.normalizedKeys(), additionalProperties, resolver)
@@ -252,17 +245,18 @@ data class HttpQueryParamPattern(
         } else resolver.withUnexpectedKeyCheck(ValidateUnexpectedKeys)
 
         val fixedQueryParams = fix(
-            jsonPatternMap = effectivePatterns, jsonValueMap = adjustedQueryParams.asValueMap(),
+            jsonPatternMap = patternsToFix, jsonValueMap = adjustedQueryParams.asValueMap(),
             resolver = updatedResolver.updateLookupPath(BreadCrumb.PARAMETERS.value).updateLookupForParam(BreadCrumb.QUERY.value).withoutAllPatternsAsMandatory(),
-            jsonPattern = JSONObjectPattern(effectivePatterns, typeAlias = null)
+            jsonPattern = JSONObjectPattern(patternsToFix, typeAlias = null)
         )
 
-        return QueryParameters(fixedQueryParams.mapValues { it.value.toStringLiteral() })
+        return QueryParameters(fixedQueryParams.mapValues { it.value.toStringLiteral() }.toList() + additionalQueryParams.paramPairs)
     }
 
     fun fillInTheBlanks(queryParams: QueryParameters?, resolver: Resolver): ReturnValue<QueryParameters> {
         val queryParamsToFill = queryParams ?: QueryParameters(emptyMap())
         val effectivePatterns = effectiveQueryPatterns(queryParamsToFill)
+        val additionalQueryParams = matchingAdditionalQueryParams(queryParamsToFill, effectivePatterns, resolver)
         val adjustedQueryParams = when {
             queryParamsToFill.paramPairs.isEmpty() -> QueryParameters(emptyMap())
             additionalProperties != null -> queryParamsToFill.withoutMatching(effectivePatterns.normalizedKeys(), additionalProperties, resolver)
@@ -283,9 +277,25 @@ data class HttpQueryParamPattern(
             resolver = updatedResolver.updateLookupPath(BreadCrumb.PARAMETERS.value).updateLookupForParam(BreadCrumb.QUERY.value),
             typeAlias = null
         ).realise(
-            hasValue = { valuesMap, _ -> HasValue(QueryParameters(valuesMap.mapValues { it.value.toStringLiteral() })) },
+            hasValue = { valuesMap, _ -> HasValue(QueryParameters(valuesMap.mapValues { it.value.toStringLiteral() }.toList() + additionalQueryParams.paramPairs)) },
             orException = { e -> e.cast() }, orFailure = { f -> f.cast() }
         )
+    }
+
+    private fun matchingAdditionalQueryParams(queryParams: QueryParameters, effectivePatterns: Map<String, Pattern>, resolver: Resolver): QueryParameters {
+        return additionalProperties?.let { queryParams.matching(effectivePatterns.normalizedKeys(), it, resolver) }
+            ?: QueryParameters(emptyMap())
+    }
+
+    private fun invalidAdditionalQueryParamPatterns(queryParams: QueryParameters, effectivePatterns: Map<String, Pattern>, resolver: Resolver): Map<String, Pattern> {
+        val additionalProperties = additionalProperties ?: return emptyMap()
+        val effectiveKeys = effectivePatterns.normalizedKeys()
+        val validAdditionalQueryParams = queryParams.matching(effectiveKeys, additionalProperties, resolver).paramPairs.toSet()
+
+        return queryParams.paramPairs
+            .filter { (key, _) -> key !in effectiveKeys }
+            .filterNot(validAdditionalQueryParams::contains)
+            .associate { (key, _) -> key to additionalProperties }
     }
 
     companion object {

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -47,8 +47,8 @@ data class HttpQueryParamPattern(
             val queryParams = effectiveQueryPatterns(row)
             val patternMap = row.withoutOmittedKeys(queryParams, resolver.defaultExampleResolver)
 
-            allOrNothingCombinationIn(patternMap, resolver.resolveRow(row)) { pattern ->
-                newMapBasedOn(pattern,row,withNullPattern(resolver))
+            queryParamCombinationsRespectingFormExplodedObjects(patternMap, resolver.resolveRow(row)).flatMap { pattern ->
+                newMapBasedOn(pattern, row, withNullPattern(resolver))
             }.map { it: ReturnValue<Map<String, Pattern>> ->
                 it.ifValue {
                     HttpQueryParamPattern(
@@ -145,15 +145,11 @@ data class HttpQueryParamPattern(
         return attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {
             val queryParams = queryPatterns
 
-            allOrNothingCombinationIn(
-                queryParams,
-                Row(),
-                null,
-                null,
-                returnValues { entry -> newBasedOn(entry.mapKeys { withoutOptionality(it.key) }, resolver) }
-            ).map {
+            queryParamCombinationsRespectingFormExplodedObjects(queryParams, Row()).flatMap { entry ->
+                newBasedOn(entry.mapKeys { withoutOptionality(it.key) }, resolver)
+            }.map {
                 HttpQueryParamPattern(
-                    it.value,
+                    it,
                     additionalProperties = additionalProperties,
                     extensibleQueryParams = extensibleQueryParams,
                     formExplodedObjectQueryParams = formExplodedObjectQueryParams
@@ -298,6 +294,39 @@ data class HttpQueryParamPattern(
             .associate { (key, _) -> key to additionalProperties }
     }
 
+    private fun queryParamCombinationsRespectingFormExplodedObjects(patternMap: Map<String, Pattern>, row: Row): Sequence<Map<String, Pattern>> {
+        return allOrNothingQueryParamCombinations(patternMap, row)
+            .flatMap(::withRequiredOnlyVariantsForPresentFormExplodedObjects)
+            .distinct()
+    }
+
+    private fun allOrNothingQueryParamCombinations(patternMap: Map<String, Pattern>, row: Row): Sequence<Map<String, Pattern>> {
+        return allOrNothingCombinationIn(patternMap, row) { selectedPatternMap ->
+            sequenceOf(HasValue(selectedPatternMap))
+        }.map { it.value }
+    }
+
+    private fun withRequiredOnlyVariantsForPresentFormExplodedObjects(patternMap: Map<String, Pattern>): Sequence<Map<String, Pattern>> {
+        val requiredOnlyObjectPatternMap = requiredOnlyVariantForPresentFormExplodedObjects(patternMap)
+        return sequenceOf(patternMap) + listOfNotNull(requiredOnlyObjectPatternMap).asSequence()
+    }
+
+    private fun requiredOnlyVariantForPresentFormExplodedObjects(patternMap: Map<String, Pattern>): Map<String, Pattern>? {
+        val requiredOnlyPatternMap = formExplodedObjectQueryParams.fold(patternMap) { patterns, objectQueryParam ->
+            if (objectQueryParam.requiredPropertyKeys.isEmpty()) return@fold patterns
+            if (objectQueryParam.propertyKeys.none { propertyKey -> patterns.containsNormalizedKey(propertyKey) }) return@fold patterns
+
+            val optionalPropertyKeys = objectQueryParam.propertyKeys - objectQueryParam.requiredPropertyKeys
+            val patternsWithoutOptionalObjectProperties = patterns.filterKeys { key -> withoutOptionality(key) !in optionalPropertyKeys }
+
+            objectQueryParam.requiredPropertyKeys.fold(patternsWithoutOptionalObjectProperties) { updatedPatterns, propertyKey ->
+                updatedPatterns.makeKeyMandatory(propertyKey)
+            }
+        }
+
+        return requiredOnlyPatternMap.takeUnless { it == patternMap }
+    }
+
     companion object {
         private const val QUERY_PARAM_KEY_ID_IN_TEST_DETAILS = "param"
     }
@@ -334,6 +363,10 @@ data class HttpQueryParamPattern(
 
     private fun Map<String, Pattern>.normalizedKeys(): Set<String> {
         return keys.map(::withoutOptionality).toSet()
+    }
+
+    private fun Map<String, Pattern>.containsNormalizedKey(key: String): Boolean {
+        return containsKey(key) || containsKey(withOptionality(key))
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -92,11 +92,7 @@ data class HttpQueryParamPattern(
 
         val keyErrors = resolver.findKeyErrorList(effectivePatterns, queryParams.asMap().mapValues { StringValue(it.value) })
         val keyErrorList: List<Result.Failure> = keyErrors.map {
-            when {
-                effectivePatterns.contains(it.name) -> it.missingKeyToResult("query param", resolver.mismatchMessages)
-                effectivePatterns.contains(withOptionality(it.name)) -> it.missingOptionalKeyToResult("query param", resolver.mismatchMessages)
-                else -> it.unknownKeyToResult("query param", resolver.mismatchMessages)
-            }.breadCrumb(it.name)
+            keyErrorToResult(it, effectivePatterns, httpRequest.queryParams, resolver).breadCrumb(it.name)
         }
 
         // 1. key is optional and request does not have the key as well
@@ -140,6 +136,43 @@ data class HttpQueryParamPattern(
         else
             Result.Success()
     }
+
+    private fun keyErrorToResult(keyError: KeyError, effectivePatterns: Map<String, Pattern>, queryParams: QueryParameters, resolver: Resolver): Result.Failure {
+        return when {
+            effectivePatterns.contains(keyError.name) ->
+                missingRequiredFormExplodedObjectPropertyToResult(keyError.name, queryParams)
+                    ?: keyError.missingKeyToResult("query param", resolver.mismatchMessages)
+            effectivePatterns.contains(withOptionality(keyError.name)) -> keyError.missingOptionalKeyToResult("query param", resolver.mismatchMessages)
+            else -> keyError.unknownKeyToResult("query param", resolver.mismatchMessages)
+        }
+    }
+
+    private fun missingRequiredFormExplodedObjectPropertyToResult(missingPropertyKey: String, queryParams: QueryParameters): Result.Failure? {
+        val objectQueryParam = formExplodedObjectQueryParams.firstOrNull { objectQueryParam ->
+            !objectQueryParam.required &&
+                missingPropertyKey in objectQueryParam.requiredPropertyKeys &&
+                objectQueryParam.propertyKeys.any(queryParams::containsKey)
+        } ?: return null
+
+        val presentPropertyKeys = objectQueryParam.propertyKeys.filter(queryParams::containsKey).sorted()
+        val missingRequiredPropertyKeys = objectQueryParam.requiredPropertyKeys.filterNot(queryParams::containsKey).sorted()
+        val presentProperties = propertyListMessage(presentPropertyKeys)
+        val missingRequiredProperties = propertyListMessage(missingRequiredPropertyKeys)
+
+        return Result.Failure(
+            message = "The request includes $presentProperties from optional form-exploded query parameter object \"${objectQueryParam.parameterName}\". Since that object is present, required $missingRequiredProperties must also be provided.",
+            ruleViolation = StandardRuleViolation.REQUIRED_PROPERTY_MISSING
+        )
+    }
+
+    private fun propertyListMessage(propertyKeys: List<String>): String {
+        return when (propertyKeys.size) {
+            1 -> "property ${propertyKeys.single().quoted()}"
+            else -> "properties ${propertyKeys.joinToString(", ") { it.quoted() }}"
+        }
+    }
+
+    private fun String.quoted(): String = "\"$this\""
 
     fun newBasedOn(resolver: Resolver): Sequence<HttpQueryParamPattern> {
         return attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -149,8 +149,7 @@ data class HttpQueryParamPattern(
 
     private fun missingRequiredFormExplodedObjectPropertyToResult(missingPropertyKey: String, queryParams: QueryParameters): Result.Failure? {
         val objectQueryParam = formExplodedObjectQueryParams.firstOrNull { objectQueryParam ->
-            !objectQueryParam.required &&
-                missingPropertyKey in objectQueryParam.requiredPropertyKeys &&
+            missingPropertyKey in objectQueryParam.requiredPropertyKeys &&
                 objectQueryParam.propertyKeys.any(queryParams::containsKey)
         } ?: return null
 
@@ -160,9 +159,22 @@ data class HttpQueryParamPattern(
         val missingRequiredProperties = propertyListMessage(missingRequiredPropertyKeys)
 
         return Result.Failure(
-            message = "The request includes $presentProperties from optional form-exploded query parameter object \"${objectQueryParam.parameterName}\". Since that object is present, required $missingRequiredProperties must also be provided.",
+            message = missingRequiredFormExplodedObjectPropertyMessage(objectQueryParam, presentProperties, missingRequiredProperties),
             ruleViolation = StandardRuleViolation.REQUIRED_PROPERTY_MISSING
         )
+    }
+
+    private fun missingRequiredFormExplodedObjectPropertyMessage(
+        objectQueryParam: FormExplodedObjectQueryParam,
+        presentProperties: String,
+        missingRequiredProperties: String
+    ): String {
+        return when {
+            objectQueryParam.required ->
+                "The request includes $presentProperties from required form-exploded query parameter object \"${objectQueryParam.parameterName}\". Required $missingRequiredProperties must also be provided."
+            else ->
+                "The request includes $presentProperties from optional form-exploded query parameter object \"${objectQueryParam.parameterName}\". Since that object is present, required $missingRequiredProperties must also be provided."
+        }
     }
 
     private fun propertyListMessage(propertyKeys: List<String>): String {

--- a/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
+++ b/core/src/main/kotlin/io/specmatic/core/HttpQueryParamPattern.kt
@@ -9,10 +9,18 @@ import io.specmatic.core.value.StringValue
 import java.net.URI
 import kotlin.collections.contains
 
+data class FormExplodedObjectQueryParam(
+    val parameterName: String,
+    val required: Boolean,
+    val propertyKeys: Set<String>,
+    val requiredPropertyKeys: Set<String>
+)
+
 data class HttpQueryParamPattern(
     val queryPatterns: Map<String, Pattern>,
     val additionalProperties: Pattern? = null,
-    val extensibleQueryParams: Boolean = false
+    val extensibleQueryParams: Boolean = false,
+    val formExplodedObjectQueryParams: List<FormExplodedObjectQueryParam> = emptyList()
 ) {
 
     val queryKeyNames = queryPatterns.keys
@@ -41,7 +49,7 @@ data class HttpQueryParamPattern(
 
     fun newBasedOn(row: Row, resolver: Resolver): Sequence<ReturnValue<HttpQueryParamPattern>> {
         return attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {
-            val queryParams = queryPatterns.let {
+            val queryParams = effectiveQueryPatterns(row).let {
                 if(additionalProperties != null)
                     it.plus(randomString(5) to additionalProperties)
                 else
@@ -55,7 +63,8 @@ data class HttpQueryParamPattern(
                 it.ifValue {
                     HttpQueryParamPattern(
                         it.mapKeys { entry -> withoutOptionality(entry.key) },
-                        extensibleQueryParams = extensibleQueryParams
+                        extensibleQueryParams = extensibleQueryParams,
+                        formExplodedObjectQueryParams = formExplodedObjectQueryParams
                     )
                 }
             }
@@ -74,24 +83,26 @@ data class HttpQueryParamPattern(
             patternWithKeyCombinationDetailsFrom(it, QUERY_PARAM_KEY_ID_IN_TEST_DETAILS) { patternMap ->
                 HttpQueryParamPattern(
                     patternMap.mapKeys { entry -> withoutOptionality(entry.key) },
-                    extensibleQueryParams = extensibleQueryParams
+                    extensibleQueryParams = extensibleQueryParams,
+                    formExplodedObjectQueryParams = formExplodedObjectQueryParams
                 )
             }
         }
     }
 
     fun matches(httpRequest: HttpRequest, resolver: Resolver): Result {
+        val effectivePatterns = effectiveQueryPatterns(httpRequest.queryParams)
         val queryParams = if(additionalProperties != null) {
-            httpRequest.queryParams.withoutMatching(queryPatterns.keys, additionalProperties, resolver)
+            httpRequest.queryParams.withoutMatching(effectivePatterns.normalizedKeys(), additionalProperties, resolver)
         } else {
             httpRequest.queryParams
         }
 
-        val keyErrors = resolver.findKeyErrorList(queryPatterns, queryParams.asMap().mapValues { StringValue(it.value) })
+        val keyErrors = resolver.findKeyErrorList(effectivePatterns, queryParams.asMap().mapValues { StringValue(it.value) })
         val keyErrorList: List<Result.Failure> = keyErrors.map {
             when {
-                queryPatterns.contains(it.name) -> it.missingKeyToResult("query param", resolver.mismatchMessages)
-                queryPatterns.contains(withOptionality(it.name)) -> it.missingOptionalKeyToResult("query param", resolver.mismatchMessages)
+                effectivePatterns.contains(it.name) -> it.missingKeyToResult("query param", resolver.mismatchMessages)
+                effectivePatterns.contains(withOptionality(it.name)) -> it.missingOptionalKeyToResult("query param", resolver.mismatchMessages)
                 else -> it.unknownKeyToResult("query param", resolver.mismatchMessages)
             }.breadCrumb(it.name)
         }
@@ -115,7 +126,7 @@ data class HttpQueryParamPattern(
         // Where we need unmatched values:
         // Matching incoming request to stubbed out API
 
-        val results: List<Result?> = queryPatterns.mapNotNull { (key, parameterPattern) ->
+        val results: List<Result?> = effectivePatterns.mapNotNull { (key, parameterPattern) ->
             val requestValues = queryParams.getValues(withoutOptionality(key))
 
             if (requestValues.isEmpty()) return@mapNotNull null
@@ -154,7 +165,11 @@ data class HttpQueryParamPattern(
                 null,
                 returnValues { entry -> newBasedOn(entry.mapKeys { withoutOptionality(it.key) }, resolver) }
             ).map {
-                HttpQueryParamPattern(it.value, extensibleQueryParams = extensibleQueryParams)
+                HttpQueryParamPattern(
+                    it.value,
+                    extensibleQueryParams = extensibleQueryParams,
+                    formExplodedObjectQueryParams = formExplodedObjectQueryParams
+                )
             }
         }
     }
@@ -170,7 +185,7 @@ data class HttpQueryParamPattern(
     fun negativeBasedOn(row: Row, resolver: Resolver, config: NegativePatternConfiguration = NegativePatternConfiguration()): Sequence<ReturnValue<HttpQueryParamPattern>> {
         return returnValue(breadCrumb = BreadCrumb.PARAM_QUERY.value) {
             attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {
-                val queryParams: Map<String, Pattern> = queryPatterns.let {
+                val queryParams: Map<String, Pattern> = effectiveQueryPatterns(row).let {
                     if (additionalProperties != null)
                         it.plus(randomString(5) to additionalProperties)
                     else
@@ -189,7 +204,8 @@ data class HttpQueryParamPattern(
                     patternWithKeyCombinationDetailsFrom(it, QUERY_PARAM_KEY_ID_IN_TEST_DETAILS) {
                         HttpQueryParamPattern(
                             it.mapKeys { entry -> withoutOptionality(entry.key) },
-                            extensibleQueryParams = extensibleQueryParams
+                            extensibleQueryParams = extensibleQueryParams,
+                            formExplodedObjectQueryParams = formExplodedObjectQueryParams
                         )
                     }
                 }
@@ -207,20 +223,28 @@ data class HttpQueryParamPattern(
         generateMandatoryEntryIfMissing: Boolean
     ): Sequence<ReturnValue<HttpQueryParamPattern>> {
         return attempt(breadCrumb = BreadCrumb.PARAM_QUERY.value) {
-            readFrom(queryPatterns, row, resolver, generateMandatoryEntryIfMissing).map { HasValue(it) }
+            readFrom(effectiveQueryPatterns(row), row, resolver, generateMandatoryEntryIfMissing).map { HasValue(it) }
         }.map { pattern ->
-            pattern.ifValue { HttpQueryParamPattern(pattern.value, extensibleQueryParams = extensibleQueryParams) }
+            pattern.ifValue {
+                HttpQueryParamPattern(
+                    pattern.value,
+                    extensibleQueryParams = extensibleQueryParams,
+                    formExplodedObjectQueryParams = formExplodedObjectQueryParams
+                )
+            }
         }
     }
     fun matches(row: Row, resolver: Resolver): Result {
-        return matches(queryPatterns, row, resolver, "query param")
+        return matches(effectiveQueryPatterns(row), row, resolver, "query param")
     }
 
     fun fixValue(queryParams: QueryParameters?, resolver: Resolver): QueryParameters {
+        val queryParamsToFix = queryParams ?: QueryParameters(emptyMap())
+        val effectivePatterns = effectiveQueryPatterns(queryParamsToFix)
         val adjustedQueryParams = when {
-            queryParams == null || queryParams.paramPairs.isEmpty() -> QueryParameters(emptyMap())
-            additionalProperties != null -> queryParams.withoutMatching(queryPatterns.keys, additionalProperties, resolver)
-            else -> queryParams
+            queryParamsToFix.paramPairs.isEmpty() -> QueryParameters(emptyMap())
+            additionalProperties != null -> queryParamsToFix.withoutMatching(effectivePatterns.normalizedKeys(), additionalProperties, resolver)
+            else -> queryParamsToFix
         }
 
         val updatedResolver = if (extensibleQueryParams) {
@@ -228,19 +252,21 @@ data class HttpQueryParamPattern(
         } else resolver.withUnexpectedKeyCheck(ValidateUnexpectedKeys)
 
         val fixedQueryParams = fix(
-            jsonPatternMap = queryPatterns, jsonValueMap = adjustedQueryParams.asValueMap(),
+            jsonPatternMap = effectivePatterns, jsonValueMap = adjustedQueryParams.asValueMap(),
             resolver = updatedResolver.updateLookupPath(BreadCrumb.PARAMETERS.value).updateLookupForParam(BreadCrumb.QUERY.value).withoutAllPatternsAsMandatory(),
-            jsonPattern = JSONObjectPattern(queryPatterns, typeAlias = null)
+            jsonPattern = JSONObjectPattern(effectivePatterns, typeAlias = null)
         )
 
         return QueryParameters(fixedQueryParams.mapValues { it.value.toStringLiteral() })
     }
 
     fun fillInTheBlanks(queryParams: QueryParameters?, resolver: Resolver): ReturnValue<QueryParameters> {
+        val queryParamsToFill = queryParams ?: QueryParameters(emptyMap())
+        val effectivePatterns = effectiveQueryPatterns(queryParamsToFill)
         val adjustedQueryParams = when {
-            queryParams == null || queryParams.paramPairs.isEmpty() -> QueryParameters(emptyMap())
-            additionalProperties != null -> queryParams.withoutMatching(queryPatterns.keys, additionalProperties, resolver)
-            else -> queryParams
+            queryParamsToFill.paramPairs.isEmpty() -> QueryParameters(emptyMap())
+            additionalProperties != null -> queryParamsToFill.withoutMatching(effectivePatterns.normalizedKeys(), additionalProperties, resolver)
+            else -> queryParamsToFill
         }
 
         val updatedResolver = if (extensibleQueryParams) {
@@ -248,12 +274,12 @@ data class HttpQueryParamPattern(
         } else resolver.withUnexpectedKeyCheck(ValidateUnexpectedKeys)
 
         val parsedQueryParams = adjustedQueryParams.asValueMap().mapValues { (key, value) ->
-            val pattern = queryPatterns[key] ?: queryPatterns["${key}?"] ?: return@mapValues value
+            val pattern = effectivePatterns[key] ?: effectivePatterns["${key}?"] ?: return@mapValues value
             runCatching { pattern.parse(value.toStringLiteral(), resolver) }.getOrDefault(value)
         }
 
         return fill(
-            jsonPatternMap = queryPatterns, jsonValueMap = parsedQueryParams,
+            jsonPatternMap = effectivePatterns, jsonValueMap = parsedQueryParams,
             resolver = updatedResolver.updateLookupPath(BreadCrumb.PARAMETERS.value).updateLookupForParam(BreadCrumb.QUERY.value),
             typeAlias = null
         ).realise(
@@ -264,6 +290,40 @@ data class HttpQueryParamPattern(
 
     companion object {
         private const val QUERY_PARAM_KEY_ID_IN_TEST_DETAILS = "param"
+    }
+
+    private fun effectiveQueryPatterns(queryParams: QueryParameters): Map<String, Pattern> {
+        return formExplodedObjectQueryParams.fold(queryPatterns) { patterns, objectQueryParam ->
+            when {
+                objectQueryParam.required || objectQueryParam.propertyKeys.any(queryParams::containsKey) ->
+                    objectQueryParam.requiredPropertyKeys.fold(patterns) { updatedPatterns, propertyKey ->
+                        updatedPatterns.makeKeyMandatory(propertyKey)
+                    }
+                else -> patterns
+            }
+        }
+    }
+
+    private fun effectiveQueryPatterns(row: Row): Map<String, Pattern> {
+        return formExplodedObjectQueryParams.fold(queryPatterns) { patterns, objectQueryParam ->
+            when {
+                objectQueryParam.required || objectQueryParam.propertyKeys.any(row::containsField) ->
+                    objectQueryParam.requiredPropertyKeys.fold(patterns) { updatedPatterns, propertyKey ->
+                        updatedPatterns.makeKeyMandatory(propertyKey)
+                    }
+                else -> patterns
+            }
+        }
+    }
+
+    private fun Map<String, Pattern>.makeKeyMandatory(key: String): Map<String, Pattern> {
+        val optionalKey = withOptionality(key)
+        val pattern = this[key] ?: this[optionalKey] ?: return this
+        return this.minus(optionalKey).plus(key to pattern)
+    }
+
+    private fun Map<String, Pattern>.normalizedKeys(): Set<String> {
+        return keys.map(::withoutOptionality).toSet()
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/QueryParameters.kt
+++ b/core/src/main/kotlin/io/specmatic/core/QueryParameters.kt
@@ -102,17 +102,26 @@ data class QueryParameters(val paramPairs: List<Pair<String, String>> = emptyLis
 
     fun withoutMatching(patternKeys: Set<String>, additionalProperties: Pattern, resolver: Resolver): QueryParameters {
         return QueryParameters(paramPairs.filterNot { (key, value) ->
-            if(key in patternKeys)
-                return@filterNot false
-
-            try {
-                val parsedValue: Value = additionalProperties.parse(value, resolver)
-                additionalProperties.matches(parsedValue, resolver) is Result.Success
-            } catch(e: Throwable) {
-                false
-            }
-
+            matchesAdditionalProperty(key, value, patternKeys, additionalProperties, resolver)
         })
+    }
+
+    fun matching(patternKeys: Set<String>, additionalProperties: Pattern, resolver: Resolver): QueryParameters {
+        return QueryParameters(paramPairs.filter { (key, value) ->
+            matchesAdditionalProperty(key, value, patternKeys, additionalProperties, resolver)
+        })
+    }
+
+    private fun matchesAdditionalProperty(key: String, value: String, patternKeys: Set<String>, additionalProperties: Pattern, resolver: Resolver): Boolean {
+        if(key in patternKeys)
+            return false
+
+        return try {
+            val parsedValue: Value = additionalProperties.parse(value, resolver)
+            additionalProperties.matches(parsedValue, resolver) is Result.Success
+        } catch(e: Throwable) {
+            false
+        }
     }
 }
 

--- a/core/src/test/kotlin/integration_tests/LenientParserTest.kt
+++ b/core/src/test/kotlin/integration_tests/LenientParserTest.kt
@@ -448,7 +448,7 @@ class LenientParserTest {
                     }
                 },
 
-                multiVersionLenientCase(name = "object schema not supported", *OpenApiVersion.allVersions()) {
+                multiVersionLenientCase(name = "object schema with non-exploded form serialization not supported", *OpenApiVersion.allVersions()) {
                     openApi {
                         paths {
                             path("/test") {
@@ -456,6 +456,8 @@ class LenientParserTest {
                                     parameter {
                                         put("name", "filter")
                                         put("in", "query")
+                                        put("style", "form")
+                                        put("explode", false)
                                         put("schema", mapOf("type" to "object"))
                                     }
                                 }
@@ -466,10 +468,10 @@ class LenientParserTest {
                     assert("paths./test.get.parameters[0].schema") {
                         toHaveSeverity(IssueSeverity.WARNING)
                         toContainViolation(OpenApiLintViolations.UNSUPPORTED_FEATURE)
-                        toMatchText("Query parameter filter is an object, and not yet supported")
+                        toMatchText("Query parameter filter is an object, and only style form with explode true is supported")
                     }
                 },
-                multiVersionLenientCase(name = "refed out object schema not supported", *OpenApiVersion.allVersions()) {
+                multiVersionLenientCase(name = "refed out object schema with non-exploded form serialization not supported", *OpenApiVersion.allVersions()) {
                     openApi {
                         paths {
                             path("/test") {
@@ -477,6 +479,8 @@ class LenientParserTest {
                                     parameter {
                                         put("name", "filter")
                                         put("in", "query")
+                                        put("style", "form")
+                                        put("explode", false)
                                         put("schema", mapOf("\$ref" to "#/components/schemas/FilterObject"))
                                     }
                                 }
@@ -494,7 +498,7 @@ class LenientParserTest {
                     assert("paths./test.get.parameters[0].schema") {
                         toHaveSeverity(IssueSeverity.WARNING)
                         toContainViolation(OpenApiLintViolations.UNSUPPORTED_FEATURE)
-                        toMatchText("Query parameter filter is an object, and not yet supported")
+                        toMatchText("Query parameter filter is an object, and only style form with explode true is supported")
                     }
                 },
             ).flatten().stream()

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -3,19 +3,21 @@ package io.specmatic.conversions
 import integration_tests.OpenApiVersion
 import io.specmatic.core.HttpRequest
 import io.specmatic.core.QueryParameters
+import io.specmatic.core.Resolver
+import io.specmatic.core.Result
 import io.specmatic.core.pattern.AnythingPattern
 import io.specmatic.core.pattern.BooleanPattern
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.DeferredPattern
 import io.specmatic.core.pattern.NumberPattern
 import io.specmatic.core.pattern.QueryParameterScalarPattern
-import io.specmatic.core.Result
-import io.specmatic.core.Resolver
 import io.specmatic.core.pattern.StringPattern
 import io.specmatic.core.pattern.XMLPattern
 import io.specmatic.core.pattern.XMLTypeData
 import io.specmatic.core.pattern.resolvedHop
 import io.specmatic.core.utilities.yamlMapper
+import io.specmatic.stub.captureStandardOutput
+import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -328,6 +330,41 @@ class OpenApiSpecificationParseTest {
             Resolver()
         )
         assertThat(completeInfo).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `required form exploded object query param with no required properties treats all object properties as optional`() {
+        val queryParamPattern = OpenApiSpecification.fromYAML(requiredObjectQueryParamWithNoRequiredPropertiesSpec(), "")
+            .toFeature()
+            .scenarios
+            .single()
+            .httpRequestPattern
+            .httpQueryParamPattern
+
+        assertThat(queryParamPattern.queryPatterns.keys).containsExactlyInAnyOrder("name?", "description?")
+
+        assertThat(queryParamPattern.matches(HttpRequest("GET", "/orders"), Resolver())).isInstanceOf(Result.Success::class.java)
+        assertThat(
+            queryParamPattern.matches(
+                HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("description" to "buyer"))),
+                Resolver()
+            )
+        ).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `required form exploded object query param with no required properties should warn`() {
+        val (stdout, _) = captureStandardOutput {
+            OpenApiSpecification.fromYAML(requiredObjectQueryParamWithNoRequiredPropertiesSpec(), "spec.yaml").toFeature()
+        }
+
+        assertThat(stdout).containsIgnoringWhitespaces(
+            toViolationReportString(
+                breadCrumb = "paths./orders.get.parameters[0].required",
+                details = "Query parameter info is a required form-exploded object, but its schema does not define any required properties. Since form-exploded object parameters are represented by their properties, no property is made mandatory.",
+                OpenApiLintViolations.SCHEMA_UNCLEAR
+            )
+        )
     }
 
     @Test
@@ -752,6 +789,32 @@ class OpenApiSpecificationParseTest {
             put("properties", mapOf(propertyName to mapOf("type" to "string")))
             if (additionalProperties != null) put("additionalProperties", additionalProperties)
         }
+    }
+
+    private fun requiredObjectQueryParamWithNoRequiredPropertiesSpec(): String {
+        return """
+            openapi: 3.0.0
+            info:
+              title: Required Form Exploded Object Query Param
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: info
+                      required: true
+                      schema:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          description:
+                            type: string
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -362,7 +362,7 @@ class OpenApiSpecificationParseTest {
             toViolationReportString(
                 breadCrumb = "paths./orders.get.parameters[0].required",
                 details = "Query parameter info is a required form-exploded object, but its schema does not define any required properties. Since form-exploded object parameters are represented by their properties, no property is made mandatory.",
-                OpenApiLintViolations.SCHEMA_UNCLEAR
+                OpenApiLintViolations.REQUIRED_QUERY_OBJECT_CONFLICT
             )
         )
     }

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -589,12 +589,169 @@ class OpenApiSpecificationParseTest {
     }
 
     @Test
+    fun `form exploded object query params allow any additional query param with free form additional properties`() {
+        val queryParamPattern = queryParamPatternWithObjectAdditionalProperties(
+            personAdditionalProperties = true
+        )
+
+        val result = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "not-a-boolean"))),
+            Resolver()
+        )
+
+        assertThat(result).withFailMessage(result.reportString()).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `form exploded object query params allow any additional query param when any object allows free form additional properties`() {
+        val queryParamPattern = queryParamPatternWithObjectAdditionalProperties(
+            personAdditionalProperties = mapOf("type" to "boolean"),
+            departmentAdditionalProperties = true
+        )
+
+        val result = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "not-a-boolean"))),
+            Resolver()
+        )
+
+        assertThat(result).withFailMessage(result.reportString()).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `form exploded object query params restrict additional query params to a single schema`() {
+        val queryParamPattern = queryParamPatternWithObjectAdditionalProperties(
+            personAdditionalProperties = mapOf("type" to "boolean")
+        )
+
+        val validResult = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "true"))),
+            Resolver()
+        )
+        val invalidResult = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "not-a-boolean"))),
+            Resolver()
+        )
+
+        assertThat(validResult).withFailMessage(validResult.reportString()).isInstanceOf(Result.Success::class.java)
+        assertThat(invalidResult).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `form exploded object query params allow additional query params matching any constrained schema`() {
+        val queryParamPattern = queryParamPatternWithObjectAdditionalProperties(
+            personAdditionalProperties = mapOf("type" to "boolean"),
+            departmentAdditionalProperties = mapOf("type" to "integer")
+        )
+
+        val booleanResult = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "true"))),
+            Resolver()
+        )
+        val integerResult = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "10"))),
+            Resolver()
+        )
+        val invalidResult = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "not-a-boolean-or-integer"))),
+            Resolver()
+        )
+
+        assertThat(booleanResult).withFailMessage(booleanResult.reportString()).isInstanceOf(Result.Success::class.java)
+        assertThat(integerResult).withFailMessage(integerResult.reportString()).isInstanceOf(Result.Success::class.java)
+        assertThat(invalidResult).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
+    fun `form exploded object query param should use additionalProperties from referenced object schema`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Referenced Object Query Param
+              version: 1.0.0
+            paths:
+              /test:
+                get:
+                  parameters:
+                    - in: query
+                      name: info
+                      schema:
+                        ${"$"}ref: '#/components/schemas/Info'
+                  responses:
+                    '200':
+                      description: OK
+            components:
+              schemas:
+                Info:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                  additionalProperties:
+                    type: boolean
+        """.trimIndent()
+
+        val queryParamPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern.httpQueryParamPattern
+
+        val validResult = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "true"))),
+            Resolver()
+        )
+        val invalidResult = queryParamPattern.matches(
+            HttpRequest("GET", "/test", queryParams = QueryParameters(mapOf("extra" to "not-a-boolean"))),
+            Resolver()
+        )
+
+        assertThat(validResult).withFailMessage(validResult.reportString()).isInstanceOf(Result.Success::class.java)
+        assertThat(invalidResult).isInstanceOf(Result.Failure::class.java)
+    }
+
+    @Test
     fun `should guard against the swagger-parser regression for discriminator mappings to external schema files with nested refs`() {
         val specFile = File("src/test/resources/openapi/discriminator_external_file_refs/openapi.yaml")
 
         val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature()
 
         assertThat(feature.scenarios).hasSize(1)
+    }
+
+    private fun queryParamPatternWithObjectAdditionalProperties(
+        personAdditionalProperties: Any?,
+        departmentAdditionalProperties: Any? = null
+    ) = OpenApiSpecification.fromYAML(
+        yamlMapper.writeValueAsString(
+            mapOf(
+                "openapi" to "3.0.0",
+                "info" to mapOf("title" to "Test API", "version" to "1.0.0"),
+                "paths" to mapOf(
+                    "/test" to mapOf(
+                        "get" to mapOf(
+                            "parameters" to listOf(
+                                mapOf(
+                                    "name" to "person_info",
+                                    "in" to "query",
+                                    "schema" to objectSchema("name", personAdditionalProperties)
+                                ),
+                                mapOf(
+                                    "name" to "department_info",
+                                    "in" to "query",
+                                    "schema" to objectSchema("department", departmentAdditionalProperties)
+                                )
+                            ),
+                            "responses" to mapOf("200" to mapOf("description" to "OK"))
+                        )
+                    )
+                )
+            )
+        ),
+        "test-api.yaml"
+    ).toFeature().scenarios.single().httpRequestPattern.httpQueryParamPattern
+
+    private fun objectSchema(propertyName: String, additionalProperties: Any?): Map<String, Any?> {
+        return buildMap {
+            put("type", "object")
+            put("properties", mapOf(propertyName to mapOf("type" to "string")))
+            if (additionalProperties != null) put("additionalProperties", additionalProperties)
+        }
     }
 
     companion object {

--- a/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
+++ b/core/src/test/kotlin/io/specmatic/conversions/OpenApiSpecificationParseTest.kt
@@ -1,6 +1,8 @@
 package io.specmatic.conversions
 
 import integration_tests.OpenApiVersion
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.QueryParameters
 import io.specmatic.core.pattern.AnythingPattern
 import io.specmatic.core.pattern.BooleanPattern
 import io.specmatic.core.pattern.ContractException
@@ -211,6 +213,163 @@ class OpenApiSpecificationParseTest {
 
         val headerPattern = requestPattern.headersPattern.pattern["X-Request-Id"]
         assertThat(headerPattern).isInstanceOf(NumberPattern::class.java)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun `should parse form exploded object query parameter properties as query params`(explicitSerialization: Boolean) {
+        val serialization = if (explicitSerialization) {
+            "          style: form\n          explode: true\n"
+        } else {
+            ""
+        }
+        val spec = """
+            |openapi: 3.0.0
+            |info:
+            |  title: Form Exploded Object Query Param
+            |  version: 1.0.0
+            |paths:
+            |  /orders:
+            |    get:
+            |      parameters:
+            |        - in: query
+            |          name: info
+            |          required: true
+            |${serialization}          schema:
+            |            ${"$"}ref: '#/components/schemas/info'
+            |        - in: query
+            |          name: type
+            |          required: false
+            |          schema:
+            |            type: string
+            |      responses:
+            |        '200':
+            |          description: OK
+            |components:
+            |  schemas:
+            |    info:
+            |      type: object
+            |      required:
+            |        - name
+            |      properties:
+            |        name:
+            |          type: string
+            |        description:
+            |          type: string
+        """.trimMargin()
+
+        val queryParamPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern.httpQueryParamPattern
+
+        assertThat(queryParamPattern.queryPatterns.keys).containsExactlyInAnyOrder("name", "description?", "type?")
+        assertThat(queryParamPattern.queryPatterns).doesNotContainKey("info")
+        assertThat(queryParamPattern.queryPatterns["name"]).isInstanceOf(QueryParameterScalarPattern::class.java)
+
+        val result = queryParamPattern.matches(
+            HttpRequest(
+                "GET",
+                "/orders",
+                queryParams = QueryParameters(listOf("name" to "Jane", "description" to "buyer", "type" to "retail"))
+            ),
+            Resolver()
+        )
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `should require required object properties only when optional form exploded object query param is present`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Optional Form Exploded Object Query Param
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: info
+                      required: false
+                      schema:
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            type: string
+                          description:
+                            type: string
+                    - in: query
+                      name: type
+                      required: false
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val queryParamPattern = OpenApiSpecification.fromYAML(spec, "").toFeature().scenarios.single().httpRequestPattern.httpQueryParamPattern
+
+        val withoutInfo = queryParamPattern.matches(
+            HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("type" to "retail"))),
+            Resolver()
+        )
+        assertThat(withoutInfo).isInstanceOf(Result.Success::class.java)
+
+        val partialInfo = queryParamPattern.matches(
+            HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("description" to "buyer"))),
+            Resolver()
+        )
+        assertThat(partialInfo).isInstanceOf(Result.Failure::class.java)
+        assertThat(partialInfo.reportString()).contains("name")
+
+        val completeInfo = queryParamPattern.matches(
+            HttpRequest("GET", "/orders", queryParams = QueryParameters(listOf("name" to "Jane"))),
+            Resolver()
+        )
+        assertThat(completeInfo).isInstanceOf(Result.Success::class.java)
+    }
+
+    @Test
+    fun `standalone query parameter colliding with form exploded object property should be reported and dropped`() {
+        val spec = """
+            openapi: 3.0.0
+            info:
+              title: Colliding Form Exploded Object Query Param
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  parameters:
+                    - in: query
+                      name: info
+                      required: true
+                      schema:
+                        type: object
+                        required:
+                          - type
+                        properties:
+                          type:
+                            type: integer
+                    - in: query
+                      name: type
+                      required: false
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: OK
+        """.trimIndent()
+
+        val (feature, result) = OpenApiSpecification.fromYAML(spec, "").toFeatureLenient()
+        val queryPatterns = feature.scenarios.single().httpRequestPattern.httpQueryParamPattern.queryPatterns
+        val typePattern = queryPatterns["type"]
+
+        assertThat(result).isInstanceOf(Result.Failure::class.java)
+        assertThat(result.reportString()).contains("conflicts with form-exploded object query parameter info.type")
+        assertThat(queryPatterns.keys).containsExactly("type")
+        assertThat(typePattern).isInstanceOf(QueryParameterScalarPattern::class.java)
+        assertThat((typePattern as QueryParameterScalarPattern).pattern).isInstanceOf(NumberPattern::class.java)
     }
 
     @ParameterizedTest(name = "openapi {0}")

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -3344,6 +3344,20 @@ paths:
     }
 
     @Test
+    fun `mandatory form exploded object query param example with only optional property should mention object query param name`(@TempDir tempDir: File) {
+        val specFile = writeFormExplodedObjectQueryParamSpec(tempDir, objectParamRequired = true)
+        val examplesDir = tempDir.resolve("object_query_param_examples").also { it.mkdirs() }
+        writeExternalizedExample(examplesDir, "optional-only.json", "/data?description=buyer")
+
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception))
+                .contains("The request includes property \"description\" from required form-exploded query parameter object \"info\"")
+        })
+    }
+
+    @Test
     @Disabled
     fun `should be able to stub out enum with string type using substitution`() {
         createStubFromContracts(

--- a/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/FeatureTest.kt
@@ -3293,6 +3293,57 @@ paths:
     }
 
     @Test
+    fun `validate externalized examples for absent required-only and all optional form exploded object query params`(@TempDir tempDir: File) {
+        val specFile = writeFormExplodedObjectQueryParamSpec(tempDir)
+        val examplesDir = tempDir.resolve("object_query_param_examples").also { it.mkdirs() }
+        writeExternalizedExample(examplesDir, "absent.json", "/data")
+        writeExternalizedExample(examplesDir, "required-only.json", "/data?name=Jane")
+        writeExternalizedExample(examplesDir, "all.json", "/data?name=Jane&description=buyer")
+
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
+
+        assertDoesNotThrow { feature.validateExamplesOrException() }
+    }
+
+    @Test
+    fun `optional form exploded object query param example with only optional property should fail validation`(@TempDir tempDir: File) {
+        val specFile = writeFormExplodedObjectQueryParamSpec(tempDir)
+        val examplesDir = tempDir.resolve("object_query_param_examples").also { it.mkdirs() }
+        writeExternalizedExample(examplesDir, "optional-only.json", "/data?description=buyer")
+
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.QUERY.name")
+        })
+    }
+
+    @Test
+    fun `validate externalized examples for required-only and all mandatory form exploded object query params`(@TempDir tempDir: File) {
+        val specFile = writeFormExplodedObjectQueryParamSpec(tempDir, objectParamRequired = true)
+        val examplesDir = tempDir.resolve("object_query_param_examples").also { it.mkdirs() }
+        writeExternalizedExample(examplesDir, "required-only.json", "/data?name=Jane")
+        writeExternalizedExample(examplesDir, "all.json", "/data?name=Jane&description=buyer")
+
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
+
+        assertDoesNotThrow { feature.validateExamplesOrException() }
+    }
+
+    @Test
+    fun `mandatory form exploded object query param example with absent object should fail validation`(@TempDir tempDir: File) {
+        val specFile = writeFormExplodedObjectQueryParamSpec(tempDir, objectParamRequired = true)
+        val examplesDir = tempDir.resolve("object_query_param_examples").also { it.mkdirs() }
+        writeExternalizedExample(examplesDir, "absent.json", "/data")
+
+        val feature = OpenApiSpecification.fromFile(specFile.canonicalPath).toFeature().loadExternalisedExamples()
+
+        assertThatThrownBy { feature.validateExamplesOrException() }.satisfies(Consumer { exception ->
+            assertThat(exceptionCauseMessage(exception)).contains("REQUEST.PARAMETERS.QUERY.name")
+        })
+    }
+
+    @Test
     @Disabled
     fun `should be able to stub out enum with string type using substitution`() {
         createStubFromContracts(
@@ -3937,6 +3988,54 @@ paths:
                 .filter { it.isFile && it.extension == "json" }
                 .sortedBy { it.name }
                 .map { ScenarioStub.readFromFile(it) }
+        }
+
+        private fun writeFormExplodedObjectQueryParamSpec(tempDir: File, objectParamRequired: Boolean = false): File {
+            return tempDir.resolve("object_query_param.yaml").apply {
+                writeText(
+                    """
+                    openapi: 3.0.0
+                    info:
+                      title: Object Query Param API
+                      version: 1.0.0
+                    paths:
+                      /data:
+                        get:
+                          parameters:
+                            - in: query
+                              name: info
+                              required: $objectParamRequired
+                              schema:
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                  description:
+                                    type: string
+                          responses:
+                            '200':
+                              description: OK
+                    """.trimIndent()
+                )
+            }
+        }
+
+        private fun writeExternalizedExample(examplesDir: File, fileName: String, path: String) {
+            examplesDir.resolve(fileName).writeText(
+                """
+                {
+                  "http-request": {
+                    "method": "GET",
+                    "path": "$path"
+                  },
+                  "http-response": {
+                    "status": 200
+                  }
+                }
+                """.trimIndent()
+            )
         }
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -284,6 +284,38 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
+    fun `should explain missing required properties when mandatory form exploded object query param has only optional property`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf(
+                "name" to QueryParameterScalarPattern(StringPattern()),
+                "description?" to QueryParameterScalarPattern(StringPattern())
+            ),
+            formExplodedObjectQueryParams = listOf(
+                FormExplodedObjectQueryParam(
+                    parameterName = "info",
+                    required = true,
+                    propertyKeys = setOf("name", "description"),
+                    requiredPropertyKeys = setOf("name")
+                )
+            )
+        )
+
+        val result = queryPattern.matches(
+            HttpRequest("GET", "/", queryParams = QueryParameters(listOf("description" to "buyer"))),
+            Resolver()
+        )
+
+        assertThat(result).isInstanceOf(Failure::class.java)
+        assertThat(result.reportString()).isEqualToIgnoringWhitespace(
+            toViolationReportString(
+                breadCrumb = "PARAMETERS.QUERY.name",
+                details = "The request includes property \"description\" from required form-exploded query parameter object \"info\". Required property \"name\" must also be provided.",
+                StandardRuleViolation.REQUIRED_PROPERTY_MISSING
+            )
+        )
+    }
+
+    @Test
     @Tag(GENERATION)
     fun `should generate required-only and all combinations for mandatory form exploded object query params from row`() {
         val queryPattern = HttpQueryParamPattern(

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -624,6 +624,31 @@ class HttpQueryParamPatternTest {
         }
 
         @Test
+        fun `should add missing required property when optional form exploded object query param is partially present`() {
+            val queryPattern = HttpQueryParamPattern(
+                mapOf(
+                    "name?" to QueryParameterScalarPattern(StringPattern()),
+                    "description?" to QueryParameterScalarPattern(StringPattern())
+                ),
+                formExplodedObjectQueryParams = listOf(
+                    FormExplodedObjectQueryParam(
+                        parameterName = "info",
+                        required = false,
+                        propertyKeys = setOf("name", "description"),
+                        requiredPropertyKeys = setOf("name")
+                    )
+                )
+            )
+            val invalidValue = QueryParameters(listOf("description" to "buyer"))
+
+            val dictionary = "PARAMETERS: { QUERY: { name: Jane } }".let(Dictionary::fromYaml)
+            val fixedValue = queryPattern.fixValue(invalidValue, Resolver(dictionary = dictionary))
+
+            assertThat(fixedValue.keys).containsExactlyInAnyOrder("name", "description")
+            assertThat(fixedValue.getValues("description")).containsExactly("buyer")
+        }
+
+        @Test
         fun `should not add missing optional keys`() {
             val queryPattern = HttpQueryParamPattern(mapOf("petId" to NumberPattern(), "owner?" to StringPattern()))
 

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -198,6 +198,147 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
+    @Tag(GENERATION)
+    fun `should generate absent required-only and all combinations for optional form exploded object query params from row`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf(
+                "name?" to QueryParameterScalarPattern(StringPattern()),
+                "description?" to QueryParameterScalarPattern(StringPattern())
+            ),
+            formExplodedObjectQueryParams = listOf(
+                FormExplodedObjectQueryParam(
+                    parameterName = "info",
+                    required = false,
+                    propertyKeys = setOf("name", "description"),
+                    requiredPropertyKeys = setOf("name")
+                )
+            )
+        )
+
+        val generatedPatterns = queryPattern.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns.keys }
+
+        assertThat(generatedPatterns).containsExactlyInAnyOrder(
+            emptySet(),
+            setOf("name"),
+            setOf("name", "description")
+        )
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `should generate absent required-only and all combinations for optional form exploded object query params without row`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf(
+                "name?" to QueryParameterScalarPattern(StringPattern()),
+                "description?" to QueryParameterScalarPattern(StringPattern())
+            ),
+            formExplodedObjectQueryParams = listOf(
+                FormExplodedObjectQueryParam(
+                    parameterName = "info",
+                    required = false,
+                    propertyKeys = setOf("name", "description"),
+                    requiredPropertyKeys = setOf("name")
+                )
+            )
+        )
+
+        val generatedPatterns = queryPattern.newBasedOn(Resolver()).toList().map { it.queryPatterns.keys }
+
+        assertThat(generatedPatterns).containsExactlyInAnyOrder(
+            emptySet(),
+            setOf("name"),
+            setOf("name", "description")
+        )
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `should generate required-only and all combinations for mandatory form exploded object query params from row`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf(
+                "name" to QueryParameterScalarPattern(StringPattern()),
+                "description?" to QueryParameterScalarPattern(StringPattern())
+            ),
+            formExplodedObjectQueryParams = listOf(
+                FormExplodedObjectQueryParam(
+                    parameterName = "info",
+                    required = true,
+                    propertyKeys = setOf("name", "description"),
+                    requiredPropertyKeys = setOf("name")
+                )
+            )
+        )
+
+        val generatedPatterns = queryPattern.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns.keys }
+
+        assertThat(generatedPatterns).containsExactlyInAnyOrder(
+            setOf("name"),
+            setOf("name", "description")
+        )
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `should generate required-only and all combinations for mandatory form exploded object query params without row`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf(
+                "name" to QueryParameterScalarPattern(StringPattern()),
+                "description?" to QueryParameterScalarPattern(StringPattern())
+            ),
+            formExplodedObjectQueryParams = listOf(
+                FormExplodedObjectQueryParam(
+                    parameterName = "info",
+                    required = true,
+                    propertyKeys = setOf("name", "description"),
+                    requiredPropertyKeys = setOf("name")
+                )
+            )
+        )
+
+        val generatedPatterns = queryPattern.newBasedOn(Resolver()).toList().map { it.queryPatterns.keys }
+
+        assertThat(generatedPatterns).containsExactlyInAnyOrder(
+            setOf("name"),
+            setOf("name", "description")
+        )
+    }
+
+    @Test
+    @Tag(GENERATION)
+    fun `should generate one required-only combination across multiple optional form exploded object query params`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf(
+                "name?" to QueryParameterScalarPattern(StringPattern()),
+                "description?" to QueryParameterScalarPattern(StringPattern()),
+                "department?" to QueryParameterScalarPattern(StringPattern()),
+                "location?" to QueryParameterScalarPattern(StringPattern())
+            ),
+            formExplodedObjectQueryParams = listOf(
+                FormExplodedObjectQueryParam(
+                    parameterName = "person_info",
+                    required = false,
+                    propertyKeys = setOf("name", "description"),
+                    requiredPropertyKeys = setOf("name")
+                ),
+                FormExplodedObjectQueryParam(
+                    parameterName = "department_info",
+                    required = false,
+                    propertyKeys = setOf("department", "location"),
+                    requiredPropertyKeys = setOf("department")
+                )
+            )
+        )
+
+        val generatedPatterns = queryPattern.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns.keys }
+
+        assertThat(generatedPatterns).containsExactlyInAnyOrder(
+            emptySet(),
+            setOf("name", "department"),
+            setOf("name", "description", "department", "location")
+        )
+    }
+
+    @Test
     fun `should correctly stringize a url matching having a query param with an array type`() {
         val matcher = HttpQueryParamPattern(mapOf("data" to CsvPattern(NumberPattern())))
         assertThat(matcher.toString()).isEqualTo("?data=(csv/number)")

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -563,7 +563,7 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
-    fun `an additional query param should be added in a generated value`() {
+    fun `an additional query param should not be added in a generated value`() {
         val queryPattern = HttpQueryParamPattern(mapOf("key" to QueryParameterScalarPattern(NumberPattern())), NumberPattern())
 
         val generatedValue = queryPattern.generate(Resolver())
@@ -571,24 +571,58 @@ class HttpQueryParamPatternTest {
         val keys = generatedValue.map { it.first }
         val values = generatedValue.map { it.second }
 
-        assertThat(generatedValue).hasSize(2)
-        assertThat(keys).contains("key")
-        assertThat(keys.filter { it != "key" }).hasSize(1)
+        assertThat(generatedValue).hasSize(1)
+        assertThat(keys).containsExactly("key")
         assertThat(values).allSatisfy {
             assertThat(it.toIntOrNull()).withFailMessage("$it was expected to be a number").isNotNull()
         }
     }
 
     @Test
-    fun `an additional query param should be added in a test`() {
+    fun `an additional query param should not be added in a test`() {
         val queryPattern = HttpQueryParamPattern(mapOf("key" to QueryParameterScalarPattern(NumberPattern())), NumberPattern())
 
         val generatedValue = queryPattern.newBasedOn(Row(), Resolver()).toList().map { it.value.queryPatterns }
 
         assertThat(generatedValue).hasSize(1)
-        assertThat(generatedValue.first()).hasSize(2)
-        assertThat(generatedValue.first().keys).contains("key")
-        assertThat(generatedValue.first().keys.filter { it != "key" }).hasSize(1)
+        assertThat(generatedValue.first()).containsOnlyKeys("key")
+    }
+
+    @Test
+    fun `valid additional query params should be preserved when fixing values`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf("key" to QueryParameterScalarPattern(NumberPattern())),
+            NumberPattern()
+        )
+
+        val fixedValue = queryPattern.fixValue(QueryParameters(mapOf("key" to "10", "extra" to "20")), Resolver())
+
+        assertThat(fixedValue.asMap()).containsEntry("extra", "20")
+    }
+
+    @Test
+    fun `invalid additional query params should be fixed when fixing values`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf("key" to QueryParameterScalarPattern(NumberPattern())),
+            NumberPattern()
+        )
+
+        val fixedValue = queryPattern.fixValue(QueryParameters(mapOf("key" to "10", "extra" to "abc")), Resolver())
+
+        assertThat(fixedValue.asMap()["extra"]).isNotEqualTo("abc")
+        assertThat(fixedValue.asMap()["extra"]?.toDoubleOrNull()).isNotNull()
+    }
+
+    @Test
+    fun `valid additional query params should be preserved when filling blanks`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf("key" to QueryParameterScalarPattern(NumberPattern())),
+            NumberPattern()
+        )
+
+        val filledValue = queryPattern.fillInTheBlanks(QueryParameters(mapOf("key" to "10", "extra" to "20")), Resolver()).value
+
+        assertThat(filledValue.asMap()).containsEntry("extra", "20")
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/HttpQueryParamPatternTest.kt
@@ -252,6 +252,38 @@ class HttpQueryParamPatternTest {
     }
 
     @Test
+    fun `should explain missing required properties when optional form exploded object query param is partially present`() {
+        val queryPattern = HttpQueryParamPattern(
+            mapOf(
+                "name?" to QueryParameterScalarPattern(StringPattern()),
+                "description?" to QueryParameterScalarPattern(StringPattern())
+            ),
+            formExplodedObjectQueryParams = listOf(
+                FormExplodedObjectQueryParam(
+                    parameterName = "info",
+                    required = false,
+                    propertyKeys = setOf("name", "description"),
+                    requiredPropertyKeys = setOf("name")
+                )
+            )
+        )
+
+        val result = queryPattern.matches(
+            HttpRequest("GET", "/", queryParams = QueryParameters(listOf("description" to "buyer"))),
+            Resolver()
+        )
+
+        assertThat(result).isInstanceOf(Failure::class.java)
+        assertThat(result.reportString()).isEqualToIgnoringWhitespace(
+            toViolationReportString(
+                breadCrumb = "PARAMETERS.QUERY.name",
+                details = "The request includes property \"description\" from optional form-exploded query parameter object \"info\". Since that object is present, required property \"name\" must also be provided.",
+                StandardRuleViolation.REQUIRED_PROPERTY_MISSING
+            )
+        )
+    }
+
+    @Test
     @Tag(GENERATION)
     fun `should generate required-only and all combinations for mandatory form exploded object query params from row`() {
         val queryPattern = HttpQueryParamPattern(


### PR DESCRIPTION
## What
- Parse form-style exploded object query params from OpenAPI specs, including `$ref` schemas.

## Why
- OpenAPI query params that model objects with `style: form` and `explode: true` were only partially handled.

## How
- Aggregate query-param `additionalProperties` per parameter in `OpenApiSpecification`.
- Carry `additionalProperties` through query-param parsing and matching logic.
- Keep positive generation paths limited to declared params, while letting `fixValue` repair supplied extra params against the additional-properties schema.
- Add regression coverage for parsing, matching, generation, fixing, and fill-in behavior.
