### PR TITLE
Implement CTRF report generation for backward compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,16 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven {
+            name = "sonatypeCentralSnapshots"
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            mavenContent {
+                snapshotsOnly()
+            }
+            content {
+                includeGroup("io.specmatic.build-reporter")
+            }
+        }
     }
 }
 

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -1,0 +1,50 @@
+package io.specmatic.core
+
+import io.specmatic.conversions.convertPathParameterStyle
+import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
+import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.reporter.internal.dto.operation.APIOperation
+import io.specmatic.reporter.model.BackwardCompatibilityResult
+import io.specmatic.reporter.model.SpecType
+import io.specmatic.test.openAPIOperationFrom
+import java.util.UUID
+
+data class OpenApiBackwardCompatibilityCheckRecord(
+    val feature: Feature,
+    val scenario: Scenario,
+    val compatResult: Result,
+    override val duration: Long = 0,
+    override val id: UUID = UUID.randomUUID(),
+    override val changeStatus: ChangeStatus = ChangeStatus.CHANGED,
+) : CtrfBackwardCompatibilityRecord {
+    override val specType: SpecType = scenario.specType
+    override val repository: String? = scenario.sourceRepository
+    override val branch: String? = scenario.sourceRepositoryBranch
+    override val specification: String = scenario.specification ?: feature.path
+
+    // TODO: Need actual positive variation from generatedScenario
+    override val name: String = scenario.fullApiDescription
+    override val message: String = compatResult.reportString()
+    override val operations: Set<APIOperation> = toOpenApiOperation(scenario)
+    override val tags: List<String> = buildList {
+        add("status:${scenario.status}")
+        add("method:${scenario.method.lowercase()}")
+        add("path:${convertPathParameterStyle(scenario.path)}")
+        scenario.requestContentType?.let { contentType -> add("content-type:$contentType") }
+        scenario.responseContentType?.let { contentType -> add("response-content-type:$contentType") }
+    }
+
+    override val result: BackwardCompatibilityResult = when (compatResult) {
+        is Result.Success -> BackwardCompatibilityResult.Compatible
+        is Result.Failure -> BackwardCompatibilityResult.Incompatible
+    }
+
+    override val operationQualifiers: List<CtrfOperationQualifiers> = buildList {
+        if (scenario.ignoreFailure) add(CtrfOperationQualifiers.WIP)
+    }
+
+    private fun toOpenApiOperation(scenario: Scenario): Set<APIOperation> = setOf(
+        element = openAPIOperationFrom(scenario, convertPathParameterStyle(scenario.path))
+    )
+}

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -1,29 +1,24 @@
 package io.specmatic.core
 
