### PR TITLE
chore: remove match field from CtrfTestMetadata

### DIFF
--- a/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/test/TestResultRecord.kt
@@ -94,7 +94,6 @@ data class TestResultRecord(
             wip = isWip,
             outputs = outputs,
             qualifiers = testQualifiers(),
-            match = matchesResponseIdentifiers,
             input = request?.toLogString().orEmpty(),
             inputTime = requestTime?.toEpochMilli() ?: 0L,
             reasons = reasoning.toCtrfSnapshots(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.46.1-SNAPSHOT
 specmaticGradlePluginVersion=0.15.8
-specmaticReporterVersion=0.3.19
+specmaticReporterVersion=0.3.20
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m

--- a/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageTest.kt
+++ b/junit5-support/src/test/kotlin/io/specmatic/test/reports/coverage/OpenApiCoverageTest.kt
@@ -64,7 +64,6 @@ class OpenApiCoverageTest {
                 assertThat(test.actualResponseStatus).isEqualTo(400)
                 assertThat(test.actualResponseContentType).isEqualTo("application/json")
                 assertThat(test.extraFields()).satisfies(
-                    { assertThat(it.match).isFalse },
                     { assertThat(it.reasons).isEmpty() },
                 )
             }
@@ -154,7 +153,6 @@ class OpenApiCoverageTest {
             assertThat(wipView.operation.metrics?.matches).isEqualTo(0)
             assertThat(wipView.tests).hasSize(1).allSatisfy { test ->
                 assertThat(test.extraFields()).satisfies(
-                    { assertThat(it.match).isFalse },
                     { assertThat(it.reasons).isEmpty() },
                 )
             }
@@ -226,11 +224,7 @@ class OpenApiCoverageTest {
             assertThat(okResponseView.operation.metrics?.matches).isEqualTo(10)
             assertThat(okResponseView.operation.metrics?.attempts).isEqualTo(10)
             assertThat(okResponseView.operation.coverageStatus).isEqualTo(CoverageStatus.COVERED)
-            assertThat(okResponseView.tests).hasSize(10).allSatisfy { test ->
-                assertThat(test.extraFields()).satisfies(
-                    { assertThat(it.match).isTrue },
-                )
-            }
+            assertThat(okResponseView.tests).hasSize(10)
         }
 
         report.verify {
@@ -239,11 +233,7 @@ class OpenApiCoverageTest {
             assertThat(badRequestView.operation.metrics?.matches).isEqualTo(20)
             assertThat(badRequestView.operation.metrics?.attempts).isEqualTo(20)
             assertThat(badRequestView.operation.coverageStatus).isEqualTo(CoverageStatus.MISSING_IN_SPEC)
-            assertThat(badRequestView.tests).hasSize(20).allSatisfy { test ->
-                assertThat(test.extraFields()).satisfies(
-                    { assertThat(it.match).isTrue },
-                )
-            }
+            assertThat(badRequestView.tests).hasSize(20)
         }
     }
 
@@ -299,9 +289,7 @@ class OpenApiCoverageTest {
             assertThat(okResponseView.operation.metrics?.attempts).isEqualTo(10)
             assertThat(okResponseView.operation.coverageStatus).isEqualTo(CoverageStatus.COVERED)
             assertThat(okResponseView.tests).hasSize(10).allSatisfy { test ->
-                assertThat(test.extraFields()).satisfies(
-                    { assertThat(it.match).isTrue },
-                )
+                assertThat(test.extraFields())
             }
         }
 
@@ -313,15 +301,11 @@ class OpenApiCoverageTest {
             assertThat(badRequestView.operation.coverageStatus).isEqualTo(CoverageStatus.COVERED)
 
             assertThat(badRequestView.tests.filter { it.actualResponseContentType == "application/json" }).hasSize(10).allSatisfy { test ->
-                assertThat(test.extraFields()).satisfies(
-                    { assertThat(it.match).isTrue },
-                )
+                assertThat(test.extraFields())
             }
 
             assertThat(badRequestView.tests.filterNot { it.actualResponseContentType == "application/json" }).hasSize(10).allSatisfy { test ->
-                assertThat(test.extraFields()).satisfies(
-                    { assertThat(it.match).isFalse },
-                )
+                assertThat(test.extraFields())
             }
         }
     }


### PR DESCRIPTION
Reason to change: 
 
Removing the addition of 'match' field from CtrfTestMetadata so that it does not appear in ctrf-report as it is not used in html-reporter and insights