### PR TITLE
feat: show wip remark in coverage console report when there are wip tests

### DIFF
--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenApiCoverageConsoleRow.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/coverage/console/OpenApiCoverageConsoleRow.kt
@@ -33,8 +33,9 @@ data class OpenApiCoverageConsoleRow(
         responseStatus = coverageReportOperation.operation.responseCode.toString(),
         exercisedCount = coverageReportOperation.metrics?.attempts ?: coverageReportOperation.tests.size,
         result = formatResult(
-            passedCount = coverageReportOperation.tests.count { it.result == TestResult.Success },
-            failedCount = coverageReportOperation.tests.count { it.result == TestResult.Failed }
+            passedCount = coverageReportOperation.tests.count { it.result == TestResult.Success && !it.isWip},
+            failedCount = coverageReportOperation.tests.count { it.result == TestResult.Failed && !it.isWip },
+            wipCount = coverageReportOperation.tests.count {it.isWip},
         ),
         coveragePercentage = coveragePercentage,
         remarks = coverageReportOperation.coverageStatus,
@@ -66,7 +67,7 @@ data class OpenApiCoverageConsoleRow(
         path,
         responseStatus.toString(),
         count,
-        formatResult(passedCount = count, failedCount = 0),
+        formatResult(passedCount = count, failedCount = 0, wipCount = 0),
         coveragePercentage,
         remarks,
         eligibleForCoverage,
@@ -127,10 +128,11 @@ data class OpenApiCoverageConsoleRow(
     internal fun formattedRemarkLength(): Int = formattedRemark.length
 
     companion object {
-        private fun formatResult(passedCount: Int, failedCount: Int): String {
+        private fun formatResult(passedCount: Int, failedCount: Int, wipCount: Int): String {
             return buildList {
                 if (passedCount > 0) add("${passedCount}p")
                 if (failedCount > 0) add("${failedCount}f")
+                if (wipCount > 0) add("${wipCount}w")
             }.joinToString(" ")
         }
     }

--- a/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportTextRenderer.kt
+++ b/junit5-support/src/main/kotlin/io/specmatic/test/reports/renderers/CoverageReportTextRenderer.kt
@@ -64,6 +64,7 @@ class CoverageReportTextRenderer: ReportRenderer<OpenAPICoverageConsoleReport> {
             "! = Operation excluded from the run due to a filter",
             "p = passed tests",
             "f = failed tests",
+            "w = wip tests",
             "",
             "${report.coveragePercentage}% API Coverage reported from ${report.operationsEligibleForCoverage} operations eligible for coverage",
             "${report.absoluteCoveragePercentage}% Absolute Coverage (includes excluded operations that were not tested)"

--- a/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleRowTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/OpenApiCoverageConsoleRowTest.kt
@@ -1,6 +1,14 @@
 package io.specmatic.test
 
+import io.specmatic.core.HttpRequest
+import io.specmatic.core.HttpResponse
+import io.specmatic.license.core.SpecmaticProtocol
+import io.specmatic.reporter.ctrf.model.CoverageReportOperation
+import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.internal.dto.coverage.CoverageStatus
+import io.specmatic.reporter.model.OpenAPIOperation
+import io.specmatic.reporter.model.SpecType
+import io.specmatic.reporter.model.TestResult
 import io.specmatic.test.reports.coverage.console.OpenApiCoverageConsoleRow
 import io.specmatic.test.reports.coverage.console.ReportColumn
 import org.assertj.core.api.Assertions.assertThat
@@ -125,4 +133,253 @@ class OpenApiCoverageConsoleRowTest {
         ).toRowString(reportColumns)
         assertThat(coverageRowString).isEqualTo("| 100%     | /orders | GET    | application/json   | 200      | NA                   | covered        | 1p         |")
     }
+
+    @Test
+    fun `should show failed count when there are wip tests`() {
+        val tests = listOf(
+            TestResultRecord(
+                result = TestResult.Failed,
+                isWip = false,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+            TestResultRecord(
+                result = TestResult.Failed,
+                isWip = true,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            )
+        )
+
+        val operation = OpenAPIOperation(
+            method = "GET",
+            path = "/orders",
+            responseCode = 200,
+            protocol = SpecmaticProtocol.HTTP
+        )
+
+        val coverageOperation = CoverageReportOperation(
+            operation = operation,
+            tests = tests,
+            coverageStatus = CoverageStatus.COVERED,
+            eligibleForCoverage = true,
+            specConfig = CtrfSpecConfig(
+                protocol = "HTTP",
+                specType = "openapi",
+                specification = "HTTP",
+
+            )
+        )
+
+
+        val row = OpenApiCoverageConsoleRow(
+            coverageReportOperation = coverageOperation,
+            coveragePercentage = 100,
+            showPath = true,
+            showMethod = true,
+            showRequestContentType = true
+        )
+
+
+        assertThat(row.result).isEqualTo("1f 1w")
+    }
+
+    @Test
+    fun `should show passed count when there are wip tests`() {
+        val tests = listOf(
+            TestResultRecord(
+                result = TestResult.Success,
+                isWip = false,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+            TestResultRecord(
+                result = TestResult.Success,
+                isWip = true,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            )
+        )
+
+        val operation = OpenAPIOperation(
+            method = "GET",
+            path = "/orders",
+            responseCode = 200,
+            protocol = SpecmaticProtocol.HTTP
+        )
+
+        val coverageOperation = CoverageReportOperation(
+            operation = operation,
+            tests = tests,
+            coverageStatus = CoverageStatus.COVERED,
+            eligibleForCoverage = true,
+            specConfig = CtrfSpecConfig(
+                protocol = "HTTP",
+                specType = "openapi",
+                specification = "HTTP",
+
+                )
+        )
+
+        val row = OpenApiCoverageConsoleRow(
+            coverageReportOperation = coverageOperation,
+            coveragePercentage = 100,
+            showPath = true,
+            showMethod = true,
+            showRequestContentType = true
+        )
+
+        assertThat(row.result).isEqualTo("1p 1w")
+    }
+
+    @Test
+    fun `should show passed count and failed count when there are wip tests`() {
+        val tests = listOf(
+            TestResultRecord(
+                result = TestResult.Success,
+                isWip = false,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+            TestResultRecord(
+                result = TestResult.Failed,
+                isWip = false,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+            TestResultRecord(
+                result = TestResult.Failed,
+                isWip = true,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+            TestResultRecord(
+                result = TestResult.Success,
+                isWip = true,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+
+        )
+
+        val operation = OpenAPIOperation(
+            method = "GET",
+            path = "/orders",
+            responseCode = 200,
+            protocol = SpecmaticProtocol.HTTP
+        )
+
+        val coverageOperation = CoverageReportOperation(
+            operation = operation,
+            tests = tests,
+            coverageStatus = CoverageStatus.COVERED,
+            eligibleForCoverage = true,
+            specConfig = CtrfSpecConfig(
+                protocol = "HTTP",
+                specType = "openapi",
+                specification = "HTTP",
+
+                )
+        )
+
+        val row = OpenApiCoverageConsoleRow(
+            coverageReportOperation = coverageOperation,
+            coveragePercentage = 100,
+            showPath = true,
+            showMethod = true,
+            showRequestContentType = true
+        )
+
+        assertThat(row.result).isEqualTo("1p 1f 2w")
+    }
+
+
+    @Test
+    fun `should show passed count and failed count when there are no wip tests`() {
+        val tests = listOf(
+            TestResultRecord(
+                result = TestResult.Success,
+                isWip = false,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+            TestResultRecord(
+                result = TestResult.Failed,
+                isWip = false,
+                method = "GET",
+                path = "/orders",
+                responseStatus = 200,
+                request = HttpRequest(),
+                response = HttpResponse(),
+                specType = SpecType.OPENAPI
+            ),
+        )
+
+        val operation = OpenAPIOperation(
+            method = "GET",
+            path = "/orders",
+            responseCode = 200,
+            protocol = SpecmaticProtocol.HTTP
+        )
+
+        val coverageOperation = CoverageReportOperation(
+            operation = operation,
+            tests = tests,
+            coverageStatus = CoverageStatus.COVERED,
+            eligibleForCoverage = true,
+            specConfig = CtrfSpecConfig(
+                protocol = "HTTP",
+                specType = "openapi",
+                specification = "HTTP",
+
+                )
+        )
+
+        val row = OpenApiCoverageConsoleRow(
+            coverageReportOperation = coverageOperation,
+            coveragePercentage = 100,
+            showPath = true,
+            showMethod = true,
+            showRequestContentType = true
+        )
+
+        assertThat(row.result).isEqualTo("1p 1f")
+    }
+
 }

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageReportInputTest.kt
@@ -482,7 +482,7 @@ class OpenApiCoverageReportInputTest {
                 path = "/mixed",
                 responseStatus = "200",
                 exercisedCount = 1,
-                result = "1f",
+                result = "1w",
                 coveragePercentage = 0,
                 remarks = CoverageStatus.NOT_IMPLEMENTED,
                 eligibleForCoverage = true,


### PR DESCRIPTION
Reason for Change

'wip' tests were previously reported as 'failed' tests in the console output. This PR fixes the classification so that 'wip' tests are displayed correctly as 'wip'.