-import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
-import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.test.asserts.toFailure
-import io.specmatic.test.openAPIOperationFrom
 import java.util.Collections
 import java.util.IdentityHashMap
 
 class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, private val newFeature: Feature) {
     private val newScenariosByMethodAndReqContentType = newFeature.scenarios.groupBy { it.method to it.requestContentType }
 
-    fun run(): Map<OpenAPIOperation, Results> {
+    fun run(): List<OpenApiBackwardCompatibilityCheckRecord> {
         val requestFamilies = groupScenariosByPathAndMethod(oldFeature)
-        val resultsByOperation = buildMap {
+        return buildList {
             requestFamilies.forEach { requestFamily ->
-                val requestResults = validateRequestCompatibility(requestFamily)
-                val responseResults = validateResponseCompatibility(requestFamily, requestResults)
-                collectOperationResults(requestResults, responseResults, this@buildMap)
+                val requestResults = validateRequestCompatibility(requestFamily).also(::addAll)
+                val responseResults = validateResponseCompatibility(requestFamily, requestResults).also(::addAll)
+                logOperationResult(requestResults.plus(responseResults))
             }
         }
-
-        return resultsByOperation.mapValues { (_, results) -> Results(results).distinct() }
     }
 
     private fun groupScenariosByPathAndMethod(feature: Feature): List<RequestFamily> {
@@ -33,7 +28,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
             .map(::RequestFamily)
     }
 
-    private fun validateRequestCompatibility(requestFamily: RequestFamily): List<ResultWithScenario> {
+    private fun validateRequestCompatibility(requestFamily: RequestFamily): List<OpenApiBackwardCompatibilityCheckRecord> {
         val scenarioPerReqIdentifier = requestFamily.oneScenarioPerReqIdentifiers()
         val positiveVariations = generatePositiveVariations(scenarioPerReqIdentifier)
         val totalPositiveVariations = positiveVariations.size
@@ -63,38 +58,42 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         }
     }
 
-    private fun evaluateVariation(variationFromOldScenario: Scenario): List<ResultWithScenario> {
+    private fun logOperationResult(results: List<OpenApiBackwardCompatibilityCheckRecord>) {
+        val verdict = if (results.any { it.compatResult is Result.Failure }) "FAIL" else "PASS"
+        logger.log("[Compatibility Check] Verdict: $verdict")
+    }
+
+    private fun evaluateVariation(variationFromOldScenario: Scenario): List<OpenApiBackwardCompatibilityCheckRecord> {
         return try {
             val request = variationFromOldScenario.generateHttpRequest(backwardCompatibilityStrategies)
             requestMatches(request, variationFromOldScenario)
         } catch (contractException: ContractException) {
             val result = contractException.failure()
-            listOf(ResultWithScenario(result, variationFromOldScenario))
+            listOf(newRecord(variationFromOldScenario, result))
         } catch (_: StackOverflowError) {
             val result = Result.Failure(STACK_OVERFLOW_MESSAGE)
-            listOf(ResultWithScenario(result, variationFromOldScenario))
+            listOf(newRecord(variationFromOldScenario, result))
         } catch (_: EmptyContract) {
             val newFilePath = if (newFeature.path.isNotEmpty()) " at ${newFeature.path}" else ""
             val result = Result.Failure("The contract$newFilePath had no operations")
-            listOf(ResultWithScenario(result, variationFromOldScenario))
+            listOf(newRecord(variationFromOldScenario, result))
         } catch (throwable: Throwable) {
             val result = Result.Failure("Exception: ${throwable.localizedMessage}")
-            listOf(ResultWithScenario(result, variationFromOldScenario))
+            listOf(newRecord(variationFromOldScenario, result))
         }
     }
 
-    private fun requestMatches(request: HttpRequest, variationFromOldScenario: Scenario): List<ResultWithScenario> {
+    private fun requestMatches(request: HttpRequest, variationFromOldScenario: Scenario): List<OpenApiBackwardCompatibilityCheckRecord> {
         if (newFeature.scenarios.isEmpty()) throw EmptyContract()
-        val candidates = newScenariosByMethodAndReqContentType.findExactOrSingle(
+        val identifierMatches = newScenariosByMethodAndReqContentType.findExactOrSingle(
             first = variationFromOldScenario.method,
             second = variationFromOldScenario.requestContentType,
             valueFilter = { it.matchesPathStructureAndMethod(request) }
         )
 
-        val identifierMatches = candidates.filter { candidate -> candidate.matchesPathStructureAndMethod(request) }
         if (identifierMatches.isEmpty()) {
             val result = Result.Failure("This API exists in the old contract but not in the new contract")
-            return listOf(ResultWithScenario(result.updateScenario(variationFromOldScenario), variationFromOldScenario))
+            return listOf(newRecord(variationFromOldScenario, result))
         }
 
         // This is a performance optimization: If Path + Method + RequestContentType has many scenarios,
@@ -109,11 +108,11 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         // This is a performance optimization: As there can be multiple scenarios with responseCode and contentTypes,
         // we can associate first result with remaining avoiding re-valuation as they will share the same request schema as per OAS
         return identifierMatches.map { newScenario ->
-            ResultWithScenario(matchResult.updateScenario(newScenario), newScenario)
+            newRecord(newScenario, matchResult)
         }
     }
 
-    private fun validateResponseCompatibility(requestFamily: RequestFamily, requestResults: List<ResultWithScenario>): List<ResultWithScenario> {
+    private fun validateResponseCompatibility(requestFamily: RequestFamily, requestResults: List<OpenApiBackwardCompatibilityCheckRecord>): List<OpenApiBackwardCompatibilityCheckRecord> {
         val oldScenarios = requestFamily.oneScenarioPerResIdentifiers()
         val newScenarios = dedupeNewScenariosByIdentity(requestResults)
         val newScenariosByStatusAndResContentType = newScenarios.groupBy { it.status to it.responseContentType }
@@ -122,48 +121,41 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
             val identifierMatches = newScenariosByStatusAndResContentType.findExactOrSingle(oldScenario.status, oldScenario.responseContentType)
             if (identifierMatches.isEmpty()) {
                 val result = Result.Failure("This API exists in the old contract but not in the new contract")
-                return@flatMap listOf(ResultWithScenario(result.updateScenario(oldScenario), oldScenario))
+                return@flatMap listOf(newRecord(oldScenario, result))
             }
 
             identifierMatches.map { newScenario -> checkResponseEncompasses(oldScenario, newScenario) }
         }
     }
 
-    private fun dedupeNewScenariosByIdentity(requestResults: List<ResultWithScenario>): List<Scenario> {
+    private fun dedupeNewScenariosByIdentity(requestResults: List<OpenApiBackwardCompatibilityCheckRecord>): List<Scenario> {
         val seenScenarios = Collections.newSetFromMap(IdentityHashMap<Scenario, Boolean>())
         return requestResults.asSequence().map { it.scenario }.filter(seenScenarios::add).toList()
     }
 
-    private fun checkResponseEncompasses(oldScenario: Scenario, newScenario: Scenario): ResultWithScenario {
+    private fun checkResponseEncompasses(oldScenario: Scenario, newScenario: Scenario): OpenApiBackwardCompatibilityCheckRecord {
         return try {
-            ResultWithScenario(
+            newRecord(
                 scenario = newScenario,
                 result = oldScenario.httpResponsePattern.encompasses(
                     other = newScenario.httpResponsePattern,
                     olderResolver = oldScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
                     newerResolver = newScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
-                ).updateScenario(newScenario)
+                )
             )
         } catch (_: StackOverflowError) {
-            ResultWithScenario(Result.Failure(STACK_OVERFLOW_MESSAGE), newScenario)
+            newRecord(newScenario, Result.Failure(STACK_OVERFLOW_MESSAGE))
         } catch (throwable: Throwable) {
-            ResultWithScenario(throwable.toFailure(), newScenario)
+            newRecord(newScenario, throwable.toFailure())
         }
     }
 
-    private fun collectOperationResults(
-        requestResults: List<ResultWithScenario>,
-        responseResults: List<ResultWithScenario>,
-        resultsByOperation: MutableMap<OpenAPIOperation, MutableList<Result>>,
-    ) {
-        val failures = (requestResults + responseResults).filter { it.result is Result.Failure }
-        failures.forEach { resultWithScenario ->
-            val operation = openAPIOperationFrom(resultWithScenario.scenario, convertPathParameterStyle(resultWithScenario.scenario.path))
-            val operationResults = resultsByOperation.getOrPut(operation) { mutableListOf() }
-            operationResults.add(resultWithScenario.result)
-        }
-
-        logger.log("[Compatibility Check] Verdict: ${if (failures.isNotEmpty()) "FAIL" else "PASS"}")
+    private fun newRecord(scenario: Scenario, result: Result): OpenApiBackwardCompatibilityCheckRecord {
+        return OpenApiBackwardCompatibilityCheckRecord(
+            feature = newFeature,
+            scenario = scenario,
+            compatResult = result.updateScenario(scenario).withoutFailureReasons()
+        )
     }
 
     private fun <First, Second, Item> Map<Pair<First, Second?>, List<Item>>.findExactOrSingle(
@@ -187,7 +179,6 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
     }
 }
 
-private data class ResultWithScenario(val result: Result, val scenario: Scenario)
 private data class RequestFamily(val scenarios: List<Scenario>) {
     private val representativeScenario: Scenario = scenarios.first()
     private val groupedByRequestIdentifiers = scenarios.groupBy { Triple(it.path, it.method, it.requestContentType) }

--- a/core/src/main/kotlin/io/specmatic/core/Result.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Result.kt
@@ -52,6 +52,7 @@ sealed class Result {
     abstract fun failureReason(failureReason: FailureReason?): Result
     open fun toIssues(breadCrumbToJsonPathConverter: BreadCrumbToJsonPathConverter = BreadCrumbToJsonPathConverter()): List<Issue> = emptyList()
     open fun withRuleViolation(ruleViolation: RuleViolation): Result = this
+    open fun withoutFailureReasons(): Result = this
 
     abstract fun shouldBeIgnored(): Boolean
 
@@ -274,6 +275,10 @@ sealed class Result {
         fun withoutRuleViolation(): Failure {
             val causesWithoutFailure = this.causes.map { it.copy(cause = it.cause?.withoutRuleViolation()) }
             return this.copy(causes = causesWithoutFailure, ruleViolationReport = null)
+        }
+
+        override fun withoutFailureReasons(): Failure {
+            return this._removeReasonsFromCauses()
         }
 
         override fun toIssues(breadCrumbToJsonPathConverter: BreadCrumbToJsonPathConverter): List<Issue> {

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -7,17 +7,23 @@ import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
+import io.specmatic.reporter.ctrf.model.CtrfReport
 
 private const val BCC_REPORT_DIR_SUFFIX = "backward_compatibility"
 private const val SPECMATIC_BCC_REPORT_FLAG = "SPECMATIC_BCC_REPORT"
 
 fun testBackwardCompatibility(older: Feature, newer: Feature): Results {
+    return testBackwardCompatibilityWithReport(older, newer).first
+}
+
+internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature): Pair<Results, CtrfReport?> {
     val startTime = System.currentTimeMillis()
     val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
     val endTime = System.currentTimeMillis()
 
-    generateBackwardCompatibilityReport(records, startTime, endTime)
-    return records.toBackwardCompatibilityResults()
+    val result = records.toBackwardCompatibilityResults()
+    val report = generateBackwardCompatibilityReport(records, startTime, endTime)
+    return Pair(result, report)
 }
 
 fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityResults(): Results {
@@ -28,11 +34,11 @@ fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityResults(): Resu
         }
 }
 
-private fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long) {
-    if (!Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) return
+private fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? {
+    if (!Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) return null
     val reportOperations = BccReportGenerator().generateReportOperations(records)
     val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()
-    ReportGenerator.generateReportBcc(
+    return ReportGenerator.generateReportBcc(
         endTime = endTime,
         startTime = startTime,
         reportDir = reportDir,

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -1,12 +1,47 @@
 package io.specmatic.core
 
+import io.specmatic.core.report.BccReportGenerator
+import io.specmatic.core.report.ReportGenerator
+import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.Value
+import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
+import kotlin.runCatching
+
+private const val BCC_REPORT_DIR_SUFFIX = "backward_compatibility"
+private const val SPECMATIC_BCC_REPORT_FLAG = "SPECMATIC_BCC_REPORT"
 
 fun testBackwardCompatibility(older: Feature, newer: Feature): Results {
-    val operationToResult = OpenApiBackwardCompatibilityChecker(older, newer).run()
-    return operationToResult.values.fold(Results()) { acc, results -> acc.plus(results) }
+    val startTime = System.currentTimeMillis()
+    val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
+    val endTime = System.currentTimeMillis()
+
+    generateBackwardCompatibilityReport(records, startTime, endTime)
+    return records.toBackwardCompatibilityResults()
+}
+
+fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityResults(): Results {
+    return filterIsInstance<OpenApiBackwardCompatibilityCheckRecord>()
+        .groupBy { it.operations }.values
+        .fold(Results()) { acc, recordsForOperation ->
+            acc.plus(Results(recordsForOperation.map { it.compatResult }).distinct())
+        }
+}
+
+private fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long) {
+    if (!Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) return
+    runCatching {
+        val reportOperations = BccReportGenerator().generateReportOperations(records)
+        val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()
+        ReportGenerator.generateReportBcc(
+            endTime = endTime,
+            startTime = startTime,
+            reportDir = reportDir,
+            coverageReportOperations = reportOperations,
+            specConfigs = reportOperations.map { it.specConfig }.distinct(),
+        )
+    }
 }
 
 object NewAndOldSpecificationRequestMismatches: MismatchMessages {

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -7,7 +7,6 @@ import io.specmatic.core.utilities.capitalizeFirstChar
 import io.specmatic.core.value.NullValue
 import io.specmatic.core.value.Value
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
-import kotlin.runCatching
 
 private const val BCC_REPORT_DIR_SUFFIX = "backward_compatibility"
 private const val SPECMATIC_BCC_REPORT_FLAG = "SPECMATIC_BCC_REPORT"
@@ -31,17 +30,15 @@ fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityResults(): Resu
 
 private fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long) {
     if (!Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) return
-    runCatching {
-        val reportOperations = BccReportGenerator().generateReportOperations(records)
-        val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()
-        ReportGenerator.generateReportBcc(
-            endTime = endTime,
-            startTime = startTime,
-            reportDir = reportDir,
-            coverageReportOperations = reportOperations,
-            specConfigs = reportOperations.map { it.specConfig }.distinct(),
-        )
-    }
+    val reportOperations = BccReportGenerator().generateReportOperations(records)
+    val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()
+    ReportGenerator.generateReportBcc(
+        endTime = endTime,
+        startTime = startTime,
+        reportDir = reportDir,
+        coverageReportOperations = reportOperations,
+        specConfigs = reportOperations.map { it.specConfig }.distinct(),
+    )
 }
 
 object NewAndOldSpecificationRequestMismatches: MismatchMessages {

--- a/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
@@ -1,0 +1,76 @@
+package io.specmatic.core.report
+
+import io.specmatic.reporter.ctrf.model.BccCoverageReportOperation
+import io.specmatic.reporter.ctrf.model.BaseBccCoverageReportOperation
+import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
+import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
+import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.reporter.internal.dto.operation.APIOperation
+import io.specmatic.reporter.model.BackwardCompatibilityResult
+
+class BccReportGenerator {
+    fun generateReportOperations(tests: List<CtrfBackwardCompatibilityRecord>): List<BaseBccCoverageReportOperation> {
+        return tests.operationSources().groupByOperation().map { (groupKey, sources) ->
+            reportOperationFrom(groupKey, sources)
+        }
+    }
+
+    private fun reportOperationFrom(groupKey: BccOperationGroupKey, sources: List<BccOperationSource>): BaseBccCoverageReportOperation {
+        val tests = sources.map { it.test }
+        return BccCoverageReportOperation(
+            tests = tests,
+            operation = groupKey.operation,
+            specConfig = groupKey.specConfig,
+            qualifiers = operationQualifiersFrom(tests),
+            changeStatus = operationChangeStatus(tests),
+            backwardCompatibilityResult = backwardCompatibilityResultFrom(tests),
+        )
+    }
+
+    private fun operationQualifiersFrom(tests: List<CtrfBackwardCompatibilityRecord>): List<CtrfOperationQualifiers> {
+        return tests.flatMap { it.operationQualifiers }.distinct()
+    }
+
+    private fun operationChangeStatus(tests: List<CtrfBackwardCompatibilityRecord>): ChangeStatus {
+        return when {
+            tests.any { it.changeStatus == ChangeStatus.CHANGED } -> ChangeStatus.CHANGED
+            else -> ChangeStatus.UNCHANGED
+        }
+    }
+
+    private fun backwardCompatibilityResultFrom(tests: List<CtrfBackwardCompatibilityRecord>): BackwardCompatibilityResult {
+        return when {
+            tests.any { it.result == BackwardCompatibilityResult.Incompatible } -> BackwardCompatibilityResult.Incompatible
+            else -> BackwardCompatibilityResult.Compatible
+        }
+    }
+
+    private fun List<CtrfBackwardCompatibilityRecord>.operationSources(): List<BccOperationSource> {
+        return flatMap { test ->
+            test.operations.map { operation ->
+                val operationGroup = BccOperationGroupKey(specConfig = test.toCtrfSpecConfig(), operation = operation)
+                BccOperationSource(group = operationGroup, test = test)
+            }
+        }
+    }
+
+    private fun List<BccOperationSource>.groupByOperation(): Map<BccOperationGroupKey, List<BccOperationSource>> {
+        return groupBy { source ->
+            BccOperationGroupKey(specConfig = source.group.specConfig, operation = source.group.operation)
+        }
+    }
+
+    private fun CtrfBackwardCompatibilityRecord.toCtrfSpecConfig(): CtrfSpecConfig {
+        return CtrfSpecConfig(
+            repository = repository,
+            specType = specType.value,
+            branch = branch ?: "main",
+            specification = specification,
+            protocol = operations.first().protocol.key,
+        )
+    }
+
+    private data class BccOperationGroupKey(val specConfig: CtrfSpecConfig, val operation: APIOperation)
+    private data class BccOperationSource(val group: BccOperationGroupKey, val test: CtrfBackwardCompatibilityRecord)
+}

--- a/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
@@ -1,8 +1,9 @@
 package io.specmatic.core.report
 
-import io.specmatic.reporter.ctrf.model.BccCoverageReportOperation
-import io.specmatic.reporter.ctrf.model.BaseBccCoverageReportOperation
+import io.specmatic.reporter.ctrf.model.BccReportOperation
+import io.specmatic.reporter.ctrf.model.BaseBccReportOperation
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
+import io.specmatic.reporter.ctrf.model.CtrfOperationCompatibility
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
@@ -10,21 +11,23 @@ import io.specmatic.reporter.internal.dto.operation.APIOperation
 import io.specmatic.reporter.model.BackwardCompatibilityResult
 
 class BccReportGenerator {
-    fun generateReportOperations(tests: List<CtrfBackwardCompatibilityRecord>): List<BaseBccCoverageReportOperation> {
+    fun generateReportOperations(tests: List<CtrfBackwardCompatibilityRecord>): List<BaseBccReportOperation> {
         return tests.operationSources().groupByOperation().map { (groupKey, sources) ->
             reportOperationFrom(groupKey, sources)
         }
     }
 
-    private fun reportOperationFrom(groupKey: BccOperationGroupKey, sources: List<BccOperationSource>): BaseBccCoverageReportOperation {
+    private fun reportOperationFrom(groupKey: BccOperationGroupKey, sources: List<BccOperationSource>): BaseBccReportOperation {
         val tests = sources.map { it.test }
-        return BccCoverageReportOperation(
+        return BccReportOperation(
             tests = tests,
             operation = groupKey.operation,
             specConfig = groupKey.specConfig,
             qualifiers = operationQualifiersFrom(tests),
-            changeStatus = operationChangeStatus(tests),
-            backwardCompatibilityResult = backwardCompatibilityResultFrom(tests),
+            compatibility = CtrfOperationCompatibility(
+                changeStatus = operationChangeStatus(tests),
+                result = backwardCompatibilityResultFrom(tests),
+            ),
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -6,6 +6,7 @@ import io.specmatic.core.log.consoleLog
 import io.specmatic.reporter.ctrf.CtrfReportGenerator
 import io.specmatic.reporter.ctrf.model.BaseBccReportOperation
 import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
+import io.specmatic.reporter.ctrf.model.CtrfReport
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.reporting.ReportProvider
 import io.specmatic.specmatic.core.VersionInfo
@@ -61,8 +62,8 @@ object ReportGenerator {
         specConfigs: List<CtrfSpecConfig>,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
         coverageReportOperations: List<BaseBccReportOperation>,
-    ) {
-        if (isCtrfSpecConfigsValid(specConfigs).not()) return
+    ): CtrfReport? {
+        if (isCtrfSpecConfigsValid(specConfigs).not()) return null
         val totalChecksRan = coverageReportOperations.asSequence().flatMap { it.tests.asSequence() }.map { it.id }.distinct().count()
         val extra = buildMap<String, Any> {
             put("specmaticConfigPath", getConfigFilePath())
@@ -81,6 +82,7 @@ object ReportGenerator {
 
         ReportProvider.generateCtrfReport(report, reportDir)
         ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
+        return report
     }
 
     internal fun specmaticConfigAsMap(): Map<String, Any> {

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -4,7 +4,7 @@ import io.specmatic.core.config.toResolvedSpecmaticConfigMap
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.consoleLog
 import io.specmatic.reporter.ctrf.CtrfReportGenerator
-import io.specmatic.reporter.ctrf.model.BaseBccCoverageReportOperation
+import io.specmatic.reporter.ctrf.model.BaseBccReportOperation
 import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.reporting.ReportProvider
@@ -60,7 +60,7 @@ object ReportGenerator {
         reportDir: File,
         specConfigs: List<CtrfSpecConfig>,
         toolName: String = "Specmatic ${VersionInfo.describe()}",
-        coverageReportOperations: List<BaseBccCoverageReportOperation>,
+        coverageReportOperations: List<BaseBccReportOperation>,
     ) {
         if (isCtrfSpecConfigsValid(specConfigs).not()) return
         val totalChecksRan = coverageReportOperations.asSequence().flatMap { it.tests.asSequence() }.map { it.id }.distinct().count()
@@ -71,7 +71,7 @@ object ReportGenerator {
 
         consoleLog("Generating BCC report for $totalChecksRan checks and ${coverageReportOperations.size} operations...")
         val report = CtrfReportGenerator.generateBccReport(
-            coverageReportOperations = coverageReportOperations,
+            bccReportOperations = coverageReportOperations,
             specConfig = specConfigs,
             startTime = startTime,
             toolName = toolName,

--- a/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/ReportGenerator.kt
@@ -4,6 +4,7 @@ import io.specmatic.core.config.toResolvedSpecmaticConfigMap
 import io.specmatic.core.getConfigFilePath
 import io.specmatic.core.log.consoleLog
 import io.specmatic.reporter.ctrf.CtrfReportGenerator
+import io.specmatic.reporter.ctrf.model.BaseBccCoverageReportOperation
 import io.specmatic.reporter.ctrf.model.BaseCoverageReportOperation
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.reporting.ReportProvider
@@ -47,6 +48,35 @@ object ReportGenerator {
             extra = extra,
             specConfig = specConfigs,
             toolName = toolName
+        )
+
+        ReportProvider.generateCtrfReport(report, reportDir)
+        ReportProvider.generateHtmlReport(report, reportDir, specmaticConfigAsMap())
+    }
+
+    fun generateReportBcc(
+        endTime: Long,
+        startTime: Long,
+        reportDir: File,
+        specConfigs: List<CtrfSpecConfig>,
+        toolName: String = "Specmatic ${VersionInfo.describe()}",
+        coverageReportOperations: List<BaseBccCoverageReportOperation>,
+    ) {
+        if (isCtrfSpecConfigsValid(specConfigs).not()) return
+        val totalChecksRan = coverageReportOperations.asSequence().flatMap { it.tests.asSequence() }.map { it.id }.distinct().count()
+        val extra = buildMap<String, Any> {
+            put("specmaticConfigPath", getConfigFilePath())
+            put("reportType", "BackwardCompatibility")
+        }
+
+        consoleLog("Generating BCC report for $totalChecksRan checks and ${coverageReportOperations.size} operations...")
+        val report = CtrfReportGenerator.generateBccReport(
+            coverageReportOperations = coverageReportOperations,
+            specConfig = specConfigs,
+            startTime = startTime,
+            toolName = toolName,
+            endTime = endTime,
+            extra = extra,
         )
 
         ReportProvider.generateCtrfReport(report, reportDir)

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -1,0 +1,122 @@
+package io.specmatic.core
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.conversions.convertPathParameterStyle
+import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.reporter.model.BackwardCompatibilityResult
+import io.specmatic.reporter.model.SpecType
+import io.specmatic.test.openAPIOperationFrom
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenApiBackwardCompatibilityCheckRecordTest {
+    @Test
+    fun `should derive record vals from openapi scenario and feature `() {
+        val feature = openApiFeature()
+        val scenario = feature.scenarios.single().copy(
+            sourceRepositoryBranch = "main",
+            specification = "specs/orders.yaml",
+            sourceRepository = "https://github.com/example/orders.git",
+        )
+
+        val record = OpenApiBackwardCompatibilityCheckRecord(
+            feature = feature.copy(scenarios = listOf(scenario)),
+            compatResult = Result.Success(),
+            scenario = scenario,
+        )
+
+        assertThat(record.id).isNotNull()
+        assertThat(record.message).isEmpty()
+        assertThat(record.operationQualifiers).isEmpty()
+        assertThat(record.duration).isEqualTo(0)
+        assertThat(record.branch).isEqualTo("main")
+        assertThat(record.specType).isEqualTo(SpecType.OPENAPI)
+        assertThat(record.tags).doesNotContain("path:${scenario.path}")
+        assertThat(record.name).isEqualTo(scenario.fullApiDescription)
+        assertThat(record.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(record.specification).isEqualTo("specs/orders.yaml")
+        assertThat(record.result).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(record.repository).isEqualTo("https://github.com/example/orders.git")
+        assertThat(record.tags).containsExactly(
+            "status:200",
+            "method:get",
+            "path:${convertPathParameterStyle(scenario.path)}",
+            "content-type:application/json",
+            "response-content-type:application/json",
+        )
+
+        assertThat(record.operations).containsExactly(
+            openAPIOperationFrom(scenario, convertPathParameterStyle(scenario.path))
+        )
+    }
+
+    @Test
+    fun `should fallback to feature path when scenario does not have specification defined`() {
+        val feature = openApiFeature()
+        val scenario = feature.scenarios.single().copy(specification = null)
+        val record = OpenApiBackwardCompatibilityCheckRecord(
+            scenario = scenario,
+            compatResult = Result.Success(),
+            feature = feature.copy(scenarios = listOf(scenario)),
+        )
+
+        assertThat(record.specification).isEqualTo(feature.path)
+    }
+
+    @Test
+    fun `should mark ignored failure scenarios as wip`() {
+        val feature = openApiFeature()
+        val scenario = feature.scenarios.single().copy(ignoreFailure = true)
+
+        val failure = Result.Failure("breaking change")
+        val record = OpenApiBackwardCompatibilityCheckRecord(
+            scenario = scenario,
+            compatResult = failure,
+            feature = feature.copy(scenarios = listOf(scenario)),
+        )
+
+        assertThat(record.message).contains("breaking change")
+        assertThat(record.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(record.operationQualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+    }
+
+    private fun openApiFeature(): Feature {
+        return OpenApiSpecification.fromYAML("""
+        openapi: 3.0.1
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders/{orderId}:
+            get:
+              parameters:
+                - in: path
+                  name: orderId
+                  required: true
+                  schema:
+                    type: integer
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required: [traceId]
+                      properties:
+                        traceId:
+                          type: string
+              responses:
+                '200':
+                  description: order found
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        required: [id]
+                        properties:
+                          id:
+                            type: integer
+        """.trimIndent(), "orders.yaml",).toFeature()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckerTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckerTest.kt
@@ -1,0 +1,67 @@
+package io.specmatic.core
+
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.toViolationReportString
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OpenApiBackwardCompatibilityCheckerTest {
+    @Test
+    fun `run should remove failure reasons from generated records without hiding mismatch`() {
+        val oldSpec = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.1
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: string
+              responses:
+                '200':
+                  description: ok
+        """.trimIndent(), "old.yaml").toFeature()
+
+        val newSpec = OpenApiSpecification.fromYAML("""
+        openapi: 3.0.1
+        info:
+          title: Orders API
+          version: 1.0.1
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  text/plain:
+                    schema:
+                      type: string
+              responses:
+                '200':
+                  description: ok
+        """.trimIndent(), "new.yaml").toFeature()
+
+        val records = OpenApiBackwardCompatibilityChecker(oldSpec, newSpec).run()
+        val failure = records.map { it.compatResult }.filterIsInstance<Result.Failure>().single()
+
+        assertThat(failure.isFluffy()).isFalse()
+        assertThat(failure.traverseFailureReason()).isNull()
+        assertThat(Results(listOf(failure)).report()).isNotEqualTo(PATH_NOT_RECOGNIZED_ERROR)
+        assertThat(failure.reportString()).isEqualToIgnoringWhitespace("""
+        In scenario "POST /orders. Response: ok"
+        API: POST /orders -> 200
+        ${
+            toViolationReportString(
+                breadCrumb = "REQUEST.PARAMETERS.HEADER.Content-Type",
+                details = "This is text/plain in the new specification, but application/json in the old specification",
+                StandardRuleViolation.VALUE_MISMATCH
+            )
+        }
+        """.trimIndent())
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -1,11 +1,12 @@
 package io.specmatic.core
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import io.specmatic.core.utilities.Flags.Companion.using
 import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
+import io.specmatic.reporter.api.client.OBJECT_MAPPER
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
@@ -4666,29 +4667,33 @@ paths:
         val reportDir = tempDir.resolve("reports/backward_compatibility").canonicalFile
 
         using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
-            val result = testBackwardCompatibility(olderContract, newerContract)
+            val (result, report) = testBackwardCompatibilityWithReport(olderContract, newerContract)
+            assertThat(report).withFailMessage("Expected CTRF Report to be generated").isNotNull
             assertThat(result.success()).isFalse
 
-            val jsonReport = reportDir.resolve("ctrf/ctrf-report.json")
-            val htmlReport = reportDir.resolve("html/index.html")
-            val reportJson = ObjectMapper().readTree(jsonReport)
+            val htmlReport = reportDir.resolve("html/index.html").canonicalFile
+            assertThat(htmlReport)
+                .withFailMessage { "Expected HTML Report ${htmlReport.canonicalPath} to exist" }
+                .exists()
+
+            val reportJson = OBJECT_MAPPER.valueToTree<JsonNode>(report)
             val summary = reportJson.path("results").path("summary")
             val executionDetails = summary.path("extra").path("executionDetails")
             val operations = executionDetails.first().path("operations")
 
-            assertThat(jsonReport).exists()
-            assertThat(htmlReport).exists()
-
             assertThat(htmlReport.readText()).contains("BackwardCompatibility")
-            assertThat(executionDetails.toString()).contains(newerSpec.canonicalPath)
+            assertThat(executionDetails.toList()).allSatisfy {
+                assertThat(it.path("specification").asText().replace('\\', '/'))
+                    .isEqualTo(newerSpec.canonicalPath.replace('\\', '/'))
+            }
 
+            assertThat(operations.size()).isEqualTo(2)
             assertThat(summary.path("tests").asInt()).isEqualTo(5)
             assertThat(summary.path("failed").asInt()).isEqualTo(1)
             assertThat(reportJson.path("results").path("tests").size()).isEqualTo(5)
             assertThat(reportJson.path("results").path("extra").path("reportType").asText()).isEqualTo("BackwardCompatibility")
-            assertThat(reportJson.path("results").path("extra").path("specmaticConfigPath").asText()).isEqualTo(configFile.canonicalPath)
-
-            assertThat(operations.size()).isEqualTo(2)
+            assertThat(reportJson.path("results").path("extra").path("specmaticConfigPath").asText().replace('\\', '/'))
+                .isEqualTo(configFile.canonicalPath.replace('\\', '/'))
 
             val postOperation = operations.first { it.path("method").asText() == "POST" }
             assertThat(postOperation.path("path").asText()).isEqualTo("/orders")

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4318,6 +4318,66 @@ paths:
     }
 
     @Test
+    fun `backward breaking single request and response content-type scenario content-type overridden`() {
+        val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/single_req_res_ct_overriden/openapi_v1.yaml")
+        val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/single_req_res_ct_overriden/openapi_v2.yaml")
+        val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
+        val result = bccChecker.run().toBackwardCompatibilityResults()
+
+        assertThat(result.report()).isEqualToNormalizingNewlines("""
+        In scenario "Missing endpoint. Response: A simple string response"
+        API: GET /missing -> 200
+        
+              This API exists in the old contract but not in the new contract
+      
+        In scenario "Simple POST endpoint. Response: A simple string response"
+        API: POST /exists/(id:string) -> 200
+        
+          >> REQUEST.BODY.field
+          
+              R1001: Type mismatch
+              Documentation: https://docs.specmatic.io/rules#r1001
+              Summary: The value type does not match the expected type defined in the specification
+          
+              This is type number in the new specification, but type string in the old specification
+        
+        In scenario "Simple POST endpoint. Response: A simple string response"
+        API: POST /exists/(id:string) -> 200
+        
+          >> RESPONSE.BODY.field
+          
+              R1001: Type mismatch
+              Documentation: https://docs.specmatic.io/rules#r1001
+              Summary: The value type does not match the expected type defined in the specification
+          
+              This is number in the new specification response but string in the old specification
+        
+        In scenario "Simple POST endpoint. Response: A simple string response"
+        API: POST /exists/(id:string) -> 201
+        
+          >> REQUEST.BODY.field
+          
+              R1001: Type mismatch
+              Documentation: https://docs.specmatic.io/rules#r1001
+              Summary: The value type does not match the expected type defined in the specification
+          
+              This is type number in the new specification, but type string in the old specification
+        
+        In scenario "Simple POST endpoint. Response: A simple string response"
+        API: POST /exists/(id:string) -> 201
+        
+          >> RESPONSE.BODY.field
+          
+              R1001: Type mismatch
+              Documentation: https://docs.specmatic.io/rules#r1001
+              Summary: The value type does not match the expected type defined in the specification
+          
+              This is number in the new specification response but string in the old specification
+        """.trimIndent())
+    }
+
+    @Test
+    @Disabled // TODO: fix matching logic for override in HttpHeadersPattern when mediaType matches override
     fun `backward breaking multi request and response content-type scenario content-type overridden`() {
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v2.yaml")

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -1,13 +1,19 @@
 package io.specmatic.core
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
+import io.specmatic.core.utilities.Flags.Companion.using
 import io.specmatic.core.log.Verbose
 import io.specmatic.core.log.logger
 import io.specmatic.stub.captureStandardOutput
 import io.specmatic.toViolationReportString
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 internal class TestBackwardCompatibilityKtTest {
     private fun assertBackwardCompatibilityFailure(results: Results, expectedReport: String) {
@@ -4124,8 +4130,8 @@ paths:
     fun `backward breaking multi request and response content-type scenario`() {
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct/openapi_v2.yaml")
-        val operationToResult = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature()).run()
-        val result = operationToResult.values.fold(Results()) { acc, results -> acc.plus(results) }
+        val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
+        val result = bccChecker.run().toBackwardCompatibilityResults()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"
@@ -4315,8 +4321,8 @@ paths:
     fun `backward breaking multi request and response content-type scenario content-type overridden`() {
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v2.yaml")
-        val operationToResult = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature()).run()
-        val result = operationToResult.values.fold(Results()) { acc, results -> acc.plus(results) }
+        val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
+        val result = bccChecker.run().toBackwardCompatibilityResults()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"
@@ -4500,6 +4506,134 @@ paths:
           
               This is number in the new specification response but string in the old specification
         """.trimIndent())
+    }
+
+    @Test
+    fun `should generate backward compatibility report with mixed compatible and incompatible operations`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply {
+            writeText("""
+            version: 2
+            reportDirPath: ${tempDir.canonicalPath}/reports
+            """.trimIndent())
+        }
+
+        val olderSpec = tempDir.resolve("orders-v1.yaml").apply {
+            writeText("""
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  responses:
+                    '200':
+                      description: List orders
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              required: [id]
+                              properties:
+                                id:
+                                  type: string
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [id]
+                          properties:
+                            id:
+                              type: string
+                            note:
+                              type: string
+                  responses:
+                    '201':
+                      description: Created
+            """.trimIndent())
+        }
+
+        val newerSpec = tempDir.resolve("orders-v2.yaml").apply {
+            writeText("""
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 2.0.0
+            paths:
+              /orders:
+                get:
+                  responses:
+                    '200':
+                      description: List orders
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              required: [id]
+                              properties:
+                                id:
+                                  type: string
+                                note:
+                                  type: string
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [id, note]
+                          properties:
+                            id:
+                              type: string
+                            note:
+                              type: string
+                  responses:
+                    '201':
+                      description: Created
+            """.trimIndent())
+        }
+
+        val olderContract = OpenApiSpecification.fromFile(olderSpec.canonicalPath).toFeature()
+        val newerContract = OpenApiSpecification.fromFile(newerSpec.canonicalPath).toFeature()
+        val reportDir = tempDir.resolve("reports/backward_compatibility").canonicalFile
+
+        using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+            val result = testBackwardCompatibility(olderContract, newerContract)
+            assertThat(result.success()).isFalse
+
+            val jsonReport = reportDir.resolve("ctrf/ctrf-report.json")
+            val htmlReport = reportDir.resolve("html/index.html")
+            val reportJson = ObjectMapper().readTree(jsonReport)
+            val summary = reportJson.path("results").path("summary")
+            val executionDetails = summary.path("extra").path("executionDetails")
+            val operations = executionDetails.first().path("operations")
+
+            assertThat(jsonReport).exists()
+            assertThat(htmlReport).exists()
+
+            assertThat(htmlReport.readText()).contains("BackwardCompatibility")
+            assertThat(executionDetails.toString()).contains(newerSpec.canonicalPath)
+
+            assertThat(summary.path("tests").asInt()).isEqualTo(5)
+            assertThat(summary.path("failed").asInt()).isEqualTo(1)
+            assertThat(reportJson.path("results").path("tests").size()).isEqualTo(5)
+            assertThat(reportJson.path("results").path("extra").path("reportType").asText()).isEqualTo("BackwardCompatibility")
+            assertThat(reportJson.path("results").path("extra").path("specmaticConfigPath").asText()).isEqualTo(configFile.canonicalPath)
+
+            assertThat(operations.size()).isEqualTo(2)
+            assertThat(operations.toString()).contains("\"method\":\"GET\"")
+            assertThat(operations.toString()).contains("\"method\":\"POST\"")
+            assertThat(operations.toString()).contains("\"backwardCompatibilityResult\":\"Compatible\"")
+            assertThat(operations.toString()).contains("\"backwardCompatibilityResult\":\"Incompatible\"")
+        }
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4689,10 +4689,28 @@ paths:
             assertThat(reportJson.path("results").path("extra").path("specmaticConfigPath").asText()).isEqualTo(configFile.canonicalPath)
 
             assertThat(operations.size()).isEqualTo(2)
-            assertThat(operations.toString()).contains("\"method\":\"GET\"")
-            assertThat(operations.toString()).contains("\"method\":\"POST\"")
-            assertThat(operations.toString()).contains("\"backwardCompatibilityResult\":\"Compatible\"")
-            assertThat(operations.toString()).contains("\"backwardCompatibilityResult\":\"Incompatible\"")
+
+            val postOperation = operations.first { it.path("method").asText() == "POST" }
+            assertThat(postOperation.path("path").asText()).isEqualTo("/orders")
+            assertThat(postOperation.path("method").asText()).isEqualTo("POST")
+            assertThat(postOperation.path("contentType").asText()).isEqualTo("application/json")
+            assertThat(postOperation.path("responseCode").asInt()).isEqualTo(201)
+            assertThat(postOperation.path("qualifiers").size()).isEqualTo(0)
+            assertThat(postOperation.path("testIds").isArray).isTrue()
+            assertThat(postOperation.path("testIds").size()).isGreaterThan(0)
+            assertThat(postOperation.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
+            assertThat(postOperation.path("compatibility").path("result").asText()).isEqualTo("Incompatible")
+
+            val getOperation = operations.first { it.path("method").asText() == "GET" }
+            assertThat(getOperation.path("path").asText()).isEqualTo("/orders")
+            assertThat(getOperation.path("method").asText()).isEqualTo("GET")
+            assertThat(getOperation.path("responseCode").asInt()).isEqualTo(200)
+            assertThat(getOperation.path("responseContentType").asText()).isEqualTo("application/json")
+            assertThat(getOperation.path("qualifiers").size()).isEqualTo(0)
+            assertThat(getOperation.path("testIds").isArray).isTrue()
+            assertThat(getOperation.path("testIds").size()).isGreaterThan(0)
+            assertThat(getOperation.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
+            assertThat(getOperation.path("compatibility").path("result").asText()).isEqualTo("Compatible")
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
@@ -50,20 +50,20 @@ class BccReportGeneratorTest {
         assertThat(reportOperations).hasSize(3)
 
         val groupedCreateOrder = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/orders.yaml" }
-        assertThat(groupedCreateOrder.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(groupedCreateOrder.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
         assertThat(groupedCreateOrder.tests).containsExactly(firstRecord, secondRecord)
         assertThat(groupedCreateOrder.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
-        assertThat(groupedCreateOrder.backwardCompatibilityResult).isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(groupedCreateOrder.compatibility.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
 
         val groupedGetOrders = reportOperations.single { it.operation == getOrders && it.specConfig.specification == "specs/orders.yaml" }
         assertThat(groupedGetOrders.tests).containsExactly(firstRecord)
         assertThat(groupedGetOrders.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
-        assertThat(groupedGetOrders.backwardCompatibilityResult).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(groupedGetOrders.compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
 
         val groupedPayments = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/payments.yaml" }
         assertThat(groupedPayments.qualifiers).isEmpty()
         assertThat(groupedPayments.tests).containsExactly(thirdRecord)
-        assertThat(groupedPayments.backwardCompatibilityResult).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(groupedPayments.compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
     }
 
     @Test
@@ -136,7 +136,7 @@ class BccReportGeneratorTest {
             )
         ).single()
 
-        assertThat(reportOperation.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(reportOperation.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
     }
 
     @Test
@@ -149,7 +149,7 @@ class BccReportGeneratorTest {
             )
         ).single()
 
-        assertThat(reportOperation.changeStatus).isEqualTo(ChangeStatus.UNCHANGED)
+        assertThat(reportOperation.compatibility.changeStatus).isEqualTo(ChangeStatus.UNCHANGED)
     }
 
     @Test
@@ -164,8 +164,8 @@ class BccReportGeneratorTest {
         val createOrderReport = reportOperations.single { it.operation == createOrder }
         val getOrdersReport = reportOperations.single { it.operation == getOrders }
 
-        assertThat(createOrderReport.changeStatus).isEqualTo(ChangeStatus.CHANGED)
-        assertThat(getOrdersReport.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(createOrderReport.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(getOrdersReport.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
     }
 
     @Test
@@ -178,8 +178,7 @@ class BccReportGeneratorTest {
             )
         )
 
-        assertThat(reportOperation.single().backwardCompatibilityResult)
-            .isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(reportOperation.single().compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
     }
 
     @Test
@@ -192,8 +191,7 @@ class BccReportGeneratorTest {
             )
         )
 
-        assertThat(reportOperation.single().backwardCompatibilityResult)
-            .isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(reportOperation.single().compatibility.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
@@ -1,0 +1,266 @@
+package io.specmatic.core.report
+
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
+import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.reporter.internal.dto.operation.APIOperation
+import io.specmatic.reporter.model.BackwardCompatibilityResult
+import io.specmatic.reporter.model.OpenAPIOperation
+import io.specmatic.reporter.model.SpecType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.collections.single
+
+class BccReportGeneratorTest {
+    private val generator = BccReportGenerator()
+
+    @Test
+    fun `should return empty list when there are no records`() {
+        val reportOperations = generator.generateReportOperations(emptyList())
+        assertThat(reportOperations).isEmpty()
+    }
+
+    @Test
+    fun `should group records by openapi operation and spec config`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val getOrders = openApiOperation(path = "/orders", method = "GET", responseCode = 200)
+
+        val firstRecord = testRecord(
+            specification = "specs/orders.yaml",
+            operations = setOf(createOrder, getOrders),
+            result = BackwardCompatibilityResult.Compatible,
+            operationQualifiers = listOf(CtrfOperationQualifiers.WIP),
+        )
+
+        val secondRecord = testRecord(
+            specification = "specs/orders.yaml",
+            operations = setOf(createOrder),
+            result = BackwardCompatibilityResult.Incompatible,
+        )
+
+        val thirdRecord = testRecord(
+            specification = "specs/payments.yaml",
+            operations = setOf(createOrder),
+            result = BackwardCompatibilityResult.Compatible,
+        )
+
+        val reportOperations = generator.generateReportOperations(listOf(firstRecord, secondRecord, thirdRecord))
+        assertThat(reportOperations).hasSize(3)
+
+        val groupedCreateOrder = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/orders.yaml" }
+        assertThat(groupedCreateOrder.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(groupedCreateOrder.tests).containsExactly(firstRecord, secondRecord)
+        assertThat(groupedCreateOrder.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+        assertThat(groupedCreateOrder.backwardCompatibilityResult).isEqualTo(BackwardCompatibilityResult.Incompatible)
+
+        val groupedGetOrders = reportOperations.single { it.operation == getOrders && it.specConfig.specification == "specs/orders.yaml" }
+        assertThat(groupedGetOrders.tests).containsExactly(firstRecord)
+        assertThat(groupedGetOrders.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+        assertThat(groupedGetOrders.backwardCompatibilityResult).isEqualTo(BackwardCompatibilityResult.Compatible)
+
+        val groupedPayments = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/payments.yaml" }
+        assertThat(groupedPayments.qualifiers).isEmpty()
+        assertThat(groupedPayments.tests).containsExactly(thirdRecord)
+        assertThat(groupedPayments.backwardCompatibilityResult).isEqualTo(BackwardCompatibilityResult.Compatible)
+    }
+
+    @Test
+    fun `should create separate groups when branch repository or specification differ`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+
+        val mainBranchRecord = testRecord(
+            branch = "main",
+            repository = "https://github.com/example/orders.git",
+            specification = "specs/orders.yaml",
+            operations = setOf(createOrder),
+        )
+
+        val featureBranchRecord = testRecord(
+            branch = "feature-1",
+            repository = "https://github.com/example/orders.git",
+            specification = "specs/orders.yaml",
+            operations = setOf(createOrder),
+        )
+
+        val otherRepoRecord = testRecord(
+            branch = "main",
+            repository = "https://github.com/example/payments.git",
+            specification = "specs/orders.yaml",
+            operations = setOf(createOrder),
+        )
+
+        val otherSpecRecord = testRecord(
+            branch = "main",
+            repository = "https://github.com/example/orders.git",
+            specification = "specs/orders-v2.yaml",
+            operations = setOf(createOrder),
+        )
+
+        val reportOperations = generator.generateReportOperations(listOf(mainBranchRecord, featureBranchRecord, otherRepoRecord, otherSpecRecord))
+        assertThat(reportOperations).hasSize(4)
+        assertThat(reportOperations.map { it.tests.single() }).containsExactly(
+            mainBranchRecord,
+            featureBranchRecord,
+            otherRepoRecord,
+            otherSpecRecord,
+        )
+    }
+
+    @Test
+    fun `should merge and deduplicate operation qualifiers across grouped records`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+
+        val firstRecord = testRecord(
+            operations = setOf(createOrder),
+            operationQualifiers = listOf(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.WIP),
+        )
+
+        val secondRecord = testRecord(
+            operations = setOf(createOrder),
+            operationQualifiers = listOf(CtrfOperationQualifiers.WIP),
+        )
+
+        val reportOperation = generator.generateReportOperations(listOf(firstRecord, secondRecord)).single()
+        assertThat(reportOperation.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+    }
+
+    @Test
+    fun `should mark operation as changed when any grouped record has changes`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val reportOperation = generator.generateReportOperations(
+            listOf(
+                testRecord(operations = setOf(createOrder), changeStatus = ChangeStatus.UNCHANGED),
+                testRecord(operations = setOf(createOrder), changeStatus = ChangeStatus.CHANGED),
+            )
+        ).single()
+
+        assertThat(reportOperation.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `should mark operation as unchanged when all grouped records have no changes`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val reportOperation = generator.generateReportOperations(
+            listOf(
+                testRecord(operations = setOf(createOrder), changeStatus = ChangeStatus.UNCHANGED),
+                testRecord(operations = setOf(createOrder), changeStatus = ChangeStatus.UNCHANGED),
+            )
+        ).single()
+
+        assertThat(reportOperation.changeStatus).isEqualTo(ChangeStatus.UNCHANGED)
+    }
+
+    @Test
+    fun `should evaluate has changes independently per grouped operation`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val getOrders = openApiOperation(path = "/orders", method = "GET", responseCode = 200)
+        val secondRecord = testRecord(operations = setOf(getOrders), changeStatus = ChangeStatus.UNCHANGED)
+        val thirdRecord = testRecord(operations = setOf(createOrder), changeStatus = ChangeStatus.UNCHANGED)
+        val firstRecord = testRecord(operations = setOf(createOrder, getOrders), changeStatus = ChangeStatus.CHANGED)
+
+        val reportOperations = generator.generateReportOperations(listOf(firstRecord, secondRecord, thirdRecord))
+        val createOrderReport = reportOperations.single { it.operation == createOrder }
+        val getOrdersReport = reportOperations.single { it.operation == getOrders }
+
+        assertThat(createOrderReport.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(getOrdersReport.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `should remain compatible when all grouped records are compatible`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val reportOperation = generator.generateReportOperations(
+            listOf(
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Compatible),
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Compatible),
+            )
+        )
+
+        assertThat(reportOperation.single().backwardCompatibilityResult)
+            .isEqualTo(BackwardCompatibilityResult.Compatible)
+    }
+
+    @Test
+    fun `should become incompatible when any grouped record is incompatible`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val reportOperation = generator.generateReportOperations(
+            listOf(
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Compatible),
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Incompatible),
+            )
+        )
+
+        assertThat(reportOperation.single().backwardCompatibilityResult)
+            .isEqualTo(BackwardCompatibilityResult.Incompatible)
+    }
+
+    @Test
+    fun `should map openapi record fields into spec config`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val reportOperation = generator.generateReportOperations(
+            listOf(
+                testRecord(
+                    branch = null,
+                    repository = "https://github.com/example/orders.git",
+                    specification = "specs/orders.yaml",
+                    specType = SpecType.OPENAPI,
+                    operations = setOf(createOrder),
+                )
+            )
+        ).single()
+
+        assertThat(reportOperation.specConfig.protocol).isEqualTo(SpecmaticProtocol.HTTP.key)
+        assertThat(reportOperation.specConfig.specType).isEqualTo(SpecType.OPENAPI.value)
+        assertThat(reportOperation.specConfig.specification).isEqualTo("specs/orders.yaml")
+        assertThat(reportOperation.specConfig.repository).isEqualTo("https://github.com/example/orders.git")
+        assertThat(reportOperation.specConfig.branch).isEqualTo("main")
+    }
+
+    private fun openApiOperation(
+        path: String,
+        method: String,
+        responseCode: Int,
+        contentType: String? = "application/json",
+        responseContentType: String? = "application/json",
+    ): OpenAPIOperation {
+        return OpenAPIOperation(
+            path = path,
+            method = method,
+            contentType = contentType,
+            responseCode = responseCode,
+            protocol = SpecmaticProtocol.HTTP,
+            responseContentType = responseContentType,
+        )
+    }
+
+    private fun testRecord(
+        id: UUID = UUID.randomUUID(),
+        branch: String? = "feature-1",
+        operations: Set<APIOperation>,
+        tags: List<String> = emptyList(),
+        specType: SpecType = SpecType.OPENAPI,
+        specification: String = "specs/openapi.yaml",
+        repository: String? = "https://github.com/example/repo.git",
+        changeStatus: ChangeStatus = ChangeStatus.CHANGED,
+        operationQualifiers: List<CtrfOperationQualifiers> = emptyList(),
+        result: BackwardCompatibilityResult = BackwardCompatibilityResult.Compatible,
+    ): CtrfBackwardCompatibilityRecord {
+        return object : CtrfBackwardCompatibilityRecord {
+            override val id: UUID = id
+            override val duration: Long = 100
+            override val message: String = ""
+            override val branch: String? = branch
+            override val name: String = "bcc-test"
+            override val tags: List<String> = tags
+            override val specType: SpecType = specType
+            override val repository: String? = repository
+            override val specification: String = specification
+            override val operations: Set<APIOperation> = operations
+            override val result: BackwardCompatibilityResult = result
+            override val changeStatus: ChangeStatus = changeStatus
+            override val operationQualifiers: List<CtrfOperationQualifiers> = operationQualifiers
+        }
+    }
+}

--- a/core/src/test/resources/openapi/single_req_res_ct_overriden/openapi_v1.yaml
+++ b/core/src/test/resources/openapi/single_req_res_ct_overriden/openapi_v1.yaml
@@ -1,0 +1,81 @@
+openapi: 3.0.3
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /missing:
+    get:
+      summary: Missing endpoint
+      responses:
+        '200':
+          description: A simple string response
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - field
+                properties:
+                  field:
+                    type: string
+  /exists/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: header
+        name: Content-Type
+        required: true
+        schema:
+          type: string
+          enum:
+            - application/json
+    post:
+      summary: Simple POST endpoint
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - field
+              properties:
+                field:
+                  type: string
+      responses:
+        '200':
+          description: A simple string response
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                enum:
+                  - application/json
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - field
+                properties:
+                  field:
+                    type: string
+        '201':
+          description: A simple string response
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                enum:
+                  - application/json
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - field
+                properties:
+                  field:
+                    type: string

--- a/core/src/test/resources/openapi/single_req_res_ct_overriden/openapi_v2.yaml
+++ b/core/src/test/resources/openapi/single_req_res_ct_overriden/openapi_v2.yaml
@@ -1,0 +1,66 @@
+openapi: 3.0.3
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /exists/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - in: header
+        name: Content-Type
+        required: true
+        schema:
+          type: string
+          enum:
+            - application/json
+    post:
+      summary: Simple POST endpoint
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - field
+              properties:
+                field:
+                  type: integer
+      responses:
+        '200':
+          description: A simple string response
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                enum:
+                  - application/json
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - field
+                properties:
+                  field:
+                    type: integer
+        '201':
+          description: A simple string response
+          headers:
+            Content-Type:
+              schema:
+                type: string
+                enum:
+                  - application/json
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - field
+                properties:
+                  field:
+                    type: integer

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.46.2-SNAPSHOT
 specmaticGradlePluginVersion=0.15.8
-specmaticReporterVersion=0.3.22
+specmaticReporterVersion=0.3.23-SNAPSHOT
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
**What**: Implement CTRF report generation for backward compatibility

**Why**:
- CTRF will let users and orgs consume compatibility results in a richer format instead of relying on console
- Reporting alignment with test and mock workflows will provide a more consistent user experience.

**Note**: 
The generation of the report is currently feature flagged under `SPECMATIC_BCC_REPORT` until the implementation is complete

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated (share link)
- [ ] Sample Project added/updated (share link)
- [ ] Demo video (share link)
- [ ] Article on Website (share link)
- [ ] Roadmpap updated (share link)
- [ ] Conference Talk (share link)
