### PR TITLE
Implement config updater from legacy V1 and V2 to latest V3

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
+++ b/core/src/main/kotlin/io/specmatic/core/SpecmaticConfigV1V2Common.kt
@@ -145,6 +145,10 @@ data class StubConfiguration(
     private val https: HttpsConfiguration? = null,
     private val lenientMode: Boolean? = null
 ) {
+    fun getLenientMode(): Boolean? {
+        return lenientMode
+    }
+
     fun getGenerative(): Boolean? {
         return generative
     }
@@ -430,7 +434,7 @@ data class SpecmaticConfigV1V2Common(
         }
 
         @JsonIgnore
-        fun getIgnoreInlineExampleWarningsOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.ignoreInlineExamples
+        fun getIgnoreInlineExampleWarningsOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.ignoreInlineExampleWarnings
 
         @JsonIgnore
         fun getEscapeSoapActionOrNull(specmaticConfig: SpecmaticConfigV1V2Common): Boolean? = specmaticConfig.escapeSoapAction
@@ -475,6 +479,11 @@ data class SpecmaticConfigV1V2Common(
         @JsonIgnore
         fun getProxyConfig(specmaticConfig: SpecmaticConfigV1V2Common): ProxyConfig? {
             return specmaticConfig.proxy
+        }
+
+        @JsonIgnore
+        fun getLogConfigurationOrNull(specmaticConfig: SpecmaticConfigV1V2Common): LoggingConfiguration? {
+            return specmaticConfig.logging
         }
     }
 
@@ -1758,6 +1767,9 @@ data class SecurityConfiguration(
     @param:JsonProperty("OpenAPI")
     private val OpenAPI: OpenAPISecurityConfiguration?
 ) {
+    val openAPI: OpenAPISecurityConfiguration?
+        get() = OpenAPI
+
     fun getOpenAPISecurityScheme(scheme: String): SecuritySchemeConfiguration? {
         return OpenAPI?.securitySchemes?.get(scheme)
     }

--- a/core/src/main/kotlin/io/specmatic/core/config/SpecmaticConfigVersion.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/SpecmaticConfigVersion.kt
@@ -23,8 +23,7 @@ enum class SpecmaticConfigVersion(@JsonValue val value: Int, val configLoader: S
         }
 
         fun getLatestVersion(): SpecmaticConfigVersion {
-            // TODO: Write migrator for V2 to V3
-            return entries.filter { it != SpecmaticConfigVersion.VERSION_3 }.maxBy { it.value }
+            return entries.maxBy { it.value }
         }
 
         fun isValidVersion(version: SpecmaticConfigVersion): Boolean {
@@ -36,6 +35,12 @@ enum class SpecmaticConfigVersion(@JsonValue val value: Int, val configLoader: S
             return latestVersion
                 .configLoader
                 .loadFrom(config.dropExcludedEndpointsAfterVersion1(latestVersion))
+        }
+
+        fun convertToVersionedConfig(config: SpecmaticConfig, version: SpecmaticConfigVersion): SpecmaticVersionedConfig {
+            return version
+                .configLoader
+                .loadFrom(config.dropExcludedEndpointsAfterVersion1(version))
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/SpecmaticGlobalSettings.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/SpecmaticGlobalSettings.kt
@@ -9,9 +9,9 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException
 
 data class SpecmaticGlobalSettings(
     @field:JsonDeserialize(using = ExampleTemplateStringDeserializer::class)
-    private val specExamplesDirectoryTemplate: String? = null,
-    @field:JsonDeserialize(using = ExampleTemplateStringDeserializer::class)
-    private val sharedExamplesDirectoryTemplate: List<String>? = null
+    val specExamplesDirectoryTemplate: String? = null,
+    @field:JsonDeserialize(contentUsing = ExampleTemplateStringDeserializer::class)
+    val sharedExamplesDirectoryTemplate: List<String>? = null
 ) {
     @JsonIgnore
     fun getSpecExampleDirTemplate(): String {

--- a/core/src/main/kotlin/io/specmatic/core/config/SpecmaticSpecConfig.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/SpecmaticSpecConfig.kt
@@ -7,6 +7,7 @@ class RawRunOptionSpecification(private val config: Map<String, Any>): IRunOptio
     override fun getBaseUrl(defaultHost: String): String? = null
     override fun getOverlayFilePath(): String? = null
     override fun getConfig(): Map<String, Any> = config
+    override fun isNoOpOverride(): Boolean = config.isEmpty()
 }
 
 class SpecmaticSpecConfig(val baseUrl: String? = null, val spec: IRunOptionSpecification? = null, val config: Map<String, Any> = emptyMap()) {

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3.kt
@@ -1,9 +1,15 @@
 package io.specmatic.core.config.v3
 
 import io.specmatic.core.SpecmaticConfig
-import io.specmatic.core.config.*
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.McpConfiguration
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.SpecmaticVersionedConfig
+import io.specmatic.core.config.SpecmaticVersionedConfigLoader
+import io.specmatic.core.config.v3.upgrade.LegacySpecmaticConfigToV3Upgrader
 import io.specmatic.core.config.v3.components.services.MockServiceConfig
 import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.pattern.ContractException
 import java.io.File
 
 data class SpecmaticConfigV3(
@@ -20,10 +26,12 @@ data class SpecmaticConfigV3(
     }
 
     companion object : SpecmaticVersionedConfigLoader {
-        private fun currentConfigVersion(): SpecmaticConfigVersion = SpecmaticConfigVersion.VERSION_3
-
         override fun loadFrom(config: SpecmaticConfig): SpecmaticConfigV3 {
-            return SpecmaticConfigV3(currentConfigVersion())
+            return when (config) {
+                is SpecmaticConfigV3Impl -> config.specmaticConfig
+                is SpecmaticConfigV1V2Common -> LegacySpecmaticConfigToV3Upgrader().upgrade(config)
+                else -> throw ContractException("Expected v1, v2, or v3 config format, but got an incompatible config structure.")
+            }
         }
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3Impl.kt
@@ -134,8 +134,9 @@ data class SpecmaticConfigV3Impl(val file: File? = null, val specmaticConfig: Sp
 
     private fun getMockSettingsFor(specFile: File): MockSettings {
         val globalMockSettings = specmaticSettings.mock ?: MockSettings()
-        val service = getMockService(specFile) ?: return globalMockSettings
-        return specmaticConfig.dependencies?.getSettings(service,globalMockSettings, resolver) ?: globalMockSettings
+        val dependencyMockSettings = specmaticConfig.dependencies?.settings?.resolveElseThrow(resolver)?.merge(globalMockSettings) ?: globalMockSettings
+        val service = getMockService(specFile) ?: return dependencyMockSettings
+        return specmaticConfig.dependencies?.getSettings(service, globalMockSettings, resolver) ?: dependencyMockSettings
     }
 
     private fun exampleFromSysProp(): List<String> = getStringValue(EXAMPLE_DIRECTORIES)?.split(",")?.map { it.trim() }.orEmpty()

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptions.kt
@@ -47,6 +47,33 @@ data class TestRunOptions(
     val protobuf: ProtobufTestConfig? = null,
 ) {
     @JsonIgnore
+    fun hasSpecOverride(specId: String): Boolean {
+        return collectOverriddenSpecIds().contains(specId)
+    }
+
+    @JsonIgnore
+    fun dropNoOpSpecificationOverrides(): TestRunOptions {
+        return copy(
+            wsdl = wsdl?.copy(specs = wsdl.specs.filterOverrides()),
+            openapi = openapi?.copy(specs = openapi.specs.filterOverrides()),
+            protobuf = protobuf?.copy(specs = protobuf.specs.filterOverrides()),
+            asyncapi = asyncapi?.copy(specs = asyncapi.specs.filterOverrides()),
+            graphqlsdl = graphqlsdl?.copy(specs = graphqlsdl.specs.filterOverrides()),
+        )
+    }
+
+    @JsonIgnore
+    private fun collectOverriddenSpecIds(): Set<String> {
+        return buildSet {
+            addAll(wsdl?.specs.collectSpecIds())
+            addAll(openapi?.specs.collectSpecIds())
+            addAll(asyncapi?.specs.collectSpecIds())
+            addAll(protobuf?.specs.collectSpecIds())
+            addAll(graphqlsdl?.specs.collectSpecIds())
+        }
+    }
+
+    @JsonIgnore
     fun getRunOptionsFor(specType: SpecType): IRunOptions? {
         return when(specType) {
             SpecType.WSDL -> wsdl
@@ -66,6 +93,33 @@ data class MockRunOptions(
     val protobuf: ProtobufMockConfig? = null,
 ) {
     @JsonIgnore
+    fun hasSpecOverride(specId: String): Boolean {
+        return collectOverriddenSpecIds().contains(specId)
+    }
+
+    @JsonIgnore
+    fun dropNoOpSpecificationOverrides(): MockRunOptions {
+        return copy(
+            wsdl = wsdl?.copy(specs = wsdl.specs.filterOverrides()),
+            openapi = openapi?.copy(specs = openapi.specs.filterOverrides()),
+            protobuf = protobuf?.copy(specs = protobuf.specs.filterOverrides()),
+            asyncapi = asyncapi?.copy(specs = asyncapi.specs.filterOverrides()),
+            graphqlsdl = graphqlsdl?.copy(specs = graphqlsdl.specs.filterOverrides()),
+        )
+    }
+
+    @JsonIgnore
+    private fun collectOverriddenSpecIds(): Set<String> {
+        return buildSet {
+            addAll(wsdl?.specs.collectSpecIds())
+            addAll(openapi?.specs.collectSpecIds())
+            addAll(asyncapi?.specs.collectSpecIds())
+            addAll(protobuf?.specs.collectSpecIds())
+            addAll(graphqlsdl?.specs.collectSpecIds())
+        }
+    }
+
+    @JsonIgnore
     fun getRunOptionsFor(specType: SpecType): IRunOptions? {
         return when(specType) {
             SpecType.WSDL -> wsdl
@@ -83,4 +137,12 @@ data class ContextDependentRunOptions(@get:JsonAnyGetter val rawValue: Map<Strin
         @JsonCreator
         fun create(@JsonAnySetter raw: Map<String, Any?>): ContextDependentRunOptions = ContextDependentRunOptions(raw)
     }
+}
+
+private fun <T : IRunOptionSpecification> List<T>?.filterOverrides(): List<T>? {
+    return this?.filterNot(IRunOptionSpecification::isNoOpOverride)?.takeUnless { it.isEmpty() }
+}
+
+private fun <T : IRunOptionSpecification> List<T>?.collectSpecIds(): Set<String> {
+    return this.orEmpty().mapNotNull(IRunOptionSpecification::getId).toSet()
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/RunOptionsSpecifications.kt
@@ -11,6 +11,7 @@ interface IRunOptionSpecification {
     fun getBaseUrl(defaultHost: String): String?
     fun getConfig(): Map<String, Any>
     fun getOverlayFilePath(): String?
+    fun isNoOpOverride(): Boolean
 
     fun extractBaseUrlFromMap(map: Map<*, *>?, defaultHost: String): String? {
         if (map.isNullOrEmpty()) return null
@@ -44,6 +45,11 @@ data class RunOptionsSpecifications(val spec: Value) : IRunOptionSpecification {
             spec.host?.let { put("host", it) }
             spec.port?.let { put("port", it) }
         }
+    }
+
+    @JsonIgnore
+    override fun isNoOpOverride(): Boolean {
+        return spec.host == null && spec.port == null && spec.overlayFilePath == null && spec.config.isEmpty()
     }
 
     data class Value(
@@ -83,6 +89,11 @@ data class WsdlRunOptionsSpecifications(val spec: Value) : IRunOptionSpecificati
     }
 
     @JsonIgnore
+    override fun isNoOpOverride(): Boolean {
+        return spec.baseUrl == null && spec.host == null && spec.port == null
+    }
+
+    @JsonIgnore
     override fun getBaseUrl(defaultHost: String): String? {
         if (spec.baseUrl != null) return spec.baseUrl
         if (spec.port == null) return null
@@ -111,6 +122,11 @@ data class OpenApiRunOptionsSpecifications(val spec: Value) : IRunOptionSpecific
     @JsonIgnore
     override fun getConfig(): Map<String, Any> {
         return emptyMap()
+    }
+
+    @JsonIgnore
+    override fun isNoOpOverride(): Boolean {
+        return spec.baseUrl == null && spec.host == null && spec.port == null && spec.overlayFilePath == null && spec.securitySchemes == null
     }
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/runOptions/WsdlRunOptions.kt
@@ -13,8 +13,9 @@ data class WsdlTestConfig(
     val baseUrl: String? = null,
     val host: String? = null,
     val port: Int? = null,
+    override val cert: RefOrValue<HttpsConfiguration>? = null,
     override val specs: List<WsdlRunOptionsSpecifications>? = null
-) : WsdlRunOptions {
+) : WsdlRunOptions, ConfigWithCert {
     private val _config: MutableMap<String, Any> = linkedMapOf()
 
     @JsonIgnore

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/services/SpecificationDefinition.kt
@@ -41,6 +41,8 @@ sealed interface SpecificationDefinition {
             return source.toSpecificationSource(specFile, spec.path, baseUrl, resiliencyTestSuite, examples)
         }
 
+        fun hasNoData(): Boolean = spec.urlPathPrefix == null && spec.config.isEmpty()
+
         companion object {
             fun from(specFile: File, id: String): ObjectValue {
                 val spec = Specification(id, specFile.canonicalPath)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/components/settings/GeneralSettings.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/components/settings/GeneralSettings.kt
@@ -13,6 +13,6 @@ data class GeneralSettings(
     val featureFlags: FeatureFlags? = null,
     @field:JsonDeserialize(using = ExampleTemplateStringDeserializer::class)
     val specExamplesDirectoryTemplate: String? = null,
-    @field:JsonDeserialize(using = ExampleTemplateStringDeserializer::class)
+    @field:JsonDeserialize(contentUsing = ExampleTemplateStringDeserializer::class)
     val sharedExamplesDirectoryTemplate: List<String>? = null
 )

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DataSectionMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DataSectionMapper.kt
@@ -1,0 +1,21 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.config.v3.Data
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.Adapter
+import io.specmatic.core.config.v3.components.Dictionary
+import io.specmatic.core.config.v3.components.ExampleDirectories
+
+class DataSectionMapper {
+    fun mapFrom(exampleDirectories: List<String>, dictionaryPath: String? = null, hooks: Map<String, String> = emptyMap()): Data {
+        val examples = exampleDirectories.takeIf { it.isNotEmpty() }?.let { directories ->
+            RefOrValue.Value<List<RefOrValue<ExampleDirectories>>>(
+                listOf(RefOrValue.Value(ExampleDirectories(directories)))
+            )
+        }
+
+        val dictionary = dictionaryPath?.let { RefOrValue.Value(Dictionary(it)) }
+        val adapters = hooks.takeIf { it.isNotEmpty() }?.let { RefOrValue.Value(Adapter(it)) }
+        return Data(examples = examples, dictionary = dictionary, adapters = adapters)
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapper.kt
@@ -53,8 +53,9 @@ class DependenciesMapper {
     }
 
     private fun buildRunOptions(migration: SourceMigration.MockSourceMigration, view: LegacyConfigView): MockRunOptions {
-        val overrides = listOf(migration.config).fold(RunOptionsMapper(defaultHostForPortOnly = "0.0.0.0")) { acc, config ->
-            acc.mergeConfig(config = config, specTypesByPath = migration.specTypesByPath)
+        val initialMapper = RunOptionsMapper(defaultHostForPortOnly = "0.0.0.0", specIdsByPath = migration.specIdsByPath, specTypesByPath = migration.specTypesByPath)
+        val overrides = listOf(migration.config).fold(initialMapper) { acc, config ->
+            acc.mergeConfig(config = config)
         }
 
         return MockRunOptions(

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapper.kt
@@ -33,7 +33,7 @@ class DependenciesMapper {
                 )
             },
             data = DataSectionMapper().mapFrom(
-                hooks = view.globalHooks,
+                hooks = view.stubHooks,
                 exampleDirectories = view.globalExamples,
                 dictionaryPath = view.stubConfig?.getDictionary(),
             ),

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapper.kt
@@ -1,0 +1,107 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.config.Switch
+import io.specmatic.core.config.OpenAPIMockConfig as LegacyOpenAPIMockConfig
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.runOptions.AsyncApiMockConfig
+import io.specmatic.core.config.v3.components.runOptions.GraphQLSdlMockConfig
+import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.runOptions.OpenApiMockConfig
+import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.ProtobufMockConfig
+import io.specmatic.core.config.v3.components.runOptions.RunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.WsdlMockConfig
+import io.specmatic.core.config.v3.components.runOptions.WsdlRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.MockServiceConfig
+import io.specmatic.core.config.v3.components.settings.MockSettings
+import io.specmatic.reporter.model.SpecType
+
+class DependenciesMapper {
+    fun mapFrom(view: LegacyConfigView, source: SourceMigrationBuilder): MockServiceConfig? {
+        val migrations = source.buildMockMigrations(view.sources)
+        if (migrations.isEmpty()) return null
+
+        return MockServiceConfig(
+            settings = RefOrValue.Value(buildSettings(view)),
+            services = migrations.map { migration ->
+                createService(
+                    view = view,
+                    migration = migration,
+                    examples = extractExamplesFromConfig(migration.config),
+                )
+            },
+            data = DataSectionMapper().mapFrom(
+                hooks = view.globalHooks,
+                exampleDirectories = view.globalExamples,
+                dictionaryPath = view.stubConfig?.getDictionary(),
+            ),
+        )
+    }
+
+    private fun buildSettings(view: LegacyConfigView): MockSettings {
+        return MockSettings(
+            generative = view.stubConfig?.getGenerative(),
+            strictMode = view.stubConfig?.getStrictMode(),
+            lenientMode = view.stubConfig?.getLenientMode(),
+            delayInMilliseconds = view.stubConfig?.getDelayInMilliseconds(),
+            hotReload = view.stubConfig?.getHotReload()?.let { it == Switch.enabled },
+            startTimeoutInMilliseconds = view.stubConfig?.getStartTimeoutInMilliseconds(),
+            gracefulRestartTimeoutInMilliseconds = view.stubConfig?.getGracefulRestartTimeoutInMilliseconds(),
+        )
+    }
+
+    private fun buildRunOptions(migration: SourceMigration.MockSourceMigration, view: LegacyConfigView): MockRunOptions {
+        val overrides = listOf(migration.config).fold(RunOptionsMapper(defaultHostForPortOnly = "0.0.0.0")) { acc, config ->
+            acc.mergeConfig(config = config, specTypesByPath = migration.specTypesByPath)
+        }
+
+        return MockRunOptions(
+            wsdl = buildWsdlMockConfig(view, migration, overrides),
+            openapi = buildOpenApiMockConfig(view, migration, overrides),
+            asyncapi = AsyncApiMockConfig(specs = overrides.asyncApi.values.map(::RunOptionsSpecifications)),
+            protobuf = ProtobufMockConfig(specs = overrides.protobuf.values.map(::RunOptionsSpecifications)),
+            graphqlsdl = GraphQLSdlMockConfig(specs = overrides.graphQl.values.map(::RunOptionsSpecifications)),
+        )
+    }
+
+    private fun buildOpenApiMockConfig(view: LegacyConfigView, migration: SourceMigration.MockSourceMigration, overrides: RunOptionsMapper): OpenApiMockConfig {
+        if (!migration.hasSpecType(SpecType.OPENAPI)) return OpenApiMockConfig()
+        return OpenApiMockConfig(
+            filter = view.stubConfig?.getFilter(),
+            baseUrl = view.stubConfig?.getBaseUrl(),
+            cert = view.stubConfig?.getHttps()?.let { RefOrValue.Value(it) },
+            specs = overrides.openApi.values.map(::OpenApiRunOptionsSpecifications),
+        )
+    }
+
+    private fun buildWsdlMockConfig(view: LegacyConfigView, migration: SourceMigration.MockSourceMigration, overrides: RunOptionsMapper): WsdlMockConfig {
+        if (!migration.hasSpecType(SpecType.WSDL)) return WsdlMockConfig()
+        return WsdlMockConfig(
+            baseUrl = view.stubConfig?.getBaseUrl(),
+            cert = view.stubConfig?.getHttps()?.let { RefOrValue.Value(it) },
+            specs = overrides.wsdl.values.map(::WsdlRunOptionsSpecifications)
+        )
+    }
+
+    private fun createService(migration: SourceMigration.MockSourceMigration, view: LegacyConfigView, examples: List<String>): MockServiceConfig.Value {
+        val runOptions = buildRunOptions(migration, view).dropNoOpSpecificationOverrides()
+        val definition = migration.definition.dropSpecificationIdsWithoutOverrides(runOptions::hasSpecOverride)
+        val data = DataSectionMapper().mapFrom(exampleDirectories = examples)
+        return MockServiceConfig.Value(
+            service = RefOrValue.Value(
+                CommonServiceConfig(
+                    data = data,
+                    definitions = listOf(definition),
+                    runOptions = RefOrValue.Value(runOptions),
+                )
+            )
+        )
+    }
+
+    private fun extractExamplesFromConfig(config: SpecExecutionConfig): List<String> {
+        val configValue = config as? SpecExecutionConfig.ConfigValue ?: return emptyList()
+        return runCatching { LegacyOpenAPIMockConfig.from(configValue.config).examples.orEmpty() }.getOrDefault(emptyList())
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacyConfigView.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacyConfigView.kt
@@ -22,6 +22,26 @@ data class LegacyConfigView(
     val globalSettings: SpecmaticGlobalSettings,
     val stubConfig: io.specmatic.core.StubConfiguration?,
 ) {
+    val stubHooks: Map<String, String> by lazy {
+        globalHooks.filterKeys {
+            when (it) {
+                "post_specmatic_response_processor", "pre_specmatic_request_processor" -> true
+                "pre_specmatic_response_processor" -> false
+                else -> true
+            }
+        }
+    }
+
+    val proxyHooks: Map<String, String> by lazy {
+        globalHooks.filterKeys {
+            when (it) {
+                "pre_specmatic_request_processor", "pre_specmatic_response_processor" -> true
+                "post_specmatic_response_processor" -> false
+                else -> true
+            }
+        }
+    }
+
     companion object {
         fun from(legacyConfig: SpecmaticConfigV1V2Common): LegacyConfigView {
             val testConfig = SpecmaticConfigV1V2Common.getTestConfigOrNull(legacyConfig)

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacyConfigView.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacyConfigView.kt
@@ -1,0 +1,52 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.Auth
+import io.specmatic.core.ReportConfigurationDetails
+import io.specmatic.core.SecurityConfiguration
+import io.specmatic.core.Source
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.TestConfiguration
+import io.specmatic.core.WorkflowConfiguration
+import io.specmatic.core.config.SpecmaticGlobalSettings
+import io.specmatic.core.config.v3.components.sources.GitAuthentication
+
+data class LegacyConfigView(
+    val sources: List<Source>,
+    val gitAuth: GitAuthentication?,
+    val globalExamples: List<String>,
+    val testConfig: TestConfiguration?,
+    val workflow: WorkflowConfiguration?,
+    val security: SecurityConfiguration?,
+    val globalHooks: Map<String, String>,
+    val report: ReportConfigurationDetails?,
+    val globalSettings: SpecmaticGlobalSettings,
+    val stubConfig: io.specmatic.core.StubConfiguration?,
+) {
+    companion object {
+        fun from(legacyConfig: SpecmaticConfigV1V2Common): LegacyConfigView {
+            val testConfig = SpecmaticConfigV1V2Common.getTestConfigOrNull(legacyConfig)
+            val stubConfig = SpecmaticConfigV1V2Common.getStubConfigOrNull(legacyConfig)
+
+            return LegacyConfigView(
+                testConfig = testConfig,
+                stubConfig = stubConfig,
+                globalHooks = legacyConfig.getHooks(),
+                globalExamples = legacyConfig.getExamples(),
+                gitAuth = legacyConfig.getAuth()?.toGitAuthentication(),
+                report = SpecmaticConfigV1V2Common.getReport(legacyConfig),
+                globalSettings = legacyConfig.getGlobalSettingsOrDefault(),
+                sources = SpecmaticConfigV1V2Common.getSources(legacyConfig),
+                workflow = SpecmaticConfigV1V2Common.getWorkflowConfiguration(legacyConfig),
+                security = SpecmaticConfigV1V2Common.getSecurityConfiguration(legacyConfig)
+            )
+        }
+
+        private fun Auth.toGitAuthentication(): GitAuthentication? {
+            return when {
+                !personalAccessToken.isNullOrBlank() -> GitAuthentication.PersonalAccessToken(personalAccessToken)
+                !bearerEnvironmentVariable.isNullOrBlank() -> GitAuthentication.BearerEnv(bearerEnvironmentVariable)
+                else -> GitAuthentication.BearerFile(bearerFile)
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3Upgrader.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3Upgrader.kt
@@ -1,0 +1,36 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.ProxyConfig
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.v3.Proxy
+import io.specmatic.core.config.v3.ProxyConfigV3
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.SpecmaticConfigV3
+
+class LegacySpecmaticConfigToV3Upgrader {
+    fun upgrade(legacyConfig: SpecmaticConfigV1V2Common): SpecmaticConfigV3 {
+        val view = LegacyConfigView.from(legacyConfig)
+        val source = SourceMigrationBuilder(view.gitAuth)
+        return SpecmaticConfigV3(
+            mcp = legacyConfig.getMcpConfiguration(),
+            version = SpecmaticConfigVersion.VERSION_3,
+            dependencies = DependenciesMapper().mapFrom(view, source),
+            systemUnderTest = SystemUnderTestMapper().mapFrom(view, source),
+            specmatic = SpecmaticMetadataMapper().mapFrom(legacyConfig, view),
+            proxies = legacyConfig.getProxyConfig()?.let { listOf(Proxy(it.toV3())) },
+        )
+    }
+
+    private fun ProxyConfig.toV3(): ProxyConfigV3 {
+        return ProxyConfigV3(
+            mock = consumes,
+            baseUrl = baseUrl,
+            target = targetUrl,
+            recordingsDirectory = outputDirectory,
+            cert = https?.let { RefOrValue.Value(it) },
+            timeoutInMilliseconds = timeoutInMilliseconds,
+            adapters = adapters?.let { RefOrValue.Value(it) },
+        )
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3Upgrader.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3Upgrader.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.config.v3.Proxy
 import io.specmatic.core.config.v3.ProxyConfigV3
 import io.specmatic.core.config.v3.RefOrValue
 import io.specmatic.core.config.v3.SpecmaticConfigV3
+import io.specmatic.core.config.v3.components.Adapter
 
 class LegacySpecmaticConfigToV3Upgrader {
     fun upgrade(legacyConfig: SpecmaticConfigV1V2Common): SpecmaticConfigV3 {
@@ -18,11 +19,12 @@ class LegacySpecmaticConfigToV3Upgrader {
             dependencies = DependenciesMapper().mapFrom(view, source),
             systemUnderTest = SystemUnderTestMapper().mapFrom(view, source),
             specmatic = SpecmaticMetadataMapper().mapFrom(legacyConfig, view),
-            proxies = legacyConfig.getProxyConfig()?.let { listOf(Proxy(it.toV3())) },
+            proxies = legacyConfig.getProxyConfig()?.let { listOf(Proxy(it.toV3(view.proxyHooks))) },
         )
     }
 
-    private fun ProxyConfig.toV3(): ProxyConfigV3 {
+    private fun ProxyConfig.toV3(hooks: Map<String, String>): ProxyConfigV3 {
+        val mergedAdapters = adapters?.hooks.orEmpty().plus(hooks).takeUnless { it.isEmpty() }
         return ProxyConfigV3(
             mock = consumes,
             baseUrl = baseUrl,
@@ -30,7 +32,7 @@ class LegacySpecmaticConfigToV3Upgrader {
             recordingsDirectory = outputDirectory,
             cert = https?.let { RefOrValue.Value(it) },
             timeoutInMilliseconds = timeoutInMilliseconds,
-            adapters = adapters?.let { RefOrValue.Value(it) },
+            adapters = mergedAdapters?.let { RefOrValue.Value(Adapter(it)) }
         )
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapper.kt
@@ -1,0 +1,208 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.components.SecuritySchemeConfigurationV3
+import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.RunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.WsdlRunOptionsSpecifications
+import io.specmatic.reporter.model.SpecType
+
+data class RunOptionsMapper(
+    private val defaultHostForPortOnly: String = "0.0.0.0",
+    val graphQl: Map<String, RunOptionsSpecifications.Value> = linkedMapOf(),
+    val wsdl: Map<String, WsdlRunOptionsSpecifications.Value> = linkedMapOf(),
+    val protobuf: Map<String, RunOptionsSpecifications.Value> = linkedMapOf(),
+    val asyncApi: Map<String, RunOptionsSpecifications.Value> = linkedMapOf(),
+    val openApi: Map<String, OpenApiRunOptionsSpecifications.Value> = linkedMapOf(),
+) {
+    fun mergeGlobalOpenApi(
+        overlayFilePath: String? = null,
+        specTypesByPath: Map<String, SpecType>,
+        securitySchemes: Map<String, SecuritySchemeConfigurationV3>? = null,
+    ): RunOptionsMapper {
+        return specTypesByPath.entries.fold(this) { acc, (specPath, specType) ->
+            if (specType != SpecType.OPENAPI) return@fold acc
+            acc.mergeGlobalOpenApi(specPath, overlayFilePath = overlayFilePath, securitySchemes = securitySchemes)
+        }
+    }
+
+    fun mergeConfig(config: SpecExecutionConfig, specTypesByPath: Map<String, SpecType>): RunOptionsMapper {
+        return config.specs().fold(this) { acc, specPath ->
+            val specType = specTypesByPath[specPath] ?: return@fold acc
+            when (config) {
+                is SpecExecutionConfig.StringValue -> acc
+                is SpecExecutionConfig.ObjectValue -> acc.mergeObjectValue(specPath, specType, config)
+                is SpecExecutionConfig.ConfigValue -> acc.mergeConfigValue(specPath, specType, config)
+            }
+        }
+    }
+
+    private fun mergeObjectValue(specPath: String, specType: SpecType, config: SpecExecutionConfig.ObjectValue): RunOptionsMapper {
+        val input = config.toUrlMergeInput()
+        return when (specType) {
+            SpecType.WSDL -> mergeWsdl(specPath, input)
+            SpecType.OPENAPI -> mergeOpenApi(specPath, input)
+            SpecType.GRAPHQL -> mergeGeneric(specPath, specType, input = input)
+            SpecType.ASYNCAPI -> mergeGeneric(specPath, specType, input = input)
+            SpecType.PROTOBUF -> mergeGeneric(specPath, specType, input = input)
+        }
+    }
+
+    private fun SpecExecutionConfig.ObjectValue.toUrlMergeInput(): UrlMergeInput {
+        return when (this) {
+            is SpecExecutionConfig.ObjectValue.FullUrl -> UrlMergeInput.BaseUrl(baseUrl)
+            is SpecExecutionConfig.ObjectValue.PartialUrl -> UrlMergeInput.HostPort(host = host, port = port)
+        }
+    }
+
+    private fun SpecExecutionConfig.ConfigValue.toUrlMergeInput(): UrlMergeInput {
+        val baseUrl = config["baseUrl"] as? String
+        if (baseUrl != null) return UrlMergeInput.BaseUrl(baseUrl)
+        val port = config["port"] as? Int
+        val host = config["host"] as? String
+        return if (port != null) {
+            UrlMergeInput.HostPort(host = host, port = port)
+        } else {
+            UrlMergeInput.None
+        }
+    }
+
+    private fun mergeConfigValue(specPath: String, specType: SpecType, config: SpecExecutionConfig.ConfigValue): RunOptionsMapper {
+        val input = config.toUrlMergeInput()
+        return when (specType) {
+            SpecType.WSDL -> mergeWsdl(specPath, input)
+            SpecType.OPENAPI -> mergeOpenApi(specPath, input)
+            SpecType.GRAPHQL -> mergeGeneric(specPath, specType, config.config, input)
+            SpecType.ASYNCAPI -> mergeGeneric(specPath, specType, config.config, input)
+            SpecType.PROTOBUF -> mergeGeneric(specPath, specType, config.config, input)
+        }
+    }
+
+    private fun mergeOpenApi(specPath: String, input: UrlMergeInput): RunOptionsMapper {
+        val existing = openApi[specPath]
+        return copy(
+            openApi = openApi.update(
+                key = specPath,
+                value = (existing ?: OpenApiRunOptionsSpecifications.Value()).copy(
+                    id = specPath,
+                    baseUrl = input.baseUrl(existing?.baseUrl),
+                    host = input.host(existing?.host, existing?.baseUrl),
+                    port = input.port(existing?.port, existing?.baseUrl),
+                )
+            )
+        )
+    }
+
+    private fun mergeWsdl(specPath: String, input: UrlMergeInput): RunOptionsMapper {
+        val existing = wsdl[specPath]
+        return copy(
+            wsdl = wsdl.update(
+                key = specPath,
+                value = (existing ?: WsdlRunOptionsSpecifications.Value()).copy(
+                    id = specPath,
+                    baseUrl = input.baseUrl(existing?.baseUrl),
+                    host = input.host(existing?.host, existing?.baseUrl),
+                    port = input.port(existing?.port, existing?.baseUrl),
+                )
+            )
+        )
+    }
+
+    private fun mergeGeneric(specPath: String, specType: SpecType, config: Map<String, Any> = emptyMap(), input: UrlMergeInput = UrlMergeInput.None): RunOptionsMapper {
+        val target = when (specType) {
+            SpecType.GRAPHQL -> graphQl
+            SpecType.ASYNCAPI -> asyncApi
+            SpecType.PROTOBUF -> protobuf
+            else -> emptyMap()
+        }
+
+        val existing = target[specPath]
+        val merged = LinkedHashMap(existing?.config.orEmpty()).apply {
+            putAll(config.drop("host", "port", "baseUrl"))
+        }
+
+        val updated = target.update(
+            key = specPath,
+            value = (existing ?: RunOptionsSpecifications.Value()).copy(
+                id = specPath,
+                host = input.toHost(existing?.host, defaultHostForPortOnly),
+                port = input.toPort(existing?.port)
+            ).withConfig(merged)
+        )
+
+        return when (specType) {
+            SpecType.GRAPHQL -> copy(graphQl = updated)
+            SpecType.ASYNCAPI -> copy(asyncApi = updated)
+            SpecType.PROTOBUF -> copy(protobuf = updated)
+            else -> this
+        }
+    }
+
+    private fun mergeGlobalOpenApi(
+        specPath: String,
+        overlayFilePath: String? = null,
+        securitySchemes: Map<String, SecuritySchemeConfigurationV3>? = null
+    ): RunOptionsMapper {
+        val existing = openApi[specPath]
+        return copy(
+            openApi = openApi.update(
+                key = specPath,
+                value = (existing ?: OpenApiRunOptionsSpecifications.Value()).copy(
+                    id = specPath,
+                    overlayFilePath = existing?.overlayFilePath ?: overlayFilePath,
+                    securitySchemes = existing?.securitySchemes ?: securitySchemes
+                )
+            )
+        )
+    }
+
+    @Suppress("SameParameterValue")
+    private fun <T> Map<String, T>.drop(vararg keys: String): Map<String, T> {
+        return this.filterKeys { key -> key !in keys }
+    }
+
+    private fun <T> Map<String, T>.update(key: String, value: T): Map<String, T> {
+        return LinkedHashMap(this).apply { put(key, value) }
+    }
+}
+
+private sealed interface UrlMergeInput {
+    fun toPort(existingPort: Int?): Int?
+    fun baseUrl(existing: String?): String?
+    fun port(existing: Int?, existingBaseUrl: String?): Int?
+    fun host(existing: String?, existingBaseUrl: String?): String?
+    fun toHost(existingHost: String?, defaultHostForPortOnly: String): String?
+
+    data class BaseUrl(val value: String) : UrlMergeInput {
+        override fun baseUrl(existing: String?) = value
+        override fun port(existing: Int?, existingBaseUrl: String?) = null
+        override fun host(existing: String?, existingBaseUrl: String?) = null
+        override fun toPort(existingPort: Int?) = parseBaseUrlParts(value).port ?: existingPort
+        override fun toHost(existingHost: String?, defaultHostForPortOnly: String) = parseBaseUrlParts(value).host ?: existingHost
+    }
+
+    data class HostPort(val host: String?, val port: Int?) : UrlMergeInput {
+        override fun baseUrl(existing: String?) = existing
+        override fun toPort(existingPort: Int?) = port ?: existingPort
+        override fun port(existing: Int?, existingBaseUrl: String?) = if (existingBaseUrl != null) null else port ?: existing
+        override fun host(existing: String?, existingBaseUrl: String?) = if (existingBaseUrl != null) null else host ?: existing
+        override fun toHost(existingHost: String?, defaultHostForPortOnly: String): String? = host ?: if (port != null) defaultHostForPortOnly else existingHost
+    }
+
+    data object None : UrlMergeInput {
+        override fun baseUrl(existing: String?) = existing
+        override fun port(existing: Int?, existingBaseUrl: String?) = existing
+        override fun host(existing: String?, existingBaseUrl: String?) = existing
+        override fun toHost(existingHost: String?, defaultHostForPortOnly: String): String? = existingHost
+        override fun toPort(existingPort: Int?) = existingPort
+    }
+}
+
+private data class BaseUrlParts(val host: String?, val port: Int?)
+private fun parseBaseUrlParts(baseUrl: String): BaseUrlParts {
+    return runCatching {
+        val uri = java.net.URI(baseUrl)
+        val parsedPort = if (uri.port == -1) null else uri.port
+        BaseUrlParts(host = uri.host, port = parsedPort)
+    }.getOrDefault(BaseUrlParts(host = null, port = null))
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapper.kt
@@ -9,6 +9,8 @@ import io.specmatic.reporter.model.SpecType
 
 data class RunOptionsMapper(
     private val defaultHostForPortOnly: String = "0.0.0.0",
+    private val specIdsByPath: Map<String, String> = emptyMap(),
+    private val specTypesByPath: Map<String, SpecType> = emptyMap(),
     val graphQl: Map<String, RunOptionsSpecifications.Value> = linkedMapOf(),
     val wsdl: Map<String, WsdlRunOptionsSpecifications.Value> = linkedMapOf(),
     val protobuf: Map<String, RunOptionsSpecifications.Value> = linkedMapOf(),
@@ -17,34 +19,33 @@ data class RunOptionsMapper(
 ) {
     fun mergeGlobalOpenApi(
         overlayFilePath: String? = null,
-        specTypesByPath: Map<String, SpecType>,
         securitySchemes: Map<String, SecuritySchemeConfigurationV3>? = null,
     ): RunOptionsMapper {
         return specTypesByPath.entries.fold(this) { acc, (specPath, specType) ->
             if (specType != SpecType.OPENAPI) return@fold acc
-            acc.mergeGlobalOpenApi(specPath, overlayFilePath = overlayFilePath, securitySchemes = securitySchemes)
+            acc.mergeGlobalOpenApi(specPath, specIdsByPath, overlayFilePath = overlayFilePath, securitySchemes = securitySchemes)
         }
     }
 
-    fun mergeConfig(config: SpecExecutionConfig, specTypesByPath: Map<String, SpecType>): RunOptionsMapper {
+    fun mergeConfig(config: SpecExecutionConfig): RunOptionsMapper {
         return config.specs().fold(this) { acc, specPath ->
             val specType = specTypesByPath[specPath] ?: return@fold acc
             when (config) {
                 is SpecExecutionConfig.StringValue -> acc
-                is SpecExecutionConfig.ObjectValue -> acc.mergeObjectValue(specPath, specType, config)
-                is SpecExecutionConfig.ConfigValue -> acc.mergeConfigValue(specPath, specType, config)
+                is SpecExecutionConfig.ObjectValue -> acc.mergeObjectValue(specPath, specIdsByPath, specType, config)
+                is SpecExecutionConfig.ConfigValue -> acc.mergeConfigValue(specPath, specIdsByPath, specType, config)
             }
         }
     }
 
-    private fun mergeObjectValue(specPath: String, specType: SpecType, config: SpecExecutionConfig.ObjectValue): RunOptionsMapper {
+    private fun mergeObjectValue(specPath: String, specIdsByPath: Map<String, String>, specType: SpecType, config: SpecExecutionConfig.ObjectValue): RunOptionsMapper {
         val input = config.toUrlMergeInput()
         return when (specType) {
-            SpecType.WSDL -> mergeWsdl(specPath, input)
-            SpecType.OPENAPI -> mergeOpenApi(specPath, input)
-            SpecType.GRAPHQL -> mergeGeneric(specPath, specType, input = input)
-            SpecType.ASYNCAPI -> mergeGeneric(specPath, specType, input = input)
-            SpecType.PROTOBUF -> mergeGeneric(specPath, specType, input = input)
+            SpecType.WSDL -> mergeWsdl(specPath, specIdsByPath, input)
+            SpecType.OPENAPI -> mergeOpenApi(specPath, specIdsByPath, input)
+            SpecType.GRAPHQL -> mergeGeneric(specPath, specIdsByPath, specType, input = input)
+            SpecType.ASYNCAPI -> mergeGeneric(specPath, specIdsByPath, specType, input = input)
+            SpecType.PROTOBUF -> mergeGeneric(specPath, specIdsByPath, specType, input = input)
         }
     }
 
@@ -67,24 +68,24 @@ data class RunOptionsMapper(
         }
     }
 
-    private fun mergeConfigValue(specPath: String, specType: SpecType, config: SpecExecutionConfig.ConfigValue): RunOptionsMapper {
+    private fun mergeConfigValue(specPath: String, specIdsByPath: Map<String, String>, specType: SpecType, config: SpecExecutionConfig.ConfigValue): RunOptionsMapper {
         val input = config.toUrlMergeInput()
         return when (specType) {
-            SpecType.WSDL -> mergeWsdl(specPath, input)
-            SpecType.OPENAPI -> mergeOpenApi(specPath, input)
-            SpecType.GRAPHQL -> mergeGeneric(specPath, specType, config.config, input)
-            SpecType.ASYNCAPI -> mergeGeneric(specPath, specType, config.config, input)
-            SpecType.PROTOBUF -> mergeGeneric(specPath, specType, config.config, input)
+            SpecType.WSDL -> mergeWsdl(specPath, specIdsByPath, input)
+            SpecType.OPENAPI -> mergeOpenApi(specPath, specIdsByPath, input)
+            SpecType.GRAPHQL -> mergeGeneric(specPath, specIdsByPath, specType, config.config, input)
+            SpecType.ASYNCAPI -> mergeGeneric(specPath, specIdsByPath, specType, config.config, input)
+            SpecType.PROTOBUF -> mergeGeneric(specPath, specIdsByPath, specType, config.config, input)
         }
     }
 
-    private fun mergeOpenApi(specPath: String, input: UrlMergeInput): RunOptionsMapper {
+    private fun mergeOpenApi(specPath: String, specIdsByPath: Map<String, String>, input: UrlMergeInput): RunOptionsMapper {
         val existing = openApi[specPath]
         return copy(
             openApi = openApi.update(
                 key = specPath,
                 value = (existing ?: OpenApiRunOptionsSpecifications.Value()).copy(
-                    id = specPath,
+                    id = specIdsByPath[specPath],
                     baseUrl = input.baseUrl(existing?.baseUrl),
                     host = input.host(existing?.host, existing?.baseUrl),
                     port = input.port(existing?.port, existing?.baseUrl),
@@ -93,13 +94,13 @@ data class RunOptionsMapper(
         )
     }
 
-    private fun mergeWsdl(specPath: String, input: UrlMergeInput): RunOptionsMapper {
+    private fun mergeWsdl(specPath: String, specIdsByPath: Map<String, String>, input: UrlMergeInput): RunOptionsMapper {
         val existing = wsdl[specPath]
         return copy(
             wsdl = wsdl.update(
                 key = specPath,
                 value = (existing ?: WsdlRunOptionsSpecifications.Value()).copy(
-                    id = specPath,
+                    id = specIdsByPath[specPath],
                     baseUrl = input.baseUrl(existing?.baseUrl),
                     host = input.host(existing?.host, existing?.baseUrl),
                     port = input.port(existing?.port, existing?.baseUrl),
@@ -108,7 +109,7 @@ data class RunOptionsMapper(
         )
     }
 
-    private fun mergeGeneric(specPath: String, specType: SpecType, config: Map<String, Any> = emptyMap(), input: UrlMergeInput = UrlMergeInput.None): RunOptionsMapper {
+    private fun mergeGeneric(specPath: String, specIdsByPath: Map<String, String>, specType: SpecType, config: Map<String, Any> = emptyMap(), input: UrlMergeInput = UrlMergeInput.None): RunOptionsMapper {
         val target = when (specType) {
             SpecType.GRAPHQL -> graphQl
             SpecType.ASYNCAPI -> asyncApi
@@ -124,7 +125,7 @@ data class RunOptionsMapper(
         val updated = target.update(
             key = specPath,
             value = (existing ?: RunOptionsSpecifications.Value()).copy(
-                id = specPath,
+                id = specIdsByPath[specPath],
                 host = input.toHost(existing?.host, defaultHostForPortOnly),
                 port = input.toPort(existing?.port)
             ).withConfig(merged)
@@ -140,6 +141,7 @@ data class RunOptionsMapper(
 
     private fun mergeGlobalOpenApi(
         specPath: String,
+        specIdsByPath: Map<String, String>,
         overlayFilePath: String? = null,
         securitySchemes: Map<String, SecuritySchemeConfigurationV3>? = null
     ): RunOptionsMapper {
@@ -148,7 +150,7 @@ data class RunOptionsMapper(
             openApi = openApi.update(
                 key = specPath,
                 value = (existing ?: OpenApiRunOptionsSpecifications.Value()).copy(
-                    id = specPath,
+                    id = specIdsByPath[specPath],
                     overlayFilePath = existing?.overlayFilePath ?: overlayFilePath,
                     securitySchemes = existing?.securitySchemes ?: securitySchemes
                 )

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilder.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilder.kt
@@ -15,17 +15,20 @@ import java.io.File
 sealed interface SourceMigration {
     val definition: Definition
     val specTypesByPath: Map<String, SpecType>
+    val specIdsByPath: Map<String, String>
 
     data class TestSourceMigration(
         override val definition: Definition,
         val configs: List<SpecExecutionConfig>,
         override val specTypesByPath: Map<String, SpecType>,
+        override val specIdsByPath: Map<String, String>,
     ) : SourceMigration
 
     data class MockSourceMigration(
         override val definition: Definition,
         val config: SpecExecutionConfig,
         override val specTypesByPath: Map<String, SpecType>,
+        override val specIdsByPath: Map<String, String>,
     ) : SourceMigration
 
     fun hasSpecType(specType: SpecType): Boolean {
@@ -50,22 +53,24 @@ class SourceMigrationBuilder(private val gitAuth: GitAuthentication?) {
     private fun createTestMigration(source: Source, configs: List<SpecExecutionConfig>): SourceMigration.TestSourceMigration? {
         if (configs.isEmpty()) return null
         val specTypesByPath = resolveSpecTypesByPath(configs)
-        val definition = createDefinition(source, configs, specTypesByPath)
-        return SourceMigration.TestSourceMigration(definition = definition, configs = configs, specTypesByPath = specTypesByPath)
+        val specIdsByPath = buildSpecificationIds(specTypesByPath.keys)
+        val definition = createDefinition(source, configs, specTypesByPath, specIdsByPath)
+        return SourceMigration.TestSourceMigration(definition = definition, configs = configs, specTypesByPath = specTypesByPath, specIdsByPath = specIdsByPath)
     }
 
     private fun createMockMigration(source: Source, config: SpecExecutionConfig): SourceMigration.MockSourceMigration {
         val configs = listOf(config)
         val specTypesByPath = resolveSpecTypesByPath(configs)
-        val definition = createDefinition(source, configs, specTypesByPath)
-        return SourceMigration.MockSourceMigration(definition = definition, config = config, specTypesByPath = specTypesByPath)
+        val specIdsByPath = buildSpecificationIds(specTypesByPath.keys)
+        val definition = createDefinition(source, configs, specTypesByPath, specIdsByPath)
+        return SourceMigration.MockSourceMigration(definition = definition, config = config, specTypesByPath = specTypesByPath, specIdsByPath = specIdsByPath)
     }
 
-    private fun createDefinition(source: Source, configs: List<SpecExecutionConfig>, specTypesByPath: Map<String, SpecType>): Definition {
+    private fun createDefinition(source: Source, configs: List<SpecExecutionConfig>, specTypesByPath: Map<String, SpecType>, specIdsByPath: Map<String, String>): Definition {
         return Definition(
             Definition.Value(
                 source = RefOrValue.Value(source.toSourceV3(gitAuth)),
-                specs = specTypesByPath.keys.map { specPath -> toSpecificationDefinition(specPath, configs) },
+                specs = specTypesByPath.keys.map { specPath -> toSpecificationDefinition(specPath, specIdsByPath, configs) },
             )
         )
     }
@@ -79,14 +84,14 @@ class SourceMigrationBuilder(private val gitAuth: GitAuthentication?) {
         }
     }
 
-    private fun toSpecificationDefinition(specPath: String, configs: List<SpecExecutionConfig>): SpecificationDefinition {
+    private fun toSpecificationDefinition(specPath: String, specIdsByPath: Map<String, String>, configs: List<SpecExecutionConfig>): SpecificationDefinition {
         val urlPathPrefix = configs.asReversed().firstNotNullOfOrNull { config ->
             val objectValue = config as? SpecExecutionConfig.ObjectValue.PartialUrl ?: return@firstNotNullOfOrNull null
             if (specPath in objectValue.specs) objectValue.basePath else null
         }
 
         return SpecificationDefinition.ObjectValue(
-            SpecificationDefinition.Specification(id = specPath, path = specPath, urlPathPrefix = urlPathPrefix)
+            SpecificationDefinition.Specification(id = specIdsByPath[specPath], path = specPath, urlPathPrefix = urlPathPrefix)
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilder.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilder.kt
@@ -1,0 +1,122 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.Source
+import io.specmatic.core.SourceProvider
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.services.Definition
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.core.config.v3.components.sources.GitAuthentication
+import io.specmatic.core.config.v3.components.sources.SourceV3
+import io.specmatic.core.config.v3.determineSpecTypeFor
+import io.specmatic.reporter.model.SpecType
+import java.io.File
+
+sealed interface SourceMigration {
+    val definition: Definition
+    val specTypesByPath: Map<String, SpecType>
+
+    data class TestSourceMigration(
+        override val definition: Definition,
+        val configs: List<SpecExecutionConfig>,
+        override val specTypesByPath: Map<String, SpecType>,
+    ) : SourceMigration
+
+    data class MockSourceMigration(
+        override val definition: Definition,
+        val config: SpecExecutionConfig,
+        override val specTypesByPath: Map<String, SpecType>,
+    ) : SourceMigration
+
+    fun hasSpecType(specType: SpecType): Boolean {
+        return specTypesByPath.values.contains(specType)
+    }
+}
+
+class SourceMigrationBuilder(private val gitAuth: GitAuthentication?) {
+    fun buildTestMigrations(sources: List<Source>): List<SourceMigration.TestSourceMigration> {
+        return sources.mapNotNull { source ->
+            createTestMigration(source, source.test.orEmpty())
+        }
+    }
+
+    fun buildMockMigrations(sources: List<Source>): List<SourceMigration.MockSourceMigration> {
+        return sources.flatMap { source ->
+            if (source.stub.isNullOrEmpty()) return@flatMap emptyList()
+            source.stub.map { config -> createMockMigration(source, config) }
+        }
+    }
+
+    private fun createTestMigration(source: Source, configs: List<SpecExecutionConfig>): SourceMigration.TestSourceMigration? {
+        if (configs.isEmpty()) return null
+        val specTypesByPath = resolveSpecTypesByPath(configs)
+        val definition = createDefinition(source, configs, specTypesByPath)
+        return SourceMigration.TestSourceMigration(definition = definition, configs = configs, specTypesByPath = specTypesByPath)
+    }
+
+    private fun createMockMigration(source: Source, config: SpecExecutionConfig): SourceMigration.MockSourceMigration {
+        val configs = listOf(config)
+        val specTypesByPath = resolveSpecTypesByPath(configs)
+        val definition = createDefinition(source, configs, specTypesByPath)
+        return SourceMigration.MockSourceMigration(definition = definition, config = config, specTypesByPath = specTypesByPath)
+    }
+
+    private fun createDefinition(source: Source, configs: List<SpecExecutionConfig>, specTypesByPath: Map<String, SpecType>): Definition {
+        return Definition(
+            Definition.Value(
+                source = RefOrValue.Value(source.toSourceV3(gitAuth)),
+                specs = specTypesByPath.keys.map { specPath -> toSpecificationDefinition(specPath, configs) },
+            )
+        )
+    }
+
+    private fun resolveSpecTypesByPath(configs: List<SpecExecutionConfig>): Map<String, SpecType> {
+        return configs.fold(linkedMapOf()) { acc, config ->
+            config.specs().fold(acc) { specsAcc, specPath ->
+                if (specPath in specsAcc) return@fold specsAcc
+                LinkedHashMap(specsAcc).apply { put(specPath, resolveSpecType(specPath, config)) }
+            }
+        }
+    }
+
+    private fun toSpecificationDefinition(specPath: String, configs: List<SpecExecutionConfig>): SpecificationDefinition {
+        val urlPathPrefix = configs.asReversed().firstNotNullOfOrNull { config ->
+            val objectValue = config as? SpecExecutionConfig.ObjectValue.PartialUrl ?: return@firstNotNullOfOrNull null
+            if (specPath in objectValue.specs) objectValue.basePath else null
+        }
+
+        return SpecificationDefinition.ObjectValue(
+            SpecificationDefinition.Specification(id = specPath, path = specPath, urlPathPrefix = urlPathPrefix)
+        )
+    }
+
+    private fun resolveSpecType(specPath: String, config: SpecExecutionConfig): SpecType {
+        val explicitType = (config as? SpecExecutionConfig.ConfigValue)?.specType?.let { type ->
+            SpecType.entries.firstOrNull { it.value.equals(type, ignoreCase = true) }
+        }
+
+        return explicitType ?: determineSpecTypeFor(File(specPath)).first()
+    }
+
+    private fun Source.toSourceV3(gitAuth: GitAuthentication?): SourceV3 {
+        return when (provider) {
+            SourceProvider.git -> SourceV3(
+                git = SourceV3.Git(url = repository, branch = branch, matchBranch = matchBranch, auth = gitAuth),
+                fileSystem = null,
+                web = null
+            )
+
+            SourceProvider.filesystem -> SourceV3(
+                git = null,
+                fileSystem = SourceV3.FileSystem(directory = directory ?: "."),
+                web = null
+            )
+
+            SourceProvider.web -> SourceV3(
+                git = null,
+                fileSystem = null,
+                web = SourceV3.Web(url = webBaseUrl)
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SpecificationIdBuilder.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SpecificationIdBuilder.kt
@@ -1,0 +1,42 @@
+package io.specmatic.core.config.v3.upgrade
+
+import java.security.MessageDigest
+
+internal fun buildSpecificationIds(specPaths: Collection<String>): Map<String, String> {
+    val normalizedPaths = specPaths.map { it.normalizeSpecPath() }
+    return normalizedPaths.associate { path -> path.original to generateSpecificationId(path, normalizedPaths) }
+}
+
+private data class NormalizedSpecPath(val original: String, val segments: List<String>)
+private fun String.normalizeSpecPath(): NormalizedSpecPath {
+    val normalized = replace('\\', '/').trimEnd('/')
+    val segments = normalized.split('/').filter { it.isNotBlank() }
+    return NormalizedSpecPath(original = this, segments = segments)
+}
+
+private fun generateSpecificationId(path: NormalizedSpecPath, allPaths: List<NormalizedSpecPath>): String {
+    val maxDepth = path.segments.lastIndex
+    for (depth in 0..maxDepth) {
+        val candidate = candidateAtDepth(path.segments, depth)
+        if (allPaths.count { candidateAtDepth(it.segments, depth) == candidate } == 1) {
+            return candidate
+        }
+    }
+
+    return candidateAtDepth(path.segments, maxDepth) + "-" + shortHash(path.original)
+}
+
+private fun candidateAtDepth(segments: List<String>, depth: Int): String {
+    val startIndex = (segments.size - 1 - depth).coerceAtLeast(0)
+    return segments.drop(startIndex).joinToString("-") { sanitizeIdPart(it) }
+}
+
+private fun sanitizeIdPart(value: String): String {
+    val withoutExt = value.substringBeforeLast('.')
+    return withoutExt.replace(Regex("[^A-Za-z0-9]+"), "-").trim('-').ifEmpty { "spec" }
+}
+
+private fun shortHash(value: String): String {
+    val bytes = MessageDigest.getInstance("SHA-1").digest(value.toByteArray())
+    return bytes.take(4).joinToString("") { "%02x".format(it) }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapper.kt
@@ -16,21 +16,22 @@ import io.specmatic.core.config.v3.specmatic.Governance
 import io.specmatic.core.config.v3.specmatic.License
 import io.specmatic.core.config.v3.specmatic.Report
 import io.specmatic.core.config.v3.specmatic.SuccessCriterion
+import java.nio.file.Path
 
 class SpecmaticMetadataMapper {
     fun mapFrom(legacyConfig: SpecmaticConfigV1V2Common, view: LegacyConfigView): Specmatic {
         return Specmatic(
             governance = buildGovernance(legacyConfig, view),
             settings = RefOrValue.Value(buildSettings(legacyConfig, view)),
-            license = legacyConfig.getLicensePath()?.let { License(path = it.toString()) },
+            license = legacyConfig.getLicensePath()?.let { License(path = it.toUnixPath()) },
         )
     }
 
     private fun buildGovernance(legacyConfig: SpecmaticConfigV1V2Common, view: LegacyConfigView): Governance {
         val reportDir = SpecmaticConfigV1V2Common.getReportDirPathOrNull(legacyConfig)
         return Governance(
-            report = Report(outputDirectory = reportDir?.toString()),
-            successCriterion = view.report?.getSuccessCriteria()?.let(SuccessCriterion.Companion::from),
+            report = Report(outputDirectory = reportDir?.toUnixPath()),
+            successCriterion = view.report?.types?.apiCoverage?.openAPI?.successCriteria?.let(SuccessCriterion.Companion::from),
         )
     }
 
@@ -112,5 +113,9 @@ class SpecmaticMetadataMapper {
     private fun Switch.toBoolean() = when (this) {
         Switch.enabled -> true
         Switch.disabled -> false
+    }
+
+    private fun Path.toUnixPath(): String {
+        return toString().replace('\\', '/')
     }
 }

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapper.kt
@@ -1,0 +1,116 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.ResiliencyTestSuite
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.Switch
+import io.specmatic.core.config.OpenAPITestConfig as LegacyOpenAPITestConfig
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.ConcreteSettings
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.Specmatic
+import io.specmatic.core.config.v3.components.settings.FeatureFlags
+import io.specmatic.core.config.v3.components.settings.GeneralSettings
+import io.specmatic.core.config.v3.components.settings.MockSettings
+import io.specmatic.core.config.v3.components.settings.TestSettings
+import io.specmatic.core.config.v3.specmatic.Governance
+import io.specmatic.core.config.v3.specmatic.License
+import io.specmatic.core.config.v3.specmatic.Report
+import io.specmatic.core.config.v3.specmatic.SuccessCriterion
+
+class SpecmaticMetadataMapper {
+    fun mapFrom(legacyConfig: SpecmaticConfigV1V2Common, view: LegacyConfigView): Specmatic {
+        return Specmatic(
+            governance = buildGovernance(legacyConfig, view),
+            settings = RefOrValue.Value(buildSettings(legacyConfig, view)),
+            license = legacyConfig.getLicensePath()?.let { License(path = it.toString()) },
+        )
+    }
+
+    private fun buildGovernance(legacyConfig: SpecmaticConfigV1V2Common, view: LegacyConfigView): Governance {
+        val reportDir = SpecmaticConfigV1V2Common.getReportDirPathOrNull(legacyConfig)
+        return Governance(
+            report = Report(outputDirectory = reportDir?.toString()),
+            successCriterion = view.report?.getSuccessCriteria()?.let(SuccessCriterion.Companion::from),
+        )
+    }
+
+    private fun buildSettings(legacyConfig: SpecmaticConfigV1V2Common, view: LegacyConfigView): ConcreteSettings {
+        return ConcreteSettings(
+            test = buildTestSettings(view),
+            mock = buildMockSettings(view),
+            general = buildGeneralSettings(legacyConfig, view),
+            backwardCompatibility = legacyConfig.getBackwardCompatibilityConfig(),
+        )
+    }
+
+    private fun buildGeneralSettings(legacyConfig: SpecmaticConfigV1V2Common, view: LegacyConfigView): GeneralSettings {
+        return GeneralSettings(
+            featureFlags = featureFlagsFrom(legacyConfig),
+            specExamplesDirectoryTemplate = view.globalSettings.specExamplesDirectoryTemplate,
+            sharedExamplesDirectoryTemplate = view.globalSettings.sharedExamplesDirectoryTemplate,
+            prettyPrint = SpecmaticConfigV1V2Common.getPrettyPrintOrNull(legacyConfig),
+            logging = SpecmaticConfigV1V2Common.getLogConfigurationOrNull(legacyConfig),
+            disableTelemetry = SpecmaticConfigV1V2Common.isTelemetryDisabledOrNull(legacyConfig),
+            ignoreInlineExamples = SpecmaticConfigV1V2Common.getIgnoreInlineExamples(legacyConfig),
+            ignoreInlineExampleWarnings = SpecmaticConfigV1V2Common.getIgnoreInlineExampleWarningsOrNull(legacyConfig),
+        )
+    }
+
+    private fun featureFlagsFrom(legacyConfig: SpecmaticConfigV1V2Common): FeatureFlags {
+        return FeatureFlags(
+            escapeSoapAction = SpecmaticConfigV1V2Common.getEscapeSoapActionOrNull(legacyConfig),
+            schemaExampleDefault = SpecmaticConfigV1V2Common.getSchemaExampleDefaultOrNull(legacyConfig),
+            fuzzyMatcherForPayloads = SpecmaticConfigV1V2Common.getFuzzyMatchingEnabledOrNull(legacyConfig),
+        )
+    }
+
+    private fun buildTestSettings(view: LegacyConfigView): TestSettings {
+        val testConfigs = view.sources.flatMap { it.test.orEmpty() }
+        val schemaResiliencyTestsFromProvides = extractSchemaResiliencyTestsFromProvides(testConfigs) ?: extractSchemaResiliencyTestsFromConfigValue(testConfigs)
+
+        return TestSettings(
+            strictMode = view.testConfig?.strictMode,
+            lenientMode = view.testConfig?.lenientMode,
+            parallelism = view.testConfig?.parallelism,
+            maxTestCount = view.testConfig?.maxTestCount,
+            junitReportDir = view.testConfig?.junitReportDir,
+            timeoutInMilliseconds = view.testConfig?.timeoutInMilliseconds,
+            validateResponseValues = view.testConfig?.validateResponseValues,
+            maxTestRequestCombinations = view.testConfig?.maxTestRequestCombinations,
+            schemaResiliencyTests = view.testConfig?.resiliencyTests?.enable ?: schemaResiliencyTestsFromProvides,
+        )
+    }
+
+    private fun extractSchemaResiliencyTestsFromProvides(testConfigs: List<SpecExecutionConfig>): ResiliencyTestSuite? {
+        return testConfigs.asReversed().firstNotNullOfOrNull { config ->
+            (config as? SpecExecutionConfig.ObjectValue)?.resiliencyTests?.enable
+        }
+    }
+
+    private fun extractSchemaResiliencyTestsFromConfigValue(testConfigs: List<SpecExecutionConfig>): ResiliencyTestSuite? {
+        return testConfigs.asConfigValues().firstNotNullOfOrNull { configValue ->
+            runCatching { LegacyOpenAPITestConfig.from(configValue.config).resiliencyTests?.enable }.getOrNull()
+        }
+    }
+
+    private fun List<SpecExecutionConfig>.asConfigValues(): Sequence<SpecExecutionConfig.ConfigValue> {
+        return asSequence().mapNotNull { it as? SpecExecutionConfig.ConfigValue }
+    }
+
+    private fun buildMockSettings(view: LegacyConfigView): MockSettings {
+        return MockSettings(
+            generative = view.stubConfig?.getGenerative(),
+            strictMode = view.stubConfig?.getStrictMode(),
+            lenientMode = view.stubConfig?.getLenientMode(),
+            hotReload = view.stubConfig?.getHotReload()?.toBoolean(),
+            delayInMilliseconds = view.stubConfig?.getDelayInMilliseconds(),
+            startTimeoutInMilliseconds = view.stubConfig?.getStartTimeoutInMilliseconds(),
+            gracefulRestartTimeoutInMilliseconds = view.stubConfig?.getGracefulRestartTimeoutInMilliseconds(),
+        )
+    }
+
+    private fun Switch.toBoolean() = when (this) {
+        Switch.enabled -> true
+        Switch.disabled -> false
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapper.kt
@@ -31,14 +31,14 @@ class SystemUnderTestMapper {
     fun mapFrom(view: LegacyConfigView, source: SourceMigrationBuilder): TestServiceConfig? {
         val testDefinitions = source.buildTestMigrations(view.sources)
         val specTypesByPath = testDefinitions.mergeAllSpecTypesByPath()
+        val specIdsByPath = testDefinitions.specIdsByPath()
         if (testDefinitions.isEmpty()) return null
 
+        val runOptionsMapper = RunOptionsMapper(defaultHostForPortOnly = "localhost", specIdsByPath = specIdsByPath, specTypesByPath = specTypesByPath)
         val runOptionsOverrides = view.sources
             .flatMap { it.test.orEmpty() }
-            .fold(RunOptionsMapper(defaultHostForPortOnly = "localhost")) { acc, config ->
-                acc.mergeConfig(config, specTypesByPath)
-            }.mergeGlobalOpenApi(
-                specTypesByPath = specTypesByPath,
+            .fold(runOptionsMapper) { acc, config -> acc.mergeConfig(config) }
+            .mergeGlobalOpenApi(
                 overlayFilePath = view.testConfig?.overlayFilePath,
                 securitySchemes = view.security?.toSecuritySchemesV3(),
             )
@@ -64,6 +64,12 @@ class SystemUnderTestMapper {
     private fun List<SourceMigration.TestSourceMigration>.mergeAllSpecTypesByPath(): Map<String, SpecType> {
         return fold(mapOf()) { acc, migration ->
             acc.plus(migration.specTypesByPath)
+        }
+    }
+
+    private fun List<SourceMigration.TestSourceMigration>.specIdsByPath(): Map<String, String> {
+        return fold(mapOf()) { acc, migration ->
+            acc.plus(migration.specIdsByPath)
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapper.kt
+++ b/core/src/main/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapper.kt
@@ -1,0 +1,150 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.APIKeySecuritySchemeConfiguration
+import io.specmatic.core.BasicAuthSecuritySchemeConfiguration
+import io.specmatic.core.BearerSecuritySchemeConfiguration
+import io.specmatic.core.OAuth2SecuritySchemeConfiguration
+import io.specmatic.core.SecurityConfiguration
+import io.specmatic.core.SecuritySchemeConfiguration
+import io.specmatic.core.config.OpenAPITestConfig as LegacyOpenAPITestConfig
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.SecuritySchemeConfigurationV3
+import io.specmatic.core.config.v3.components.SecuritySchemeType
+import io.specmatic.core.config.v3.components.runOptions.AsyncApiTestConfig
+import io.specmatic.core.config.v3.components.runOptions.GraphQLSdlTestConfig
+import io.specmatic.core.config.v3.components.runOptions.OpenApiRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.OpenApiTestConfig
+import io.specmatic.core.config.v3.components.runOptions.ProtobufTestConfig
+import io.specmatic.core.config.v3.components.runOptions.RunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.runOptions.WsdlRunOptionsSpecifications
+import io.specmatic.core.config.v3.components.runOptions.WsdlTestConfig
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.Definition
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.core.config.v3.components.services.TestServiceConfig
+import io.specmatic.core.config.v3.components.settings.TestSettings
+import io.specmatic.reporter.model.SpecType
+
+class SystemUnderTestMapper {
+    fun mapFrom(view: LegacyConfigView, source: SourceMigrationBuilder): TestServiceConfig? {
+        val testDefinitions = source.buildTestMigrations(view.sources)
+        val specTypesByPath = testDefinitions.mergeAllSpecTypesByPath()
+        if (testDefinitions.isEmpty()) return null
+
+        val runOptionsOverrides = view.sources
+            .flatMap { it.test.orEmpty() }
+            .fold(RunOptionsMapper(defaultHostForPortOnly = "localhost")) { acc, config ->
+                acc.mergeConfig(config, specTypesByPath)
+            }.mergeGlobalOpenApi(
+                specTypesByPath = specTypesByPath,
+                overlayFilePath = view.testConfig?.overlayFilePath,
+                securitySchemes = view.security?.toSecuritySchemesV3(),
+            )
+
+        val openApiConfigExamples = extractExamplesFromTestConfigs(view)
+        val runOptions = buildRunOptions(view, testDefinitions, runOptionsOverrides).dropNoOpSpecificationOverrides()
+        val definitions = testDefinitions.map { migration ->
+            migration.definition.dropSpecificationIdsWithoutOverrides(runOptions::hasSpecOverride)
+        }
+
+        val service = CommonServiceConfig<TestRunOptions, TestSettings>(
+            definitions = definitions,
+            runOptions = RefOrValue.Value(runOptions),
+            data = DataSectionMapper().mapFrom(
+                exampleDirectories = view.globalExamples + openApiConfigExamples,
+                dictionaryPath = view.stubConfig?.getDictionary()
+            ),
+        )
+
+        return TestServiceConfig(service = RefOrValue.Value(service))
+    }
+
+    private fun List<SourceMigration.TestSourceMigration>.mergeAllSpecTypesByPath(): Map<String, SpecType> {
+        return fold(mapOf()) { acc, migration ->
+            acc.plus(migration.specTypesByPath)
+        }
+    }
+
+    private fun buildRunOptions(view: LegacyConfigView, migrations: List<SourceMigration.TestSourceMigration>, overrides: RunOptionsMapper): TestRunOptions {
+        return TestRunOptions(
+            wsdl = buildWsdlTestConfig(view, migrations, overrides),
+            openapi = buildOpenApiTestConfig(view, migrations, overrides),
+            asyncapi = AsyncApiTestConfig(specs = overrides.asyncApi.values.map(::RunOptionsSpecifications)),
+            protobuf = ProtobufTestConfig(specs = overrides.protobuf.values.map(::RunOptionsSpecifications)),
+            graphqlsdl = GraphQLSdlTestConfig(specs = overrides.graphQl.values.map(::RunOptionsSpecifications)),
+        )
+    }
+
+    private fun buildOpenApiTestConfig(view: LegacyConfigView, migrations: List<SourceMigration.TestSourceMigration>, overrides: RunOptionsMapper): OpenApiTestConfig {
+        if (migrations.none { it.hasSpecType(SpecType.OPENAPI) }) return OpenApiTestConfig()
+        return OpenApiTestConfig(
+            workflow = view.workflow,
+            filter = view.testConfig?.filter,
+            baseUrl = view.testConfig?.baseUrl,
+            swaggerUrl = view.testConfig?.swaggerUrl,
+            actuatorUrl = view.testConfig?.actuatorUrl,
+            swaggerUiBaseUrl = view.testConfig?.swaggerUIBaseURL,
+            cert = view.testConfig?.https?.let { RefOrValue.Value(it) },
+            specs = overrides.openApi.values.map(::OpenApiRunOptionsSpecifications),
+        )
+    }
+
+    private fun buildWsdlTestConfig(view: LegacyConfigView, migrations: List<SourceMigration.TestSourceMigration>, overrides: RunOptionsMapper): WsdlTestConfig {
+        if (migrations.none { it.hasSpecType(SpecType.WSDL) }) return WsdlTestConfig()
+        return WsdlTestConfig(
+            baseUrl = view.testConfig?.baseUrl,
+            cert = view.testConfig?.https?.let { RefOrValue.Value(it) },
+            specs = overrides.wsdl.values.map(::WsdlRunOptionsSpecifications)
+        )
+    }
+
+    private fun SecurityConfiguration.toSecuritySchemesV3(): Map<String, SecuritySchemeConfigurationV3>? {
+        return openAPI?.securitySchemes?.mapValues { (_, scheme) -> scheme.toSecuritySchemeV3() }
+    }
+
+    private fun SecuritySchemeConfiguration.toSecuritySchemeV3(): SecuritySchemeConfigurationV3 {
+        return when (this) {
+            is OAuth2SecuritySchemeConfiguration ->
+                SecuritySchemeConfigurationV3(SecuritySchemeType.OAUTH2, token)
+            is BasicAuthSecuritySchemeConfiguration ->
+                SecuritySchemeConfigurationV3(SecuritySchemeType.BASIC_AUTH, token)
+            is BearerSecuritySchemeConfiguration ->
+                SecuritySchemeConfigurationV3(SecuritySchemeType.BEARER, token)
+            is APIKeySecuritySchemeConfiguration ->
+                SecuritySchemeConfigurationV3(SecuritySchemeType.API_KEY, value)
+        }
+    }
+
+    private fun extractExamplesFromTestConfigs(view: LegacyConfigView): List<String> {
+        return view.sources
+            .flatMap { it.test.orEmpty() }
+            .asConfigValues()
+            .flatMap { extractExamplesFromTestConfig(it).asSequence() }
+            .distinct()
+            .toList()
+    }
+
+    private fun List<SpecExecutionConfig>.asConfigValues(): Sequence<SpecExecutionConfig.ConfigValue> {
+        return asSequence().mapNotNull { it as? SpecExecutionConfig.ConfigValue }
+    }
+
+    private fun extractExamplesFromTestConfig(configValue: SpecExecutionConfig.ConfigValue): List<String> {
+        return runCatching { LegacyOpenAPITestConfig.from(configValue.config).examples.orEmpty() }.getOrDefault(emptyList())
+    }
+}
+
+internal fun Definition.dropSpecificationIdsWithoutOverrides(hasSpecOverride: (String) -> Boolean): Definition {
+    return copy(
+        definition = definition.copy(
+            specs = definition.specs.map { specificationDefinition ->
+                val objectDefinition = specificationDefinition as? SpecificationDefinition.ObjectValue ?: return@map specificationDefinition
+                val specId = objectDefinition.spec.id ?: return@map specificationDefinition
+                if (hasSpecOverride(specId)) return@map specificationDefinition
+                if (objectDefinition.hasNoData()) return@map SpecificationDefinition.StringValue(objectDefinition.spec.path)
+                objectDefinition.copy(spec = objectDefinition.spec.copy(id = null))
+            }
+        )
+    )
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/SpecmaticConfigAllTest.kt
@@ -12,6 +12,7 @@ import io.specmatic.core.SourceProvider.web
 import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToLatestVersionedConfig
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.SpecmaticConfigVersion.Companion.convertToVersionedConfig
 import io.specmatic.core.config.v1.SpecmaticConfigV1
 import io.specmatic.core.config.v2.ContractConfig
 import io.specmatic.core.config.v2.ContractConfig.FileSystemContractSource
@@ -1064,7 +1065,7 @@ internal class SpecmaticConfigAllTest {
         val dslConfig = configV1.transform()
 
         val (output, configV2) = captureStandardOutput {
-            convertToLatestVersionedConfig(dslConfig) as SpecmaticConfigV2
+            convertToVersionedConfig(dslConfig, SpecmaticConfigVersion.VERSION_2) as SpecmaticConfigV2
         }
 
         assertThat(output).contains("WARNING")

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3UpgradeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3UpgradeTest.kt
@@ -138,13 +138,13 @@ class SpecmaticConfigV3UpgradeTest {
                                   directory: ./specs
                               specs:
                                 - spec:
-                                    id: resilient.yaml
+                                    id: resilient
                                     path: resilient.yaml
                         runOptions:
                           openapi:
                             specs:
                               - spec:
-                                  id: resilient.yaml
+                                  id: resilient
                                   baseUrl: http://resilient.example
                     """.trimIndent())
                 ),
@@ -179,13 +179,13 @@ class SpecmaticConfigV3UpgradeTest {
                                   directory: ./specs
                               specs:
                                 - spec:
-                                    id: resilient-config.yaml
+                                    id: resilient-config
                                     path: resilient-config.yaml
                         runOptions:
                           openapi:
                             specs:
                               - spec:
-                                  id: resilient-config.yaml
+                                  id: resilient-config
                                   baseUrl: http://resilient.example
                     """.trimIndent())
                 )
@@ -300,7 +300,7 @@ class SpecmaticConfigV3UpgradeTest {
                                   directory: ./src/test/resources/openapi
                               specs:
                                 - spec:
-                                    id: hello.yaml
+                                    id: hello
                                     path: hello.yaml
                         runOptions:
                           openapi:
@@ -315,7 +315,7 @@ class SpecmaticConfigV3UpgradeTest {
                               keyStorePassword: password
                             specs:
                               - spec:
-                                  id: hello.yaml
+                                  id: hello
                                   overlayFilePath: overlay-v2.yaml
                     """.trimIndent())
                 ),
@@ -588,7 +588,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: petstore.yaml
+                            id: petstore
                             baseUrl: http://full.example:8081
                     """.trimIndent()
                 ),
@@ -603,7 +603,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: orders.yaml
+                            id: orders
                             host: host-only.example
                     """.trimIndent()
                 ),
@@ -618,7 +618,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: payments.yaml
+                            id: payments
                             port: 9191
                     """.trimIndent()
                 ),
@@ -634,7 +634,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: users.yaml
+                            id: users
                             host: hp.example
                             port: 8181
                     """.trimIndent()
@@ -653,7 +653,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: basepath.yaml
+                            id: basepath
                             host: basepath.example
                             port: 8088
                     """.trimIndent()
@@ -669,7 +669,7 @@ class SpecmaticConfigV3UpgradeTest {
                     wsdl:
                       specs:
                         - spec:
-                            id: calculator.wsdl
+                            id: calculator
                             baseUrl: http://wsdl.example:7070
                     """.trimIndent()
                 ),
@@ -685,7 +685,7 @@ class SpecmaticConfigV3UpgradeTest {
                     wsdl:
                       specs:
                         - spec:
-                            id: inventory.wsdl
+                            id: inventory
                             host: wsdl-host.example
                             port: 7171
                     """.trimIndent()
@@ -703,7 +703,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: cfg-openapi.yaml
+                            id: cfg-openapi
                             baseUrl: http://cfg-openapi.example:9090
                     """.trimIndent()
                 ),
@@ -721,7 +721,7 @@ class SpecmaticConfigV3UpgradeTest {
                     wsdl:
                       specs:
                         - spec:
-                            id: cfg-wsdl.wsdl
+                            id: cfg-wsdl
                             host: cfg-wsdl.example
                             port: 5252
                     """.trimIndent()
@@ -742,7 +742,7 @@ class SpecmaticConfigV3UpgradeTest {
                     graphqlsdl:
                       specs:
                         - spec:
-                            id: graph.graphql
+                            id: graph
                             host: graph.example
                             port: 4040
                             timeout: 50
@@ -763,7 +763,7 @@ class SpecmaticConfigV3UpgradeTest {
                     graphqlsdl:
                       specs:
                         - spec:
-                            id: graph-baseurl.graphql
+                            id: graph-baseurl
                             host: graph-baseurl.example
                             port: 5050
                             timeout: 50
@@ -783,7 +783,7 @@ class SpecmaticConfigV3UpgradeTest {
                     graphqlsdl:
                       specs:
                         - spec:
-                            id: graph-port.graphql
+                            id: graph-port
                             host: localhost
                             port: 5051
                             timeout: 99
@@ -792,7 +792,7 @@ class SpecmaticConfigV3UpgradeTest {
                     graphqlsdl:
                       specs:
                         - spec:
-                            id: graph-port.graphql
+                            id: graph-port
                             host: 0.0.0.0
                             port: 5051
                             timeout: 99
@@ -816,7 +816,7 @@ class SpecmaticConfigV3UpgradeTest {
                     asyncapi:
                       specs:
                         - spec:
-                            id: event-spec.yaml
+                            id: event-spec
                             host: async.example
                             port: 6060
                             inMemoryBroker:
@@ -841,7 +841,7 @@ class SpecmaticConfigV3UpgradeTest {
                     protobuf:
                       specs:
                         - spec:
-                            id: payment.proto
+                            id: payment
                             host: proto.example
                             port: 6161
                             package: payment
@@ -861,7 +861,7 @@ class SpecmaticConfigV3UpgradeTest {
                       baseUrl: http://global.example
                       specs:
                         - spec:
-                            id: precedence.yaml
+                            id: precedence
                             baseUrl: http://object.example
                     """.trimIndent()
                 ),
@@ -880,7 +880,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: precedence-clear.yaml
+                            id: precedence-clear
                             baseUrl: http://final.example
                     """.trimIndent(),
                     sides = listOf(Side.SystemUnderTest)
@@ -898,7 +898,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: retained.yaml
+                            id: retained
                             host: retained.example
                             port: 9898
                     """.trimIndent(),
@@ -920,7 +920,7 @@ class SpecmaticConfigV3UpgradeTest {
                     openapi:
                       specs:
                         - spec:
-                            id: repeated.yaml
+                            id: repeated
                             host: final.example
                             port: 8181
                     """.trimIndent(),
@@ -975,6 +975,7 @@ class SpecmaticConfigV3UpgradeTest {
                 else -> "\nstub:\n${indent(beforeSettings, 2)}"
             }
 
+            val primarySpecPath = primarySpecPath(beforeSpecs)
             val primarySpecId = primarySpecId(beforeSpecs)
             val urlPathPrefix = specUrlPathPrefix(beforeSpecs)
             val plainSpecDefinition = shouldUsePlainSpecDefinition(beforeSpecs)
@@ -989,11 +990,11 @@ class SpecmaticConfigV3UpgradeTest {
                     appendLine("              directory: ./specs")
                     appendLine("          specs:")
                     if (plainSpecDefinition && urlPathPrefix == null) {
-                        appendLine("            - $primarySpecId")
+                        appendLine("            - $primarySpecPath")
                     } else {
                         appendLine("            - spec:")
                         appendLine("                id: $primarySpecId")
-                        appendLine("                path: $primarySpecId")
+                        appendLine("                path: $primarySpecPath")
                         appendLine("                urlPathPrefix: $urlPathPrefix")
                     }
                     appendLine("    runOptions:")
@@ -1009,11 +1010,11 @@ class SpecmaticConfigV3UpgradeTest {
                     appendLine("                  directory: ./specs")
                     appendLine("              specs:")
                     if (plainSpecDefinition && urlPathPrefix == null) {
-                        appendLine("                - $primarySpecId")
+                        appendLine("                - $primarySpecPath")
                     } else {
                         appendLine("                - spec:")
                         appendLine("                    id: $primarySpecId")
-                        appendLine("                    path: $primarySpecId")
+                        appendLine("                    path: $primarySpecPath")
                         appendLine("                    urlPathPrefix: $urlPathPrefix")
                     }
                     appendLine("        runOptions:")
@@ -1039,10 +1040,31 @@ class SpecmaticConfigV3UpgradeTest {
             )
         }
 
+        private fun primarySpecPath(providesBlock: String): String {
+            return Regex("""-\s+([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""")
+                .findAll(providesBlock)
+                .map { it.groupValues[1] }
+                .toList()
+                .ifEmpty {
+                    Regex("""id:\s*([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""")
+                        .findAll(providesBlock)
+                        .map { it.groupValues[1] }
+                        .toList()
+                }
+                .distinct()
+                .first()
+        }
+
         private fun primarySpecId(providesBlock: String): String {
-            val ids = Regex("""-\s+([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""").findAll(providesBlock).map { it.groupValues[1] }.toList()
+            val ids = Regex("""-\s+([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""")
+                .findAll(providesBlock)
+                .map { it.groupValues[1].substringBeforeLast('.') }
+                .toList()
             return ids.ifEmpty {
-                Regex("""id:\s*([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""").findAll(providesBlock).map { it.groupValues[1] }.toList()
+                Regex("""id:\s*([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""")
+                    .findAll(providesBlock)
+                    .map { it.groupValues[1].substringBeforeLast('.') }
+                    .toList()
             }.distinct().first()
         }
 
@@ -1169,13 +1191,13 @@ class SpecmaticConfigV3UpgradeTest {
                                   directory: ./specs
                               specs:
                                 - spec:
-                                    id: secure.yaml
+                                    id: secure
                                     path: secure.yaml
                         runOptions:
                           openapi:
                             specs:
                               - spec:
-                                  id: secure.yaml
+                                  id: secure
                                   securitySchemes:
                                     basicAuth:
                                       type: basicAuth
@@ -1350,13 +1372,13 @@ class SpecmaticConfigV3UpgradeTest {
                                       directory: ./specs
                                   specs:
                                     - spec:
-                                        id: dep.yaml
+                                        id: dep
                                         path: dep.yaml
                             runOptions:
                               openapi:
                                 specs:
                                   - spec:
-                                      id: dep.yaml
+                                      id: dep
                                       baseUrl: https//localhost:9090
                             data:
                               examples:
@@ -1380,13 +1402,13 @@ class SpecmaticConfigV3UpgradeTest {
                                   directory: ./specs
                               specs:
                                 - spec:
-                                    id: sut.yaml
+                                    id: sut
                                     path: sut.yaml
                         runOptions:
                           openapi:
                             specs:
                               - spec:
-                                  id: sut.yaml
+                                  id: sut
                                   baseUrl: https//localhost:8080
                     """.trimIndent()
                 ),

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3UpgradeTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/SpecmaticConfigV3UpgradeTest.kt
@@ -1,0 +1,1765 @@
+package io.specmatic.core.config.v3
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.flipkart.zjsonpatch.JsonDiff
+import io.specmatic.core.config.resolveTemplates
+import io.specmatic.core.config.v1.SpecmaticConfigV1
+import io.specmatic.core.config.v2.SpecmaticConfigV2
+import io.specmatic.core.pattern.ContractException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+import kotlin.io.readText
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+class SpecmaticConfigV3UpgradeTest {
+    private val mapper: ObjectMapper = ObjectMapper(YAMLFactory()).apply {
+        registerKotlinModule()
+        setDefaultPropertyInclusion(
+            JsonInclude.Value.construct(JsonInclude.Include.CUSTOM, JsonInclude.Include.CUSTOM)
+            .withValueFilter(EmptyCollectionFilter::class.java)
+        )
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fileUpgradeCases")
+    fun `should upgrade legacy file config to v3`(testCase: UpgradeTestCase) {
+        assertUpgrade(testCase)
+    }
+
+    @Nested
+    inner class TestSettings {
+        @TestFactory
+        fun `should upgrade test settings`() = dynamicCases(cases())
+
+        private fun cases(): List<UpgradeTestCase> {
+            val directCases = listOf(
+                UpgradeTestCase(
+                    name = "test settings from v1 upgrade to specmatic settings v3",
+                    before = InputSource.RawInput("""
+                    version: 1
+                    test:
+                      resiliencyTests:
+                        enable: positiveOnly
+                      validateResponseValues: false
+                      allowExtensibleSchema: true
+                      timeoutInMilliseconds: 4321
+                      strictMode: false
+                      lenientMode: true
+                      parallelism: 4
+                      maxTestRequestCombinations: 11
+                      maxTestCount: 19
+                      junitReportDir: reports/legacy-junit
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    specmatic:
+                      settings:
+                        test:
+                          schemaResiliencyTests: positiveOnly
+                          validateResponseValues: false
+                          timeoutInMilliseconds: 4321
+                          strictMode: false
+                          lenientMode: true
+                          parallelism: 4
+                          maxTestRequestCombinations: 11
+                          maxTestCount: 19
+                          junitReportDir: reports/legacy-junit
+                    """.trimIndent())
+                ),
+                UpgradeTestCase(
+                    name = "test settings from v2 upgrade to specmatic settings v3",
+                    before = InputSource.RawInput("""
+                    version: 2
+                    test:
+                      resiliencyTests:
+                        enable: all
+                      validateResponseValues: true
+                      timeoutInMilliseconds: 1234
+                      strictMode: true
+                      lenientMode: true
+                      parallelism: 8
+                      maxTestRequestCombinations: 17
+                      maxTestCount: 23
+                      junitReportDir: reports/junit
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    specmatic:
+                      settings:
+                        test:
+                          schemaResiliencyTests: all
+                          validateResponseValues: true
+                          timeoutInMilliseconds: 1234
+                          strictMode: true
+                          lenientMode: true
+                          parallelism: 8
+                          maxTestRequestCombinations: 17
+                          maxTestCount: 23
+                          junitReportDir: reports/junit
+                    """.trimIndent())
+                ),
+                UpgradeTestCase(
+                    name = "test settings from provides object resiliencyTests upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        provides:
+                          - specs:
+                              - resilient.yaml
+                            baseUrl: http://resilient.example
+                            resiliencyTests:
+                              enable: all
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    specmatic:
+                      settings:
+                        test:
+                          schemaResiliencyTests: all
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: resilient.yaml
+                                    path: resilient.yaml
+                        runOptions:
+                          openapi:
+                            specs:
+                              - spec:
+                                  id: resilient.yaml
+                                  baseUrl: http://resilient.example
+                    """.trimIndent())
+                ),
+                UpgradeTestCase(
+                    name = "test settings from provides config value openapi resiliencyTests upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        provides:
+                          - specs:
+                              - resilient-config.yaml
+                            specType: OPENAPI
+                            config:
+                              baseUrl: http://resilient.example
+                              resiliencyTests:
+                                enable: all
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    specmatic:
+                      settings:
+                        test:
+                          schemaResiliencyTests: all
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: resilient-config.yaml
+                                    path: resilient-config.yaml
+                        runOptions:
+                          openapi:
+                            specs:
+                              - spec:
+                                  id: resilient-config.yaml
+                                  baseUrl: http://resilient.example
+                    """.trimIndent())
+                )
+            )
+
+            val pairCases = listOf(
+                LegacyPairCase(
+                    name = "dropped test fields",
+                    beforeV1 = """
+                    version: 1
+                    test:
+                      allowExtensibleSchema: true
+                      testsDirectory: legacy-tests-v1
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    test:
+                      allowExtensibleSchema: true
+                      testsDirectory: legacy-tests
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    """.trimIndent()
+                ),
+            )
+
+            return directCases + pairCases.flatMap(::expandPairCase)
+
+        }
+    }
+
+    @Nested
+    inner class SystemUnderTest {
+        @TestFactory
+        fun `should upgrade system under test`() = dynamicCases(cases())
+
+        private fun cases(): List<UpgradeTestCase> {
+            return listOf(
+                UpgradeTestCase(
+                    name = "system under test fields from v1 upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./src/test/resources/openapi
+                        provides:
+                          - hello.yaml
+                    test:
+                      baseUrl: http://localhost:8081
+                      filter: PATH!='/health,/ready'
+                      swaggerUrl: http://localhost:8081/swagger.yaml
+                      swaggerUIBaseURL: http://localhost:8081/swagger-ui
+                      actuatorUrl: http://localhost:8081/actuator/mappings
+                      https:
+                        keyStore:
+                          file: ./client-cert-v1.jks
+                        keyStorePassword: password
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./src/test/resources/openapi
+                              specs:
+                                - hello.yaml
+                        runOptions:
+                          openapi:
+                            filter: PATH!='/health,/ready'
+                            baseUrl: http://localhost:8081
+                            swaggerUrl: http://localhost:8081/swagger.yaml
+                            swaggerUiBaseUrl: http://localhost:8081/swagger-ui
+                            actuatorUrl: http://localhost:8081/actuator/mappings
+                            cert:
+                              keyStore:
+                                file: ./client-cert-v1.jks
+                              keyStorePassword: password
+                    """.trimIndent())
+                ),
+                UpgradeTestCase(
+                    name = "system under test fields from v2 upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./src/test/resources/openapi
+                        provides:
+                          - hello.yaml
+                    test:
+                      baseUrl: http://localhost:8080
+                      filter: PATH!='/health'
+                      swaggerUrl: http://localhost:8080/swagger.yaml
+                      swaggerUIBaseURL: http://localhost:8080/swagger-ui
+                      actuatorUrl: http://localhost:8080/actuator/mappings
+                      overlayFilePath: overlay-v2.yaml
+                      https:
+                        keyStore:
+                          file: ./client-cert.jks
+                        keyStorePassword: password
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./src/test/resources/openapi
+                              specs:
+                                - spec:
+                                    id: hello.yaml
+                                    path: hello.yaml
+                        runOptions:
+                          openapi:
+                            filter: PATH!='/health'
+                            baseUrl: http://localhost:8080
+                            swaggerUrl: http://localhost:8080/swagger.yaml
+                            swaggerUiBaseUrl: http://localhost:8080/swagger-ui
+                            actuatorUrl: http://localhost:8080/actuator/mappings
+                            cert:
+                              keyStore:
+                                file: ./client-cert.jks
+                              keyStorePassword: password
+                            specs:
+                              - spec:
+                                  id: hello.yaml
+                                  overlayFilePath: overlay-v2.yaml
+                    """.trimIndent())
+                ),
+            )
+
+        }
+    }
+
+    @Nested
+    inner class StubSettings {
+        @TestFactory
+        fun `should upgrade stub settings`() = dynamicCases(cases())
+
+        private fun cases(): List<UpgradeTestCase> {
+            return listOf(
+                LegacyPairCase(
+                    name = "stub settings to specmatic settings",
+                    beforeV1 = """
+                    version: 1
+                    stub:
+                      generative: true
+                      delayInMilliseconds: 123
+                      startTimeoutInMilliseconds: 456
+                      hotReload: enabled
+                      strictMode: true
+                      gracefulRestartTimeoutInMilliseconds: 789
+                      lenientMode: true
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    stub:
+                      generative: true
+                      delayInMilliseconds: 123
+                      startTimeoutInMilliseconds: 456
+                      hotReload: enabled
+                      strictMode: true
+                      gracefulRestartTimeoutInMilliseconds: 789
+                      lenientMode: true
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    specmatic:
+                      settings:
+                        mock:
+                          generative: true
+                          delayInMilliseconds: 123
+                          startTimeoutInMilliseconds: 456
+                          hotReload: true
+                          strictMode: true
+                          gracefulRestartTimeoutInMilliseconds: 789
+                          lenientMode: true
+                    """.trimIndent()
+                )
+            ).flatMap(::expandPairCase)
+
+        }
+    }
+
+    @Nested
+    inner class Dependencies {
+        @TestFactory
+        fun `should upgrade dependencies`() = dynamicCases(cases())
+
+        private fun cases(): List<UpgradeTestCase> {
+            return listOf(
+                UpgradeTestCase(
+                    name = "dependency fields from v1 upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./src/test/resources/openapi
+                        consumes:
+                          - hello.yaml
+                    stub:
+                      filter: PATH!='/health'
+                      https:
+                        keyStore:
+                          file: ./client-cert-v1.jks
+                        keyStorePassword: password
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    dependencies:
+                      services:
+                        - service:
+                            definitions:
+                              - definition:
+                                  source:
+                                    filesystem:
+                                      directory: ./src/test/resources/openapi
+                                  specs:
+                                    - hello.yaml
+                            runOptions:
+                              openapi:
+                                filter: PATH!='/health'
+                                cert:
+                                  keyStore:
+                                    file: ./client-cert-v1.jks
+                                  keyStorePassword: password
+                    """.trimIndent())
+                ),
+                UpgradeTestCase(
+                    name = "dependency fields from v2 upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./src/test/resources/openapi
+                        consumes:
+                          - hello.yaml
+                    stub:
+                      filter: PATH!='/health'
+                      https:
+                        keyStore:
+                          file: ./client-cert.jks
+                        keyStorePassword: password
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    dependencies:
+                      services:
+                        - service:
+                            definitions:
+                              - definition:
+                                  source:
+                                    filesystem:
+                                      directory: ./src/test/resources/openapi
+                                  specs:
+                                    - hello.yaml
+                            runOptions:
+                              openapi:
+                                filter: PATH!='/health'
+                                cert:
+                                  keyStore:
+                                    file: ./client-cert.jks
+                                  keyStorePassword: password
+                    """.trimIndent())
+                ),
+            )
+        }
+    }
+
+    @Nested
+    inner class TopLevel {
+        @TestFactory
+        fun `should upgrade top level`() = dynamicCases(cases())
+
+        private fun cases(): List<UpgradeTestCase> {
+            val directCases = listOf(
+                UpgradeTestCase(
+                    name = "top level fields from v1 upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 1
+                    ignoreInlineExamples: true
+                    disableTelemetry: true
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    specmatic:
+                      settings:
+                        general:
+                          ignoreInlineExamples: true
+                          disableTelemetry: true
+                    """.trimIndent())
+                ),
+                UpgradeTestCase(
+                    name = "top level fields from v2 upgrade to v3",
+                    before = InputSource.RawInput("""
+                    version: 2
+                    prettyPrint: false
+                    fuzzy: true
+                    escapeSoapAction: true
+                    schemaExampleDefault: true
+                    disableTelemetry: true
+                    ignoreInlineExamples: true
+                    ignoreInlineExampleWarnings: true
+                    license_path: ./license-v2.txt
+                    report_dir_path: ./reports/v2
+                    """.trimIndent()),
+                    after = InputSource.RawInput("""
+                    version: 3
+                    specmatic:
+                      license:
+                        path: ./license-v2.txt
+                      governance:
+                        report:
+                          outputDirectory: ./reports/v2
+                      settings:
+                        general:
+                          featureFlags:
+                            escapeSoapAction: true
+                            schemaExampleDefault: true
+                            fuzzyMatcherForPayloads: true
+                          prettyPrint: false
+                          disableTelemetry: true
+                          ignoreInlineExamples: true
+                          ignoreInlineExampleWarnings: true
+                    """.trimIndent())
+                )
+            )
+
+            val pairCases = listOf(
+                LegacyPairCase(
+                    name = "dropped top level fields",
+                    beforeV1 = """
+                    version: 1
+                    additionalExampleParamsFilePath: ./params-v1.json
+                    attribute_selection_pattern:
+                      default_fields:
+                        - id
+                        - name
+                      query_param_key: selection
+                    all_patterns_mandatory: true
+                    default_pattern_values:
+                      foo: bar
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    extensibleQueryParams: true
+                    additionalExampleParamsFilePath: ./params-v2.json
+                    attribute_selection_pattern:
+                      default_fields:
+                        - id
+                        - name
+                      query_param_key: selection
+                    all_patterns_mandatory: true
+                    default_pattern_values:
+                      foo: bar
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    """.trimIndent()
+                ),
+            )
+
+            return directCases + pairCases.flatMap(::expandPairCase)
+
+        }
+    }
+
+    @Nested
+    inner class SpecExecutionConfig {
+        @TestFactory
+        fun `should upgrade spec execution config`() = dynamicCases(cases())
+
+        private fun cases(): List<UpgradeTestCase> {
+            return listOf(
+                SpecExecutionScenario(
+                    name = "string value openapi with global base url",
+                    beforeSpecs = "- sample.yaml",
+                    beforeSettings = "baseUrl: http://global.example",
+                    expectedSystemUnderTestRunOptions = """
+                    openapi:
+                      baseUrl: http://global.example
+                    """.trimIndent(),
+                    expectedDependenciesRunOptions = """
+                    openapi:
+                      baseUrl: http://global.example
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "object fullUrl openapi",
+                    beforeSpecs = """
+                    - specs:
+                        - petstore.yaml
+                      baseUrl: http://full.example:8081
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: petstore.yaml
+                            baseUrl: http://full.example:8081
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "object partial host only openapi",
+                    beforeSpecs = """
+                    - specs:
+                        - orders.yaml
+                      host: host-only.example
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: orders.yaml
+                            host: host-only.example
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "object partial port only openapi",
+                    beforeSpecs = """
+                    - specs:
+                        - payments.yaml
+                      port: 9191
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: payments.yaml
+                            port: 9191
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "object partial host and port openapi",
+                    beforeSpecs = """
+                    - specs:
+                        - users.yaml
+                      host: hp.example
+                      port: 8181
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: users.yaml
+                            host: hp.example
+                            port: 8181
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "object partial basePath maps to urlPathPrefix",
+                    versions = listOf(1),
+                    beforeSpecs = """
+                    - specs:
+                        - basepath.yaml
+                      host: basepath.example
+                      port: 8088
+                      basePath: /api/v1
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: basepath.yaml
+                            host: basepath.example
+                            port: 8088
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "object fullUrl wsdl",
+                    beforeSpecs = """
+                    - specs:
+                        - calculator.wsdl
+                      baseUrl: http://wsdl.example:7070
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    wsdl:
+                      specs:
+                        - spec:
+                            id: calculator.wsdl
+                            baseUrl: http://wsdl.example:7070
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "object partial host and port wsdl",
+                    beforeSpecs = """
+                    - specs:
+                        - inventory.wsdl
+                      host: wsdl-host.example
+                      port: 7171
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    wsdl:
+                      specs:
+                        - spec:
+                            id: inventory.wsdl
+                            host: wsdl-host.example
+                            port: 7171
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "config value openapi baseUrl",
+                    beforeSpecs = """
+                    - specs:
+                        - cfg-openapi.yaml
+                      specType: OPENAPI
+                      config:
+                        baseUrl: http://cfg-openapi.example:9090
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: cfg-openapi.yaml
+                            baseUrl: http://cfg-openapi.example:9090
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "config value wsdl host and port",
+                    beforeSpecs = """
+                    - specs:
+                        - cfg-wsdl.wsdl
+                      specType: WSDL
+                      config:
+                        host: cfg-wsdl.example
+                        port: 5252
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    wsdl:
+                      specs:
+                        - spec:
+                            id: cfg-wsdl.wsdl
+                            host: cfg-wsdl.example
+                            port: 5252
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "config value graphql preserves config strips host port",
+                    beforeSpecs = """
+                    - specs:
+                        - graph.graphql
+                      specType: GRAPHQL
+                      config:
+                        host: graph.example
+                        port: 4040
+                        timeout: 50
+                        authType: bearer
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    graphqlsdl:
+                      specs:
+                        - spec:
+                            id: graph.graphql
+                            host: graph.example
+                            port: 4040
+                            timeout: 50
+                            authType: bearer
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "config value graphql baseUrl maps to host and port",
+                    beforeSpecs = """
+                    - specs:
+                        - graph-baseurl.graphql
+                      specType: GRAPHQL
+                      config:
+                        baseUrl: http://graph-baseurl.example:5050/graphql
+                        timeout: 50
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    graphqlsdl:
+                      specs:
+                        - spec:
+                            id: graph-baseurl.graphql
+                            host: graph-baseurl.example
+                            port: 5050
+                            timeout: 50
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "config value graphql port only uses side default host",
+                    beforeSpecs = """
+                    - specs:
+                        - graph-port.graphql
+                      specType: GRAPHQL
+                      config:
+                        port: 5051
+                        timeout: 99
+                    """.trimIndent(),
+                    expectedSystemUnderTestRunOptions = """
+                    graphqlsdl:
+                      specs:
+                        - spec:
+                            id: graph-port.graphql
+                            host: localhost
+                            port: 5051
+                            timeout: 99
+                    """.trimIndent(),
+                    expectedDependenciesRunOptions = """
+                    graphqlsdl:
+                      specs:
+                        - spec:
+                            id: graph-port.graphql
+                            host: 0.0.0.0
+                            port: 5051
+                            timeout: 99
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "config value asyncapi preserves config strips host port",
+                    beforeSpecs = """
+                    - specs:
+                        - event-spec.yaml
+                      specType: ASYNCAPI
+                      config:
+                        host: async.example
+                        port: 6060
+                        inMemoryBroker:
+                          host: broker
+                          port: 7071
+                        mode: consumer
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    asyncapi:
+                      specs:
+                        - spec:
+                            id: event-spec.yaml
+                            host: async.example
+                            port: 6060
+                            inMemoryBroker:
+                              host: broker
+                              port: 7071
+                            mode: consumer
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "config value protobuf preserves config strips host port",
+                    beforeSpecs = """
+                    - specs:
+                        - payment.proto
+                      specType: PROTOBUF
+                      config:
+                        host: proto.example
+                        port: 6161
+                        package: payment
+                        timeoutMs: 1000
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    protobuf:
+                      specs:
+                        - spec:
+                            id: payment.proto
+                            host: proto.example
+                            port: 6161
+                            package: payment
+                            timeoutMs: 1000
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "url precedence global baseUrl overridden by object fullUrl",
+                    beforeSpecs = """
+                    - specs:
+                        - precedence.yaml
+                      baseUrl: http://object.example
+                    """.trimIndent(),
+                    beforeSettings = "baseUrl: http://global.example",
+                    expectedRunOptions = """
+                    openapi:
+                      baseUrl: http://global.example
+                      specs:
+                        - spec:
+                            id: precedence.yaml
+                            baseUrl: http://object.example
+                    """.trimIndent()
+                ),
+                SpecExecutionScenario(
+                    name = "url precedence baseUrl clears host port",
+                    beforeSpecs = """
+                    - specs:
+                        - precedence-clear.yaml
+                      host: host-before.example
+                      port: 9393
+                    - specs:
+                        - precedence-clear.yaml
+                      baseUrl: http://final.example
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: precedence-clear.yaml
+                            baseUrl: http://final.example
+                    """.trimIndent(),
+                    sides = listOf(Side.SystemUnderTest)
+                ),
+                SpecExecutionScenario(
+                    name = "url precedence host port retained when no baseUrl",
+                    beforeSpecs = """
+                    - specs:
+                        - retained.yaml
+                      host: retained.example
+                      port: 9898
+                    - retained.yaml
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: retained.yaml
+                            host: retained.example
+                            port: 9898
+                    """.trimIndent(),
+                    sides = listOf(Side.SystemUnderTest)
+                ),
+                SpecExecutionScenario(
+                    name = "repeated spec path uses last write",
+                    beforeSpecs = """
+                    - specs:
+                        - repeated.yaml
+                      host: first.example
+                      port: 8080
+                    - specs:
+                        - repeated.yaml
+                      host: final.example
+                      port: 8181
+                    """.trimIndent(),
+                    expectedRunOptions = """
+                    openapi:
+                      specs:
+                        - spec:
+                            id: repeated.yaml
+                            host: final.example
+                            port: 8181
+                    """.trimIndent(),
+                    sides = listOf(Side.SystemUnderTest)
+                )
+            ).flatMap(::expandSpecExecutionScenario)
+        }
+
+        private fun expandSpecExecutionScenario(scenario: SpecExecutionScenario): List<UpgradeTestCase> {
+            return scenario.versions.flatMap { version ->
+                scenario.sides.map { side ->
+                    specCase(
+                        side = side,
+                        version = version,
+                        name = "v$version ${side.label} ${scenario.name}",
+                        beforeSpecs = scenario.beforeSpecs,
+                        expectedRunOptions = scenario.expectedRunOptionsFor(side),
+                        beforeSettings = scenario.beforeSettings,
+                    )
+                }
+            }
+        }
+
+        private fun specCase(
+            name: String,
+            version: Int,
+            side: Side,
+            beforeSpecs: String,
+            expectedRunOptions: String,
+            beforeSettings: String? = null,
+        ): UpgradeTestCase {
+            val beforeSourceKey = if (version == 1) side.sourceKeyV1 else side.sourceKeyV2
+            val beforeContracts = buildString {
+                if (version == 1) {
+                    appendLine("contract_repositories:")
+                    appendLine("  - type: filesystem")
+                    appendLine("    directory: ./specs")
+                    appendLine("    $beforeSourceKey:")
+                    appendLine(indent(beforeSpecs, 6))
+                } else {
+                    appendLine("contracts:")
+                    appendLine("  - filesystem:")
+                    appendLine("      directory: ./specs")
+                    appendLine("    $beforeSourceKey:")
+                    appendLine(indent(beforeSpecs, 6))
+                }
+            }.trimEnd()
+
+            val beforeSettings = when {
+                beforeSettings == null -> ""
+                side == Side.SystemUnderTest -> "\ntest:\n${indent(beforeSettings, 2)}"
+                else -> "\nstub:\n${indent(beforeSettings, 2)}"
+            }
+
+            val primarySpecId = primarySpecId(beforeSpecs)
+            val urlPathPrefix = specUrlPathPrefix(beforeSpecs)
+            val plainSpecDefinition = shouldUsePlainSpecDefinition(beforeSpecs)
+            val afterRoot = buildString {
+                if (side == Side.SystemUnderTest) {
+                    appendLine("systemUnderTest:")
+                    appendLine("  service:")
+                    appendLine("    definitions:")
+                    appendLine("      - definition:")
+                    appendLine("          source:")
+                    appendLine("            filesystem:")
+                    appendLine("              directory: ./specs")
+                    appendLine("          specs:")
+                    if (plainSpecDefinition && urlPathPrefix == null) {
+                        appendLine("            - $primarySpecId")
+                    } else {
+                        appendLine("            - spec:")
+                        appendLine("                id: $primarySpecId")
+                        appendLine("                path: $primarySpecId")
+                        appendLine("                urlPathPrefix: $urlPathPrefix")
+                    }
+                    appendLine("    runOptions:")
+                    appendLine(indent(expectedRunOptions, 6))
+                } else {
+                    appendLine("dependencies:")
+                    appendLine("  services:")
+                    appendLine("    - service:")
+                    appendLine("        definitions:")
+                    appendLine("          - definition:")
+                    appendLine("              source:")
+                    appendLine("                filesystem:")
+                    appendLine("                  directory: ./specs")
+                    appendLine("              specs:")
+                    if (plainSpecDefinition && urlPathPrefix == null) {
+                        appendLine("                - $primarySpecId")
+                    } else {
+                        appendLine("                - spec:")
+                        appendLine("                    id: $primarySpecId")
+                        appendLine("                    path: $primarySpecId")
+                        appendLine("                    urlPathPrefix: $urlPathPrefix")
+                    }
+                    appendLine("        runOptions:")
+                    appendLine(indent(expectedRunOptions, 10))
+                }
+            }.trimEnd()
+
+            val before = listOfNotNull(
+                "version: $version",
+                beforeContracts,
+                beforeSettings.takeIf { it.isNotBlank() }
+            ).joinToString("\n")
+
+            val after = listOf(
+                "version: 3",
+                afterRoot
+            ).joinToString("\n")
+
+            return UpgradeTestCase(
+                name = name,
+                before = InputSource.RawInput(before),
+                after = InputSource.RawInput(after)
+            )
+        }
+
+        private fun primarySpecId(providesBlock: String): String {
+            val ids = Regex("""-\s+([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""").findAll(providesBlock).map { it.groupValues[1] }.toList()
+            return ids.ifEmpty {
+                Regex("""id:\s*([A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls))\b""").findAll(providesBlock).map { it.groupValues[1] }.toList()
+            }.distinct().first()
+        }
+
+        private fun indent(value: String, spaces: Int): String {
+            val prefix = " ".repeat(spaces)
+            return value.lines().joinToString("\n") { if (it.isBlank()) it else prefix + it }
+        }
+
+        private fun specUrlPathPrefix(beforeSpecs: String): String? {
+            return Regex("""basePath:\s*([^\n]+)""").find(beforeSpecs)?.groupValues?.get(1)?.trim()
+        }
+
+        private fun shouldUsePlainSpecDefinition(beforeSpecs: String): Boolean {
+            val hasScalarSpecEntry = Regex("""(?m)^\s*-\s+[A-Za-z0-9._/-]+\.(yaml|yml|wsdl|proto|graphql|graphqls)\s*$""")
+                .containsMatchIn(beforeSpecs)
+            val hasObjectStyleMarkers = listOf("specs:", "specType:", "config:", "host:", "port:", "baseUrl:", "basePath:", "id:")
+                .any(beforeSpecs::contains)
+            return hasScalarSpecEntry && !hasObjectStyleMarkers
+        }
+    }
+
+    @Nested
+    inner class CrossCuttingMapper {
+        @TestFactory
+        fun `should upgrade cross cutting mapper fields`() = dynamicCases(cases())
+
+        private fun cases(): List<UpgradeTestCase> {
+            val pairCases = listOf(
+                LegacyPairCase(
+                    name = "workflow maps to openapi test run options",
+                    beforeV1 = """
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./specs
+                        provides:
+                          - workflow.yaml
+                    workflow:
+                      ids:
+                        create:
+                          extract: $.id
+                        get:
+                          use: $.id
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        provides:
+                          - workflow.yaml
+                    workflow:
+                      ids:
+                        create:
+                          extract: $.id
+                        get:
+                          use: $.id
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - workflow.yaml
+                        runOptions:
+                          openapi:
+                            workflow:
+                              ids:
+                                create:
+                                  extract: $.id
+                                get:
+                                  use: $.id
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "security schemes map to openapi specs",
+                    beforeV1 = """
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./specs
+                        provides:
+                          - secure.yaml
+                    security:
+                      OpenAPI:
+                        securitySchemes:
+                          basicAuth:
+                            type: basicAuth
+                            token: basic-token
+                          bearerAuth:
+                            type: bearer
+                            token: bearer-token
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        provides:
+                          - secure.yaml
+                    security:
+                      OpenAPI:
+                        securitySchemes:
+                          basicAuth:
+                            type: basicAuth
+                            token: basic-token
+                          bearerAuth:
+                            type: bearer
+                            token: bearer-token
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: secure.yaml
+                                    path: secure.yaml
+                        runOptions:
+                          openapi:
+                            specs:
+                              - spec:
+                                  id: secure.yaml
+                                  securitySchemes:
+                                    basicAuth:
+                                      type: basicAuth
+                                      token: basic-token
+                                    bearerAuth:
+                                      type: bearer
+                                      token: bearer-token
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "hooks map to dependencies adapters",
+                    beforeV1 = """
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./specs
+                        consumes:
+                          - dep.yaml
+                    hooks:
+                      beforeRequest: ./scripts/before.sh
+                      afterResponse: ./scripts/after.sh
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        consumes:
+                          - dep.yaml
+                    hooks:
+                      beforeRequest: ./scripts/before.sh
+                      afterResponse: ./scripts/after.sh
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    dependencies:
+                      data:
+                        adapters:
+                          beforeRequest: ./scripts/before.sh
+                          afterResponse: ./scripts/after.sh
+                      services:
+                        - service:
+                            definitions:
+                              - definition:
+                                  source:
+                                    filesystem:
+                                      directory: ./specs
+                                  specs:
+                                    - dep.yaml
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "examples map to both test and dependencies data examples",
+                    beforeV1 = """
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./specs
+                        provides:
+                          - sut.yaml
+                        consumes:
+                          - dep.yaml
+                    examples:
+                      - ./examples/global
+                      - ./examples/shared
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        provides:
+                          - sut.yaml
+                        consumes:
+                          - dep.yaml
+                    examples:
+                      - ./examples/global
+                      - ./examples/shared
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    dependencies:
+                      services:
+                        - service:
+                            definitions:
+                            - definition:
+                                source:
+                                  filesystem:
+                                    directory: ./specs
+                                specs:
+                                - dep.yaml
+                      data:
+                        examples:
+                        - directories:
+                          - ./examples/global
+                          - ./examples/shared
+                    systemUnderTest:
+                      service:
+                        data:
+                          examples:
+                            - directories:
+                                - ./examples/global
+                                - ./examples/shared
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - sut.yaml
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "openapi config value examples merge into respective service data examples",
+                    beforeV1 = """
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./specs
+                        provides:
+                          - specs:
+                              - sut.yaml
+                            specType: OPENAPI
+                            config:
+                              baseUrl: https//localhost:8080
+                              examples:
+                                - ./examples/sut
+                        consumes:
+                          - specs:
+                              - dep.yaml
+                            specType: OPENAPI
+                            config:
+                              baseUrl: https//localhost:9090
+                              examples:
+                                - ./examples/dep
+                    examples:
+                      - ./examples/global
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        provides:
+                          - specs:
+                              - sut.yaml
+                            specType: OPENAPI
+                            config:
+                              baseUrl: https//localhost:8080
+                              examples:
+                                - ./examples/sut
+                        consumes:
+                          - specs:
+                              - dep.yaml
+                            specType: OPENAPI
+                            config:
+                              baseUrl: https//localhost:9090
+                              examples:
+                                - ./examples/dep
+                    examples:
+                      - ./examples/global
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    dependencies:
+                      services:
+                        - service:
+                            definitions:
+                              - definition:
+                                  source:
+                                    filesystem:
+                                      directory: ./specs
+                                  specs:
+                                    - spec:
+                                        id: dep.yaml
+                                        path: dep.yaml
+                            runOptions:
+                              openapi:
+                                specs:
+                                  - spec:
+                                      id: dep.yaml
+                                      baseUrl: https//localhost:9090
+                            data:
+                              examples:
+                                - directories:
+                                    - ./examples/dep
+                      data:
+                        examples:
+                          - directories:
+                              - ./examples/global
+                    systemUnderTest:
+                      service:
+                        data:
+                          examples:
+                            - directories:
+                                - ./examples/global
+                                - ./examples/sut
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - spec:
+                                    id: sut.yaml
+                                    path: sut.yaml
+                        runOptions:
+                          openapi:
+                            specs:
+                              - spec:
+                                  id: sut.yaml
+                                  baseUrl: https//localhost:8080
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "dictionary maps to both test and dependency data",
+                    beforeV1 = """
+                    version: 1
+                    contract_repositories:
+                      - type: filesystem
+                        directory: ./specs
+                        provides:
+                          - sut.yaml
+                        consumes:
+                          - dep.yaml
+                    stub:
+                      dictionary: ./dict/values.json
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    contracts:
+                      - filesystem:
+                          directory: ./specs
+                        provides:
+                          - sut.yaml
+                        consumes:
+                          - dep.yaml
+                    stub:
+                      dictionary: ./dict/values.json
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        data:
+                          dictionary:
+                            path: ./dict/values.json
+                        definitions:
+                          - definition:
+                              source:
+                                filesystem:
+                                  directory: ./specs
+                              specs:
+                                - sut.yaml
+                    dependencies:
+                      data:
+                        dictionary:
+                          path: ./dict/values.json
+                      services:
+                        - service:
+                            definitions:
+                              - definition:
+                                  source:
+                                    filesystem:
+                                      directory: ./specs
+                                  specs:
+                                    - dep.yaml
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "auth personal access token maps to git auth",
+                    beforeV1 = """
+                    version: 1
+                    auth:
+                      personal-access-token: token123
+                    contract_repositories:
+                      - type: git
+                        repository: https://git.example/repo-a.git
+                        branch: main
+                        provides:
+                          - git-a.yaml
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    auth:
+                      personal-access-token: token123
+                    contracts:
+                      - git:
+                          url: https://git.example/repo-a.git
+                          branch: main
+                        provides:
+                          - git-a.yaml
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                git:
+                                  url: https://git.example/repo-a.git
+                                  branch: main
+                                  auth:
+                                    personalAccessToken: token123
+                              specs:
+                                - git-a.yaml
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "auth bearer env maps to git auth",
+                    beforeV1 = """
+                    version: 1
+                    auth:
+                      bearer-environment-variable: TOKEN_ENV
+                    contract_repositories:
+                      - type: git
+                        repository: https://git.example/repo-b.git
+                        branch: main
+                        provides:
+                          - git-b.yaml
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    auth:
+                      bearer-environment-variable: TOKEN_ENV
+                    contracts:
+                      - git:
+                          url: https://git.example/repo-b.git
+                          branch: main
+                        provides:
+                          - git-b.yaml
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                git:
+                                  url: https://git.example/repo-b.git
+                                  branch: main
+                                  auth:
+                                    bearerEnvironmentVariable: TOKEN_ENV
+                              specs:
+                                - git-b.yaml
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "auth bearer file maps to git auth",
+                    beforeV1 = """
+                    version: 1
+                    auth:
+                      bearer-file: ./bearer.txt
+                    contract_repositories:
+                      - type: git
+                        repository: https://git.example/repo-c.git
+                        branch: main
+                        provides:
+                          - git-c.yaml
+                    """.trimIndent(),
+                    beforeV2 = """
+                    version: 2
+                    auth:
+                      bearer-file: ./bearer.txt
+                    contracts:
+                      - git:
+                          url: https://git.example/repo-c.git
+                          branch: main
+                        provides:
+                          - git-c.yaml
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    systemUnderTest:
+                      service:
+                        definitions:
+                          - definition:
+                              source:
+                                git:
+                                  url: https://git.example/repo-c.git
+                                  branch: main
+                                  auth:
+                                    bearerFile: ./bearer.txt
+                              specs:
+                                - git-c.yaml
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "proxy maps to proxies",
+                    beforeV2 = """
+                    version: 2
+                    proxy:
+                      consumes:
+                        - users.yaml
+                      baseUrl: http://localhost:9001
+                      targetUrl: http://localhost:9000
+                      outputDirectory: ./recordings
+                      timeoutInMilliseconds: 7000
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    proxies:
+                      - proxy:
+                          mock:
+                            - users.yaml
+                          baseUrl: http://localhost:9001
+                          target: http://localhost:9000
+                          recordingsDirectory: ./recordings
+                          timeoutInMilliseconds: 7000
+                    """.trimIndent()
+                ),
+                LegacyPairCase(
+                    name = "report success criteria report dir and license",
+                    beforeV2 = """
+                    version: 2
+                    license_path: ./license.txt
+                    report_dir_path: ./reports
+                    report:
+                      formatters:
+                        - type: text
+                          layout: table
+                          output: stdout
+                      types:
+                        APICoverage:
+                          OpenAPI:
+                            successCriteria:
+                              minThresholdPercentage: 95
+                    """.trimIndent(),
+                    afterV3 = """
+                    version: 3
+                    specmatic:
+                      license:
+                        path: ./license.txt
+                      governance:
+                        report:
+                          outputDirectory: ./reports
+                        successCriteria:
+                          minCoveragePercentage: 95
+                    """.trimIndent()
+                )
+            )
+            return pairCases.flatMap(::expandPairCase)
+
+        }
+    }
+
+    private fun dynamicCases(cases: List<UpgradeTestCase>): List<DynamicTest> {
+        return cases.map { testCase ->
+            DynamicTest.dynamicTest(testCase.name) {
+                assertUpgrade(testCase)
+            }
+        }
+    }
+
+    private fun assertUpgrade(testCase: UpgradeTestCase) {
+        val upgraded = mapper.valueToTree<JsonNode>(upgrade(testCase.before))
+        val expected = mapper.valueToTree<JsonNode>(loadExpected(testCase.after))
+        val diff = JsonDiff.asJson(expected, upgraded)
+        assertThat(diff)
+        .withFailMessage { "Upgraded config mismatch for '${testCase.name}':\n${mapper.writerWithDefaultPrettyPrinter().writeValueAsString(diff)}" }
+        .isEmpty()
+    }
+
+    private fun upgrade(input: InputSource): SpecmaticConfigV3 {
+        val legacyConfig = loadLegacyConfig(input)
+        return SpecmaticConfigV3.loadFrom(legacyConfig)
+    }
+
+    private fun loadExpected(input: InputSource): SpecmaticConfigV3 {
+        val tree = resolveTemplates(mapper.readTree(input.read()))
+        return mapper.treeToValue(tree, SpecmaticConfigV3::class.java)
+    }
+
+    private fun loadLegacyConfig(input: InputSource): io.specmatic.core.SpecmaticConfig {
+        val tree = resolveTemplates(mapper.readTree(input.read()))
+        return when (tree["version"].asInt()) {
+            1 -> {
+                mapper.treeToValue(tree, SpecmaticConfigV1::class.java).transform(null)
+            }
+            2 -> {
+                mapper.treeToValue(tree, SpecmaticConfigV2::class.java).transform(null)
+            }
+            3 -> {
+                mapper.treeToValue(tree, SpecmaticConfigV3::class.java).transform(null)
+            }
+            else -> {
+                throw ContractException("Unsupported Specmatic config version")
+            }
+        }
+    }
+
+    companion object {
+        @Suppress("unused")
+        private enum class Side(val label: String, val sourceKeyV1: String, val sourceKeyV2: String) {
+            SystemUnderTest("systemUnderTest", "provides", "provides"),
+            Dependencies("dependencies", "consumes", "consumes");
+        }
+
+        private data class SpecExecutionScenario(
+            val name: String,
+            val beforeSpecs: String,
+            val expectedRunOptions: String? = null,
+            val expectedSystemUnderTestRunOptions: String? = expectedRunOptions,
+            val expectedDependenciesRunOptions: String? = expectedRunOptions,
+            val beforeSettings: String? = null,
+            val versions: List<Int> = listOf(1, 2),
+            val sides: List<Side> = listOf(Side.SystemUnderTest, Side.Dependencies),
+        ) {
+            fun expectedRunOptionsFor(side: Side): String {
+                return when (side) {
+                    Side.SystemUnderTest -> expectedSystemUnderTestRunOptions
+                    Side.Dependencies -> expectedDependenciesRunOptions
+                } ?: error("Missing expected runOptions for ${side.label} in scenario '$name'")
+            }
+        }
+
+        data class LegacyPairCase(val name: String, val beforeV1: String? = null, val beforeV2: String? = null, val afterV3: String)
+        data class UpgradeTestCase(val name: String, val before: InputSource, val after: InputSource) {
+            override fun toString(): String = name
+        }
+
+        sealed interface InputSource {
+            fun read(): String
+
+            data class FileInput(val file: File) : InputSource {
+                constructor(path: String) : this(File(path))
+                override fun read(): String = file.readText()
+            }
+
+            data class RawInput(val value: String) : InputSource {
+                override fun read(): String = value
+            }
+        }
+
+        @JvmStatic
+        fun fileUpgradeCases(): List<UpgradeTestCase> {
+            return listOf(
+                UpgradeTestCase(
+                    name = "openapi test with asyncapi and openapi mock with governance",
+                    before = InputSource.FileInput("src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/before.yaml"),
+                    after = InputSource.FileInput("src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/after.yaml")
+                )
+            )
+        }
+
+        private fun expandPairCase(pairCase: LegacyPairCase): List<UpgradeTestCase> {
+            val after = InputSource.RawInput(pairCase.afterV3)
+            return buildList {
+                pairCase.beforeV1?.let { add(UpgradeTestCase(name = "v1 ${pairCase.name}", before = InputSource.RawInput(it), after = after)) }
+                pairCase.beforeV2?.let { add(UpgradeTestCase(name = "v2 ${pairCase.name}", before = InputSource.RawInput(it), after = after)) }
+            }
+        }
+    }
+}
+
+private class EmptyCollectionFilter {
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return true
+        if (other.javaClass == this.javaClass)
+            return true
+
+        return when (other) {
+            is Map<*, *> -> other.all { it.key is String && equals(it.value) }
+            is Collection<*> -> other.all { equals(it) }
+            is Array<*> -> other.all { equals(it) }
+            is String -> other.isBlank()
+            else -> isEmptyDataClass(other)
+        }
+    }
+
+    private fun isEmptyDataClass(obj: Any): Boolean {
+        val kClass: KClass<*> = obj::class
+        if (!kClass.isData) return false
+
+        return kClass.memberProperties.all { prop ->
+            prop.isAccessible = true
+            val value = prop.call(obj)
+            equals(value)
+        }
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/DataSectionMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/DataSectionMapperTest.kt
@@ -1,0 +1,30 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.config.v3.RefOrValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DataSectionMapperTest {
+    @Test
+    fun `maps examples dictionary and hooks`() {
+        val data = DataSectionMapper().mapFrom(
+            dictionaryPath = "dict.json",
+            exampleDirectories = listOf("examples/common", "examples/payments"),
+            hooks = mapOf("response-header" to "scripts/hook.js"),
+        )
+
+        val examples = (data.examples as RefOrValue.Value).value
+        val directories = ((examples.single()) as RefOrValue.Value).value.directories
+        assertThat(directories).containsExactly("examples/common", "examples/payments")
+        assertThat((data.dictionary as RefOrValue.Value).value.path).isEqualTo("dict.json")
+        assertThat((data.adapters as RefOrValue.Value).value.hooks).containsEntry("response-header", "scripts/hook.js")
+    }
+
+    @Test
+    fun `keeps data fields null when input empty`() {
+        val data = DataSectionMapper().mapFrom(exampleDirectories = emptyList(), dictionaryPath = null, hooks = emptyMap())
+        assertThat(data.examples).isNull()
+        assertThat(data.dictionary).isNull()
+        assertThat(data.adapters).isNull()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapperTest.kt
@@ -1,0 +1,66 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.Source
+import io.specmatic.core.SourceProvider
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.StubConfiguration
+import io.specmatic.core.config.Switch
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.runOptions.MockRunOptions
+import io.specmatic.core.config.v3.components.settings.MockSettings
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DependenciesMapperTest {
+    @Test
+    fun `returns null when no stub specs are found`() {
+        val view = LegacyConfigView.from(SpecmaticConfigV1V2Common())
+        val result = DependenciesMapper().mapFrom(view, SourceMigrationBuilder(null))
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `maps mock service settings data and openapi overrides`() {
+        val source = Source(
+            provider = SourceProvider.filesystem,
+            directory = "./specs",
+            stub = listOf(
+                SpecExecutionConfig.ConfigValue(
+                    specs = listOf("orders.yaml"),
+                    specType = "OPENAPI",
+                    config = mapOf("baseUrl" to "http://localhost:9000", "examples" to listOf("examples/orders"))
+                )
+            )
+        )
+
+        val view = LegacyConfigView.from(
+            SpecmaticConfigV1V2Common(
+                sources = listOf(source),
+                hooks = mapOf("request-body" to "hooks/req.js"),
+                stub = StubConfiguration(
+                    hotReload = Switch.enabled,
+                    dictionary = "dict.json",
+                    filter = "PATH='/orders'",
+                    baseUrl = "http://global-mock:8080",
+                ),
+            )
+        )
+
+        val result = DependenciesMapper().mapFrom(view, SourceMigrationBuilder(null))!!
+        assertThat(result.services).hasSize(1)
+
+        val dictionary = ((result.data?.dictionary) as RefOrValue.Value).value
+        assertThat(dictionary.path).isEqualTo("dict.json")
+
+        val settings = (result.settings as RefOrValue.Value<MockSettings>).value
+        assertThat(settings.hotReload).isTrue()
+
+        val service = ((result.services.single().service) as RefOrValue.Value<CommonServiceConfig<MockRunOptions, MockSettings>>).value
+        val runOptions = (service.runOptions as RefOrValue.Value<MockRunOptions>).value
+        assertThat(runOptions.openapi?.filter).isEqualTo("PATH='/orders'")
+        assertThat(runOptions.openapi?.baseUrl).isEqualTo("http://global-mock:8080")
+        assertThat(runOptions.openapi?.specs?.map { it.spec.id }).containsExactly("orders.yaml")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/DependenciesMapperTest.kt
@@ -61,6 +61,6 @@ class DependenciesMapperTest {
         val runOptions = (service.runOptions as RefOrValue.Value<MockRunOptions>).value
         assertThat(runOptions.openapi?.filter).isEqualTo("PATH='/orders'")
         assertThat(runOptions.openapi?.baseUrl).isEqualTo("http://global-mock:8080")
-        assertThat(runOptions.openapi?.specs?.map { it.spec.id }).containsExactly("orders.yaml")
+        assertThat(runOptions.openapi?.specs?.map { it.spec.id }).containsExactly("orders")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/LegacyConfigViewTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/LegacyConfigViewTest.kt
@@ -1,0 +1,41 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.Auth
+import io.specmatic.core.Source
+import io.specmatic.core.SourceProvider
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.v3.components.sources.GitAuthentication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LegacyConfigViewTest {
+    @Test
+    fun `maps legacy config fields and prefers personal access token`() {
+        val legacy = SpecmaticConfigV1V2Common(
+            sources = listOf(Source(provider = SourceProvider.filesystem, directory = "./specs")),
+            auth = Auth(bearerFile = "bearer.txt", bearerEnvironmentVariable = "TOKEN_ENV", personalAccessToken = "pat-123"),
+            hooks = mapOf("request-body" to "hooks/req.js"),
+            examples = listOf("examples"),
+        )
+
+        val view = LegacyConfigView.from(legacy)
+        assertThat(view.sources).hasSize(1)
+        assertThat(view.globalHooks).containsEntry("request-body", "hooks/req.js")
+        assertThat(view.globalExamples).containsExactly("examples")
+        assertThat(view.gitAuth).isEqualTo(GitAuthentication.PersonalAccessToken("pat-123"))
+    }
+
+    @Test
+    fun `uses bearer env when pat absent`() {
+        val legacy = SpecmaticConfigV1V2Common(auth = Auth(bearerFile = "bearer.txt", bearerEnvironmentVariable = "TOKEN_ENV"))
+        val view = LegacyConfigView.from(legacy)
+        assertThat(view.gitAuth).isEqualTo(GitAuthentication.BearerEnv("TOKEN_ENV"))
+    }
+
+    @Test
+    fun `fallback to bearer file auth when no token is found, but auth field is present`() {
+        val legacy = SpecmaticConfigV1V2Common(auth = Auth())
+        val view = LegacyConfigView.from(legacy)
+        assertThat(view.gitAuth).isEqualTo(GitAuthentication.BearerFile("bearer.txt"))
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3UpgraderTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3UpgraderTest.kt
@@ -47,4 +47,37 @@ class LegacySpecmaticConfigToV3UpgraderTest {
         val upgraded = LegacySpecmaticConfigToV3Upgrader().upgrade(SpecmaticConfigV1V2Common())
         assertThat(upgraded.proxies).isNull()
     }
+
+    @Test
+    fun `upgrade routes stub hook to stub data and proxy hook to proxy adapters`() {
+        val config = SpecmaticConfigV1V2Common(
+            sources = listOf(
+                Source(
+                    provider = SourceProvider.filesystem,
+                    stub = listOf(SpecExecutionConfig.StringValue("spec.yaml"))
+                )
+            ),
+            proxy = ProxyConfig(baseUrl = "http://localhost:9090", targetUrl = "http://upstream:8080"),
+            hooks = mapOf(
+                "pre_specmatic_request_processor" to "cat request.txt",
+                "pre_specmatic_response_processor" to "cat proxy-response.txt",
+                "post_specmatic_response_processor" to "cat stub-response.txt",
+                "custom_hook" to "cat custom.txt",
+            )
+        )
+
+        val upgraded = LegacySpecmaticConfigToV3Upgrader().upgrade(config)
+        val dependenciesHooks = upgraded.dependencies?.data?.adapters?.getUnsafe()?.hooks.orEmpty()
+        val proxyHooks = upgraded.proxies?.single()?.proxy?.adapters?.getUnsafe()?.hooks.orEmpty()
+
+        assertThat(dependenciesHooks["pre_specmatic_request_processor"]).isEqualTo("cat request.txt")
+        assertThat(dependenciesHooks["post_specmatic_response_processor"]).isEqualTo("cat stub-response.txt")
+        assertThat(dependenciesHooks["custom_hook"]).isEqualTo("cat custom.txt")
+        assertThat(dependenciesHooks["pre_specmatic_response_processor"]).isNull()
+
+        assertThat(proxyHooks["pre_specmatic_request_processor"]).isEqualTo("cat request.txt")
+        assertThat(proxyHooks["pre_specmatic_response_processor"]).isEqualTo("cat proxy-response.txt")
+        assertThat(proxyHooks["custom_hook"]).isEqualTo("cat custom.txt")
+        assertThat(proxyHooks["post_specmatic_response_processor"]).isNull()
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3UpgraderTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/LegacySpecmaticConfigToV3UpgraderTest.kt
@@ -1,0 +1,50 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.ProxyConfig
+import io.specmatic.core.Source
+import io.specmatic.core.SourceProvider
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.config.SpecmaticConfigVersion
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LegacySpecmaticConfigToV3UpgraderTest {
+    @Test
+    fun `upgrade maps proxy to listOf and sets version to 3`() {
+        val config = SpecmaticConfigV1V2Common(
+            sources = listOf(
+                Source(
+                    provider = SourceProvider.filesystem,
+                    test = listOf(SpecExecutionConfig.StringValue("spec.yaml"))
+                )
+            ),
+            proxy = ProxyConfig(
+                consumes = listOf("mock-service"),
+                baseUrl = "http://localhost:9090",
+                targetUrl = "http://upstream:8080",
+                outputDirectory = "recordings",
+            )
+        )
+
+        val upgraded = LegacySpecmaticConfigToV3Upgrader().upgrade(config)
+        assertThat(upgraded.version).isEqualTo(SpecmaticConfigVersion.VERSION_3)
+        assertThat(upgraded.proxies).hasSize(1)
+
+        val proxy = upgraded.proxies!!.single().proxy
+        assertThat(proxy.mock).containsExactly("mock-service")
+        assertThat(proxy.baseUrl).isEqualTo("http://localhost:9090")
+        assertThat(proxy.target).isEqualTo("http://upstream:8080")
+        assertThat(proxy.recordingsDirectory).isEqualTo("recordings")
+        assertThat(proxy.cert).isNull()
+        assertThat(proxy.adapters).isNull()
+        assertThat(upgraded.systemUnderTest).isNotNull
+        assertThat(upgraded.specmatic).isNotNull
+    }
+
+    @Test
+    fun `upgrade leaves proxies null when proxy is absent`() {
+        val upgraded = LegacySpecmaticConfigToV3Upgrader().upgrade(SpecmaticConfigV1V2Common())
+        assertThat(upgraded.proxies).isNull()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapperTest.kt
@@ -11,20 +11,21 @@ class RunOptionsMapperTest {
     @Test
     fun `openapi baseUrl overrides host port and keeps global overlay security`() {
         val specTypes = linkedMapOf("petstore.yaml" to SpecType.OPENAPI)
-        val mapper = RunOptionsMapper(defaultHostForPortOnly = "localhost")
-            .mergeConfig(
-                specTypesByPath = specTypes,
-                config = SpecExecutionConfig.ConfigValue(
-                    specs = listOf("petstore.yaml"),
-                    specType = "OPENAPI",
-                    config = mapOf("baseUrl" to "http://example.com:9001")
-                ),
-            )
-            .mergeGlobalOpenApi(
-                overlayFilePath = "overlay.yaml",
-                securitySchemes = mapOf("oauth" to SecuritySchemeConfigurationV3(SecuritySchemeType.OAUTH2, "token")),
-                specTypesByPath = specTypes,
-            )
+        val mapper = RunOptionsMapper(
+            defaultHostForPortOnly = "localhost",
+            specIdsByPath = mapOf("petstore.yaml" to "petstore"),
+            specTypesByPath = specTypes,
+        ).mergeConfig(
+            config = SpecExecutionConfig.ConfigValue(
+                specs = listOf("petstore.yaml"),
+                specType = "OPENAPI",
+                config = mapOf("baseUrl" to "http://example.com:9001")
+            ),
+        )
+        .mergeGlobalOpenApi(
+            overlayFilePath = "overlay.yaml",
+            securitySchemes = mapOf("oauth" to SecuritySchemeConfigurationV3(SecuritySchemeType.OAUTH2, "token")),
+        )
 
         val openApi = mapper.openApi["petstore.yaml"]!!
         assertThat(openApi.securitySchemes).containsKey("oauth")
@@ -37,8 +38,10 @@ class RunOptionsMapperTest {
     @Test
     fun `openapi host and port mapped when baseUrl is missing`() {
         val specTypes = linkedMapOf("inventory.yaml" to SpecType.OPENAPI)
-        val mapper = RunOptionsMapper().mergeConfig(
+        val mapper = RunOptionsMapper(
+            specIdsByPath = mapOf("inventory.yaml" to "inventory"),
             specTypesByPath = specTypes,
+        ).mergeConfig(
             config = SpecExecutionConfig.ConfigValue(
                 specs = listOf("inventory.yaml"),
                 specType = "openapi",
@@ -50,5 +53,26 @@ class RunOptionsMapperTest {
         assertThat(openApi.baseUrl).isNull()
         assertThat(openApi.port).isEqualTo(9090)
         assertThat(openApi.host).isEqualTo("svc.internal")
+    }
+
+    @Test
+    fun `run options uses same stable readable id for matching specs`() {
+        val specTypes = linkedMapOf("services/payments/api.yaml" to SpecType.OPENAPI, "customers/api.yaml" to SpecType.OPENAPI)
+        val mapper = RunOptionsMapper(
+            specTypesByPath = specTypes,
+            specIdsByPath = mapOf(
+                "services/payments/api.yaml" to "payments-api",
+                "customers/api.yaml" to "customers-api",
+            ),
+        ).mergeConfig(
+            config = SpecExecutionConfig.ConfigValue(
+                specs = listOf("services/payments/api.yaml", "customers/api.yaml"),
+                specType = "openapi",
+                config = emptyMap(),
+            ),
+        )
+
+        assertThat(mapper.openApi["services/payments/api.yaml"]?.id).isEqualTo("payments-api")
+        assertThat(mapper.openApi["customers/api.yaml"]?.id).isEqualTo("customers-api")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/RunOptionsMapperTest.kt
@@ -1,0 +1,54 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.components.SecuritySchemeConfigurationV3
+import io.specmatic.core.config.v3.components.SecuritySchemeType
+import io.specmatic.reporter.model.SpecType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RunOptionsMapperTest {
+    @Test
+    fun `openapi baseUrl overrides host port and keeps global overlay security`() {
+        val specTypes = linkedMapOf("petstore.yaml" to SpecType.OPENAPI)
+        val mapper = RunOptionsMapper(defaultHostForPortOnly = "localhost")
+            .mergeConfig(
+                specTypesByPath = specTypes,
+                config = SpecExecutionConfig.ConfigValue(
+                    specs = listOf("petstore.yaml"),
+                    specType = "OPENAPI",
+                    config = mapOf("baseUrl" to "http://example.com:9001")
+                ),
+            )
+            .mergeGlobalOpenApi(
+                overlayFilePath = "overlay.yaml",
+                securitySchemes = mapOf("oauth" to SecuritySchemeConfigurationV3(SecuritySchemeType.OAUTH2, "token")),
+                specTypesByPath = specTypes,
+            )
+
+        val openApi = mapper.openApi["petstore.yaml"]!!
+        assertThat(openApi.securitySchemes).containsKey("oauth")
+        assertThat(openApi.overlayFilePath).isEqualTo("overlay.yaml")
+        assertThat(openApi.baseUrl).isEqualTo("http://example.com:9001")
+        assertThat(openApi.host).isNull()
+        assertThat(openApi.port).isNull()
+    }
+
+    @Test
+    fun `openapi host and port mapped when baseUrl is missing`() {
+        val specTypes = linkedMapOf("inventory.yaml" to SpecType.OPENAPI)
+        val mapper = RunOptionsMapper().mergeConfig(
+            specTypesByPath = specTypes,
+            config = SpecExecutionConfig.ConfigValue(
+                specs = listOf("inventory.yaml"),
+                specType = "openapi",
+                config = mapOf("port" to 9090, "host" to "svc.internal")
+            ),
+        )
+
+        val openApi = mapper.openApi["inventory.yaml"]!!
+        assertThat(openApi.baseUrl).isNull()
+        assertThat(openApi.port).isEqualTo(9090)
+        assertThat(openApi.host).isEqualTo("svc.internal")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilderTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilderTest.kt
@@ -30,7 +30,7 @@ class SourceMigrationBuilderTest {
         assertThat(migration.specTypesByPath).containsEntry("api.yaml", SpecType.OPENAPI)
 
         val spec = migration.definition.definition.specs.single() as SpecificationDefinition.ObjectValue
-        assertThat(spec.spec.id).isEqualTo("api.yaml")
+        assertThat(spec.spec.id).isEqualTo("api")
         assertThat(spec.spec.urlPathPrefix).isEqualTo("/v2")
 
         val sourceV3 = (migration.definition.definition.source as RefOrValue.Value).value
@@ -48,5 +48,23 @@ class SourceMigrationBuilderTest {
         val migrations = SourceMigrationBuilder(null).buildMockMigrations(listOf(source))
         assertThat(migrations).hasSize(2)
         assertThat(migrations.map { it.specTypesByPath.keys.single() }).containsExactly("a.yaml", "b.yaml")
+    }
+
+    @Test
+    fun `build test migrations creates stable readable ids and disambiguates collisions`() {
+        val source = Source(
+            provider = SourceProvider.filesystem,
+            directory = "./specs",
+            test = listOf(
+                SpecExecutionConfig.StringValue("services/payments/api.yaml"),
+                SpecExecutionConfig.StringValue("customers/api.yaml"),
+            ),
+        )
+
+        val migration = SourceMigrationBuilder(null).buildTestMigrations(listOf(source)).single()
+        val ids = migration.definition.definition.specs.map { (it as SpecificationDefinition.ObjectValue).spec.id }
+
+        assertThat(ids[0]).isEqualTo("payments-api")
+        assertThat(ids[1]).isEqualTo("customers-api")
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilderTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SourceMigrationBuilderTest.kt
@@ -1,0 +1,52 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.Source
+import io.specmatic.core.SourceProvider
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import io.specmatic.core.config.v3.components.sources.GitAuthentication
+import io.specmatic.reporter.model.SpecType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SourceMigrationBuilderTest {
+    @Test
+    fun `build test migrations keeps first spec type and latest partial base path`() {
+        val source = Source(
+            provider = SourceProvider.git,
+            repository = "https://github.com/specmatic/specs.git",
+            branch = "main",
+            test = listOf(
+                SpecExecutionConfig.ObjectValue.PartialUrl(specs = listOf("api.yaml"), basePath = "/v1"),
+                SpecExecutionConfig.ObjectValue.PartialUrl(specs = listOf("api.yaml"), basePath = "/v2"),
+            ),
+        )
+
+        val migration = SourceMigrationBuilder(GitAuthentication.BearerEnv("TOKEN"))
+            .buildTestMigrations(listOf(source))
+            .single()
+
+        assertThat(migration.specTypesByPath).containsEntry("api.yaml", SpecType.OPENAPI)
+
+        val spec = migration.definition.definition.specs.single() as SpecificationDefinition.ObjectValue
+        assertThat(spec.spec.id).isEqualTo("api.yaml")
+        assertThat(spec.spec.urlPathPrefix).isEqualTo("/v2")
+
+        val sourceV3 = (migration.definition.definition.source as RefOrValue.Value).value
+        assertThat(sourceV3.getGit()?.auth).isEqualTo(GitAuthentication.BearerEnv("TOKEN"))
+    }
+
+    @Test
+    fun `build mock migrations creates one migration per stub config`() {
+        val source = Source(
+            provider = SourceProvider.filesystem,
+            directory = "./specs",
+            stub = listOf(SpecExecutionConfig.StringValue("a.yaml"), SpecExecutionConfig.StringValue("b.yaml"),)
+        )
+
+        val migrations = SourceMigrationBuilder(null).buildMockMigrations(listOf(source))
+        assertThat(migrations).hasSize(2)
+        assertThat(migrations.map { it.specTypesByPath.keys.single() }).containsExactly("a.yaml", "b.yaml")
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapperTest.kt
@@ -1,0 +1,66 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.APICoverage
+import io.specmatic.core.APICoverageConfiguration
+import io.specmatic.core.ReportConfigurationDetails
+import io.specmatic.core.ReportTypes
+import io.specmatic.core.ResiliencyTestSuite
+import io.specmatic.core.ResiliencyTestsConfig
+import io.specmatic.core.Source
+import io.specmatic.core.SourceProvider
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.SuccessCriteria
+import io.specmatic.core.TestConfiguration
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.ConcreteSettings
+import io.specmatic.core.config.v3.RefOrValue
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SpecmaticMetadataMapperTest {
+    @Test
+    fun `maps test settings and picks resiliency from source when test config missing`() {
+        val config = SpecmaticConfigV1V2Common(
+            test = TestConfiguration(parallelism = "4", timeoutInMilliseconds = 9000, validateResponseValues = true),
+            sources = listOf(
+                Source(
+                    provider = SourceProvider.filesystem,
+                    test = listOf(
+                        SpecExecutionConfig.ObjectValue.PartialUrl(
+                            specs = listOf("payments.yaml"),
+                            resiliencyTests = ResiliencyTestsConfig(ResiliencyTestSuite.positiveOnly)
+                        )
+                    )
+                )
+            ),
+        )
+
+        val metadata = SpecmaticMetadataMapper().mapFrom(config, LegacyConfigView.from(config))
+        val settings = (metadata.settings as RefOrValue.Value<ConcreteSettings>).value
+
+        assertThat(settings.test?.parallelism).isEqualTo("4")
+        assertThat(settings.test?.validateResponseValues).isTrue()
+        assertThat(settings.test?.timeoutInMilliseconds).isEqualTo(9000)
+        assertThat(settings.test?.schemaResiliencyTests).isEqualTo(ResiliencyTestSuite.positiveOnly)
+    }
+
+    @Test
+    fun `maps governance success criterion from report`() {
+        val config = SpecmaticConfigV1V2Common(
+            report = ReportConfigurationDetails(
+                types = ReportTypes(
+                    apiCoverage = APICoverage(
+                        openAPI = APICoverageConfiguration(
+                            successCriteria = SuccessCriteria(minThresholdPercentage = 70, maxMissedEndpointsInSpec = 2, enforce = true)
+                        )
+                    )
+                )
+            )
+        )
+
+        val metadata = SpecmaticMetadataMapper().mapFrom(config, LegacyConfigView.from(config))
+        assertThat(metadata.governance?.successCriterion?.minCoveragePercentage).isEqualTo(70)
+        assertThat(metadata.governance?.successCriterion?.maxMissedOperationsInSpec).isEqualTo(2)
+        assertThat(metadata.governance?.successCriterion?.enforce).isTrue()
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SpecmaticMetadataMapperTest.kt
@@ -63,4 +63,11 @@ class SpecmaticMetadataMapperTest {
         assertThat(metadata.governance?.successCriterion?.maxMissedOperationsInSpec).isEqualTo(2)
         assertThat(metadata.governance?.successCriterion?.enforce).isTrue()
     }
+
+    @Test
+    fun `should not use default value for successCriteria if missing from legacy config`() {
+        val config = SpecmaticConfigV1V2Common(report = ReportConfigurationDetails(types = ReportTypes(apiCoverage = APICoverage(openAPI = APICoverageConfiguration()))))
+        val metadata = SpecmaticMetadataMapper().mapFrom(config, LegacyConfigView.from(config))
+        assertThat(metadata.governance?.successCriterion).isNull()
+    }
 }

--- a/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapperTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/config/v3/upgrade/SystemUnderTestMapperTest.kt
@@ -1,0 +1,75 @@
+package io.specmatic.core.config.v3.upgrade
+
+import io.specmatic.core.APIKeySecuritySchemeConfiguration
+import io.specmatic.core.OpenAPISecurityConfiguration
+import io.specmatic.core.ResiliencyTestSuite
+import io.specmatic.core.ResiliencyTestsConfig
+import io.specmatic.core.SecurityConfiguration
+import io.specmatic.core.Source
+import io.specmatic.core.SourceProvider
+import io.specmatic.core.SpecmaticConfigV1V2Common
+import io.specmatic.core.TestConfiguration
+import io.specmatic.core.config.v2.SpecExecutionConfig
+import io.specmatic.core.config.v3.RefOrValue
+import io.specmatic.core.config.v3.components.runOptions.TestRunOptions
+import io.specmatic.core.config.v3.components.services.CommonServiceConfig
+import io.specmatic.core.config.v3.components.services.Definition
+import io.specmatic.core.config.v3.components.services.SpecificationDefinition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SystemUnderTestMapperTest {
+    @Test
+    fun `maps openapi run options with global overlay and security`() {
+        val source = Source(
+            provider = SourceProvider.filesystem,
+            directory = "./specs",
+            test = listOf(
+                SpecExecutionConfig.ObjectValue.PartialUrl(
+                    host = "localhost",
+                    port = 8080,
+                    specs = listOf("users.yaml"),
+                    resiliencyTests = ResiliencyTestsConfig(ResiliencyTestSuite.all)
+                )
+            ),
+        )
+
+        val config = SpecmaticConfigV1V2Common(
+            sources = listOf(source),
+            test = TestConfiguration(baseUrl = "http://localhost:8080", overlayFilePath = "overlay.yaml", filter = "PATH='/users'"),
+            security = SecurityConfiguration(OpenAPI = OpenAPISecurityConfiguration(securitySchemes = mapOf("api_key" to APIKeySecuritySchemeConfiguration(value = "secret")))),
+            examples = listOf("examples/global"),
+        )
+
+        val serviceConfig = SystemUnderTestMapper().mapFrom(LegacyConfigView.from(config), SourceMigrationBuilder(null))!!
+        val service = (serviceConfig.service as RefOrValue.Value<CommonServiceConfig<TestRunOptions, *>>).value
+        val runOptions = (service.runOptions as RefOrValue.Value<TestRunOptions>).value
+
+        assertThat(service.definitions).hasSize(1)
+        assertThat(runOptions.openapi?.filter).isEqualTo("PATH='/users'")
+        assertThat(runOptions.openapi?.baseUrl).isEqualTo("http://localhost:8080")
+        assertThat(runOptions.openapi?.specs?.single()?.spec?.overlayFilePath).isEqualTo("overlay.yaml")
+        assertThat(runOptions.openapi?.specs?.single()?.spec?.securitySchemes).containsKey("api_key")
+    }
+
+    @Test
+    fun `drops specification id when no override but keeps id when overridden`() {
+        val definition = Definition(
+            definition = Definition.Value(
+                source = RefOrValue.Value(io.specmatic.core.config.v3.components.sources.SourceV3(fileSystem = io.specmatic.core.config.v3.components.sources.SourceV3.FileSystem(), git = null, web = null)),
+                specs = listOf(
+                    SpecificationDefinition.ObjectValue(SpecificationDefinition.Specification(id = "a.yaml", path = "a.yaml")),
+                    SpecificationDefinition.ObjectValue(SpecificationDefinition.Specification(id = "b.yaml", path = "b.yaml")),
+                )
+            )
+        )
+
+        val transformed = definition.dropSpecificationIdsWithoutOverrides { it == "b.yaml" }
+        val specs = transformed.definition.specs
+
+        val firstSpec = specs[0] as SpecificationDefinition.StringValue
+        val secondSpec = specs[1] as SpecificationDefinition.ObjectValue
+        assertThat(firstSpec.specification).isEqualTo("a.yaml")
+        assertThat(secondSpec.spec.id).isEqualTo("b.yaml")
+    }
+}

--- a/core/src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/after.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/after.yaml
@@ -1,0 +1,81 @@
+version: 3
+systemUnderTest:
+  service:
+    definitions:
+      - definition:
+          source:
+            git:
+              url: https://github.com/specmatic/specmatic-order-contracts.git
+          specs:
+            - spec:
+                id: io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+                path: io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+    runOptions:
+      openapi:
+        filter: PATH!='/health,/monitor/{id},/swagger'
+        actuatorUrl: http://localhost:8080/actuator/mappings
+        specs:
+          - spec:
+              id: io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+              baseUrl: http://localhost:8080
+    data:
+      examples:
+        - directories:
+            - ./src/test/resources/bff
+dependencies:
+  services:
+    - service:
+        definitions:
+          - definition:
+              source:
+                git:
+                  url: https://github.com/specmatic/specmatic-order-contracts.git
+              specs:
+                - spec:
+                    id: io/specmatic/examples/store/openapi/api_order_v5.yaml
+                    path: io/specmatic/examples/store/openapi/api_order_v5.yaml
+        runOptions:
+          openapi:
+            specs:
+              - spec:
+                  id: io/specmatic/examples/store/openapi/api_order_v5.yaml
+                  baseUrl: http://localhost:8090
+        data:
+          examples:
+            - directories:
+                - ./src/test/resources/domain_service
+    - service:
+        definitions:
+          - definition:
+              source:
+                git:
+                  url: https://github.com/specmatic/specmatic-order-contracts.git
+              specs:
+                - spec:
+                    id: io/specmatic/examples/store/asyncapi/kafka.yaml
+                    path: io/specmatic/examples/store/asyncapi/kafka.yaml
+        runOptions:
+          asyncapi:
+            specs:
+              - spec:
+                  id: io/specmatic/examples/store/asyncapi/kafka.yaml
+                  inMemoryBroker:
+                    host: localhost
+                    port: 9092
+                  servers:
+                    - host: localhost:9092
+                      protocol: kafka
+  data:
+    adapters:
+      post_specmatic_response_processor: ./hooks/post_specmatic_response_processor.sh
+specmatic:
+  license:
+    path: /root/specmatic-license.txt
+  governance:
+    successCriteria:
+      minCoveragePercentage: 70
+      maxMissedOperationsInSpec: 0
+      enforce: true
+  settings:
+    test:
+      schemaResiliencyTests: all

--- a/core/src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/after.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/after.yaml
@@ -8,7 +8,7 @@ systemUnderTest:
               url: https://github.com/specmatic/specmatic-order-contracts.git
           specs:
             - spec:
-                id: io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+                id: product-search-bff-v6
                 path: io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
     runOptions:
       openapi:
@@ -16,7 +16,7 @@ systemUnderTest:
         actuatorUrl: http://localhost:8080/actuator/mappings
         specs:
           - spec:
-              id: io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+              id: product-search-bff-v6
               baseUrl: http://localhost:8080
     data:
       examples:
@@ -32,13 +32,13 @@ dependencies:
                   url: https://github.com/specmatic/specmatic-order-contracts.git
               specs:
                 - spec:
-                    id: io/specmatic/examples/store/openapi/api_order_v5.yaml
+                    id: api-order-v5
                     path: io/specmatic/examples/store/openapi/api_order_v5.yaml
         runOptions:
           openapi:
             specs:
               - spec:
-                  id: io/specmatic/examples/store/openapi/api_order_v5.yaml
+                  id: api-order-v5
                   baseUrl: http://localhost:8090
         data:
           examples:
@@ -52,13 +52,13 @@ dependencies:
                   url: https://github.com/specmatic/specmatic-order-contracts.git
               specs:
                 - spec:
-                    id: io/specmatic/examples/store/asyncapi/kafka.yaml
+                    id: kafka
                     path: io/specmatic/examples/store/asyncapi/kafka.yaml
         runOptions:
           asyncapi:
             specs:
               - spec:
-                  id: io/specmatic/examples/store/asyncapi/kafka.yaml
+                  id: kafka
                   inMemoryBroker:
                     host: localhost
                     port: 9092

--- a/core/src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/before.yaml
+++ b/core/src/test/resources/specmaticConfigFiles/v3/v2ToV3/bff/before.yaml
@@ -1,0 +1,48 @@
+version: 2
+contracts:
+  - git:
+      url: https://github.com/specmatic/specmatic-order-contracts.git
+    provides:
+      - specs:
+          - io/specmatic/examples/store/openapi/product_search_bff_v6.yaml
+        specType: openapi
+        config:
+          baseUrl: "{APP_URL:http://localhost:8080}"
+          examples:
+            - ./src/test/resources/bff
+          resiliencyTests:
+            enable: "all"
+    consumes:
+      - specs:
+          - io/specmatic/examples/store/openapi/api_order_v5.yaml
+        specType: openapi
+        config:
+          baseUrl: http://localhost:8090
+          examples:
+            - ./src/test/resources/domain_service
+      - specs:
+          - io/specmatic/examples/store/asyncapi/kafka.yaml
+        specType: asyncapi
+        config:
+          inMemoryBroker:
+            host: localhost
+            port: 9092
+          servers:
+            - host: localhost:9092
+              protocol: kafka
+license_path: "/root/specmatic-license.txt"
+test:
+  filter: "PATH!='/health,/monitor/{id},/swagger'"
+  actuatorUrl: "{APP_URL:http://localhost:8080}/actuator/mappings"
+  resiliencyTests:
+    enable: all
+hooks:
+  post_specmatic_response_processor: ./hooks/post_specmatic_response_processor.sh
+report:
+  types:
+    APICoverage:
+      OpenAPI:
+        successCriteria:
+          minThresholdPercentage: 70
+          maxMissedEndpointsInSpec: 0
+          enforce: true


### PR DESCRIPTION
**What**: Added support for upgrading legacy V1 and V2 Specmatic configuration to the latest V3 format.

**Why**: This removes the need for users to manually rewrite older configuration files when adopting the newer config model. It reduces migration effort, lowers the risk of configuration mistakes, and makes it easier for existing projects to move forward without changing their setup by hand.

**How**: The updater now accepts legacy configuration input and produces an equivalent V3 configuration automatically, preserving the user’s existing intent and behavior as closely as possible.

**Checklist**:

- [x] Unit Tests
- [x] Build passing locally
- [ ] Sonar Quality Gate
- [ ] Security scans don't report any vulnerabilities
- [ ] Documentation added/updated
- [ ] Sample Project added/updated
- [ ] Demo video
- [ ] Article on Website
- [ ] Roadmap updated
- [ ] Conference Talk