### PR TITLE
Mark an operation as changed in the BCC report if it was edited in the new spec

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -97,7 +97,8 @@ class OpenApiSpecification(
     private val dictionary: Dictionary = loadDictionary(openApiFilePath, specmaticConfig.getDictionary(), strictMode),
     private val logger: LogStrategy = io.specmatic.core.log.logger,
     private val parseCollectorContext: CollectorContext = CollectorContext(),
-    private val exampleDirPaths: List<String> = emptyList()
+    private val exampleDirPaths: List<String> = emptyList(),
+    private val changeTrackingSource: OpenApiChangeTrackingSource? = null,
 ) : IncludedSpecification, ApiSpecification {
     private val extensibleQueryParams: Boolean = specmaticConfig.getExtensibleQueryParams()
     private val preferEscapedSoapAction: Boolean = specmaticConfig.getEscapeSoapAction()
@@ -335,7 +336,40 @@ class OpenApiSpecification(
                 lenientMode = lenientMode,
                 logger = logger,
                 parseCollectorContext = collectorContext,
-                exampleDirPaths = exampleDirPaths
+                exampleDirPaths = exampleDirPaths,
+                changeTrackingSource = OpenApiChangeTrackingSource(
+                    yamlContent = preprocessedYaml,
+                    openApiFilePath = openApiFilePath.replace("\\", "/"),
+                    lenientMode = lenientMode,
+                ),
+            )
+        }
+
+        internal fun fromYAMLForChangeTracking(
+            yamlContent: String,
+            openApiFilePath: String,
+            specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
+            strictMode: Boolean = false,
+            lenientMode: Boolean = false,
+            exampleDirPaths: List<String> = emptyList(),
+        ): OpenApiSpecification {
+            val parseResult: SwaggerParseResult =
+                OpenAPIV3Parser().readContents(
+                    yamlContent,
+                    null,
+                    resolveFullyReferences(),
+                    openApiFilePath.replace("\\", "/")
+                )
+            val parsedOpenApi: OpenAPI = parseResult.openAPI
+                ?: throw ContractException("Could not parse contract $openApiFilePath for change tracking, please validate the syntax using https://editor.swagger.io")
+
+            return OpenApiSpecification(
+                openApiFilePath,
+                parsedOpenApi,
+                specmaticConfig = specmaticConfig,
+                strictMode = strictMode,
+                lenientMode = lenientMode,
+                exampleDirPaths = exampleDirPaths,
             )
         }
 
@@ -367,6 +401,12 @@ class OpenApiSpecification(
                 it.isResolve = true
                 it.isResolveRequestBody = true
                 it.isResolveResponses = true
+            }
+        }
+
+        private fun resolveFullyReferences(): ParseOptions {
+            return resolveExternalReferences().also {
+                it.isResolveFully = true
             }
         }
 
@@ -526,7 +566,8 @@ class OpenApiSpecification(
             specmaticConfig = specmaticConfig,
             strictMode = strictMode,
             protocol = protocol,
-            exampleDirPaths = exampleDirPaths
+            exampleDirPaths = exampleDirPaths,
+            changeTrackingSource = changeTrackingSource,
         )
 
         return Pair(feature, rootContext.toCollector().toResult())

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -185,8 +185,17 @@ data class Feature(
     val strictMode: Boolean = false,
     val exampleStore: ExampleStore = ExampleStore.empty(),
     val protocol: SpecmaticProtocol,
-    val exampleDirPaths: List<String> = emptyList()
+    val exampleDirPaths: List<String> = emptyList(),
+    val changeTrackingSource: OpenApiChangeTrackingSource? = null,
 ): IFeature {
+    fun scenariosForChangeTracking(): List<Scenario> {
+        return changeTrackingSource?.scenarios(
+            specmaticConfig = specmaticConfig,
+            strictMode = strictMode,
+            exampleDirPaths = exampleDirPaths,
+        ) ?: scenarios
+    }
+
     val inlineNamedStubs: List<NamedStub>
         get() = exampleStore.examples
             .asSequence()
@@ -2549,7 +2558,8 @@ data class Feature(
             flagsBased: FlagsBased = strategiesFromFlags(specmaticConfig),
             strictMode: Boolean = false,
             protocol: SpecmaticProtocol,
-            exampleDirPaths: List<String> = emptyList()
+            exampleDirPaths: List<String> = emptyList(),
+            changeTrackingSource: OpenApiChangeTrackingSource? = null,
         ): Feature {
             val inlineExamples = stubsFromExamples.flatMap { (exampleName, stubs) ->
                 stubs.map { (request, response) ->
@@ -2572,7 +2582,8 @@ data class Feature(
                 flagsBased = flagsBased,
                 strictMode = strictMode,
                 protocol = protocol,
-                exampleDirPaths = exampleDirPaths
+                exampleDirPaths = exampleDirPaths,
+                changeTrackingSource = changeTrackingSource,
             )
         }
 
@@ -2592,7 +2603,8 @@ data class Feature(
             flagsBased: FlagsBased = strategiesFromFlags(specmaticConfig),
             strictMode: Boolean = false,
             protocol: SpecmaticProtocol,
-            exampleDirPaths: List<String> = emptyList()
+            exampleDirPaths: List<String> = emptyList(),
+            changeTrackingSource: OpenApiChangeTrackingSource? = null,
         ): Feature {
             return Feature(
                 scenarios = scenarios,
@@ -2610,7 +2622,8 @@ data class Feature(
                 strictMode = strictMode,
                 exampleStore = ExampleStore.from(inlineExamples, type = ExampleType.INLINE),
                 protocol = protocol,
-                exampleDirPaths = exampleDirPaths
+                exampleDirPaths = exampleDirPaths,
+                changeTrackingSource = changeTrackingSource,
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -193,7 +193,7 @@ data class Feature(
             specmaticConfig = specmaticConfig,
             strictMode = strictMode,
             exampleDirPaths = exampleDirPaths,
-        ) ?: scenarios
+        ).orEmpty()
     }
 
     fun scenariosForChangeTracking(): List<Scenario> = cachedScenariosForChangeTracking

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -188,13 +188,15 @@ data class Feature(
     val exampleDirPaths: List<String> = emptyList(),
     val changeTrackingSource: OpenApiChangeTrackingSource? = null,
 ): IFeature {
-    fun scenariosForChangeTracking(): List<Scenario> {
-        return changeTrackingSource?.scenarios(
+    private val cachedScenariosForChangeTracking: List<Scenario> by lazy {
+        changeTrackingSource?.scenarios(
             specmaticConfig = specmaticConfig,
             strictMode = strictMode,
             exampleDirPaths = exampleDirPaths,
         ) ?: scenarios
     }
+
+    fun scenariosForChangeTracking(): List<Scenario> = cachedScenariosForChangeTracking
 
     val inlineNamedStubs: List<NamedStub>
         get() = exampleStore.examples

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -21,15 +21,15 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         val requestFamilies = groupScenariosByPathAndMethod(oldFeature)
         return buildList {
             requestFamilies.forEach { requestFamily ->
-                val changeStatus = operationChangeStatus(requestFamily)
-                val requestResults = validateRequestCompatibility(requestFamily, changeStatus).also(::addAll)
-                val responseResults = validateResponseCompatibility(requestFamily, requestResults, changeStatus).also(::addAll)
+                val changeStatusFor = operationChangeStatus(requestFamily)
+                val requestResults = validateRequestCompatibility(requestFamily, changeStatusFor).also(::addAll)
+                val responseResults = validateResponseCompatibility(requestFamily, requestResults, changeStatusFor).also(::addAll)
                 logOperationResult(requestResults.plus(responseResults))
             }
         }
     }
 
-    private fun operationChangeStatus(requestFamily: RequestFamily): ChangeStatus {
+    private fun operationChangeStatus(requestFamily: RequestFamily): (Scenario) -> ChangeStatus {
         val operationIdentifier = requestFamily.path to requestFamily.method
         val oldScenariosForOperation = oldChangeTrackingScenariosByPathAndMethod[operationIdentifier] ?: requestFamily.scenarios
         val newScenariosForOperation = newChangeTrackingScenariosByPathAndMethod[operationIdentifier].orEmpty()
@@ -43,7 +43,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
             .map(::RequestFamily)
     }
 
-    private fun validateRequestCompatibility(requestFamily: RequestFamily, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun validateRequestCompatibility(requestFamily: RequestFamily, changeStatusFor: (Scenario) -> ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         val scenarioPerReqIdentifier = requestFamily.oneScenarioPerReqIdentifiers()
         val positiveVariations = generatePositiveVariations(scenarioPerReqIdentifier)
         val totalPositiveVariations = positiveVariations.size
@@ -51,7 +51,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         logger.boundary()
         logger.log(initialLogMessage(requestFamily, totalPositiveVariations))
         return positiveVariations.withIndex().flatMap { (index, variation) ->
-            evaluateVariation(variation, changeStatus).also {
+            evaluateVariation(variation, changeStatusFor).also {
                 logProgress(index.inc(), totalPositiveVariations)
             }
         }
@@ -78,27 +78,27 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         logger.log("[Compatibility Check] Verdict: $verdict")
     }
 
-    private fun evaluateVariation(variationFromOldScenario: Scenario, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun evaluateVariation(variationFromOldScenario: Scenario, changeStatusFor: (Scenario) -> ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         return try {
             val request = variationFromOldScenario.generateHttpRequest(backwardCompatibilityStrategies)
-            requestMatches(request, variationFromOldScenario, changeStatus)
+            requestMatches(request, variationFromOldScenario, changeStatusFor)
         } catch (contractException: ContractException) {
             val result = contractException.failure()
-            listOf(newRecord(variationFromOldScenario, result, changeStatus))
+            listOf(newRecord(variationFromOldScenario, result, changeStatusFor))
         } catch (_: StackOverflowError) {
             val result = Result.Failure(STACK_OVERFLOW_MESSAGE)
-            listOf(newRecord(variationFromOldScenario, result, changeStatus))
+            listOf(newRecord(variationFromOldScenario, result, changeStatusFor))
         } catch (_: EmptyContract) {
             val newFilePath = if (newFeature.path.isNotEmpty()) " at ${newFeature.path}" else ""
             val result = Result.Failure("The contract$newFilePath had no operations")
-            listOf(newRecord(variationFromOldScenario, result, changeStatus))
+            listOf(newRecord(variationFromOldScenario, result, changeStatusFor))
         } catch (throwable: Throwable) {
             val result = Result.Failure("Exception: ${throwable.localizedMessage}")
-            listOf(newRecord(variationFromOldScenario, result, changeStatus))
+            listOf(newRecord(variationFromOldScenario, result, changeStatusFor))
         }
     }
 
-    private fun requestMatches(request: HttpRequest, variationFromOldScenario: Scenario, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun requestMatches(request: HttpRequest, variationFromOldScenario: Scenario, changeStatusFor: (Scenario) -> ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         if (newFeature.scenarios.isEmpty()) throw EmptyContract()
         val identifierMatches = newScenariosByMethodAndReqContentType.findExactOrSingle(
             first = variationFromOldScenario.method,
@@ -108,7 +108,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
 
         if (identifierMatches.isEmpty()) {
             val result = Result.Failure("This API exists in the old contract but not in the new contract")
-            return listOf(newRecord(variationFromOldScenario, result, changeStatus))
+            return listOf(newRecord(variationFromOldScenario, result, changeStatusFor))
         }
 
         // This is a performance optimization: If Path + Method + RequestContentType has many scenarios,
@@ -123,11 +123,11 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         // This is a performance optimization: As there can be multiple scenarios with responseCode and contentTypes,
         // we can associate first result with remaining avoiding re-valuation as they will share the same request schema as per OAS
         return identifierMatches.map { newScenario ->
-            newRecord(newScenario, matchResult, changeStatus)
+            newRecord(newScenario, matchResult, changeStatusFor)
         }
     }
 
-    private fun validateResponseCompatibility(requestFamily: RequestFamily, requestResults: List<OpenApiBackwardCompatibilityCheckRecord>, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun validateResponseCompatibility(requestFamily: RequestFamily, requestResults: List<OpenApiBackwardCompatibilityCheckRecord>, changeStatusFor: (Scenario) -> ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         val oldScenarios = requestFamily.oneScenarioPerResIdentifiers()
         val newScenarios = dedupeNewScenariosByIdentity(requestResults)
         val newScenariosByStatusAndResContentType = newScenarios.groupBy { it.status to it.responseContentType }
@@ -136,10 +136,10 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
             val identifierMatches = newScenariosByStatusAndResContentType.findExactOrSingle(oldScenario.status, oldScenario.responseContentType)
             if (identifierMatches.isEmpty()) {
                 val result = Result.Failure("This API exists in the old contract but not in the new contract")
-                return@flatMap listOf(newRecord(oldScenario, result, changeStatus))
+                return@flatMap listOf(newRecord(oldScenario, result, changeStatusFor))
             }
 
-            identifierMatches.map { newScenario -> checkResponseEncompasses(oldScenario, newScenario, changeStatus) }
+            identifierMatches.map { newScenario -> checkResponseEncompasses(oldScenario, newScenario, changeStatusFor) }
         }
     }
 
@@ -148,7 +148,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         return requestResults.asSequence().map { it.scenario }.filter(seenScenarios::add).toList()
     }
 
-    private fun checkResponseEncompasses(oldScenario: Scenario, newScenario: Scenario, changeStatus: ChangeStatus): OpenApiBackwardCompatibilityCheckRecord {
+    private fun checkResponseEncompasses(oldScenario: Scenario, newScenario: Scenario, changeStatusFor: (Scenario) -> ChangeStatus): OpenApiBackwardCompatibilityCheckRecord {
         return try {
             newRecord(
                 scenario = newScenario,
@@ -157,21 +157,21 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
                     olderResolver = oldScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
                     newerResolver = newScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
                 ),
-                changeStatus = changeStatus,
+                changeStatusFor = changeStatusFor,
             )
         } catch (_: StackOverflowError) {
-            newRecord(newScenario, Result.Failure(STACK_OVERFLOW_MESSAGE), changeStatus)
+            newRecord(newScenario, Result.Failure(STACK_OVERFLOW_MESSAGE), changeStatusFor)
         } catch (throwable: Throwable) {
-            newRecord(newScenario, throwable.toFailure(), changeStatus)
+            newRecord(newScenario, throwable.toFailure(), changeStatusFor)
         }
     }
 
-    private fun newRecord(scenario: Scenario, result: Result, changeStatus: ChangeStatus): OpenApiBackwardCompatibilityCheckRecord {
+    private fun newRecord(scenario: Scenario, result: Result, changeStatusFor: (Scenario) -> ChangeStatus): OpenApiBackwardCompatibilityCheckRecord {
         return OpenApiBackwardCompatibilityCheckRecord(
             feature = newFeature,
             scenario = scenario,
             compatResult = result.updateScenario(scenario).withoutFailureReasons(),
-            changeStatus = changeStatus,
+            changeStatus = changeStatusFor(scenario),
         )
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -11,6 +11,11 @@ import java.util.IdentityHashMap
 class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, private val newFeature: Feature) {
     private val newScenariosByMethodAndReqContentType = newFeature.scenarios.groupBy { it.method to it.requestContentType }
     private val newScenariosByPathAndMethod = newFeature.scenarios.groupBy { it.path to it.method }
+    private val oldChangeTrackingScenariosByPathAndMethod = oldFeature.scenariosForChangeTracking()
+        .filter { !it.ignoreFailure }
+        .groupBy { it.path to it.method }
+    private val newChangeTrackingScenariosByPathAndMethod = newFeature.scenariosForChangeTracking()
+        .groupBy { it.path to it.method }
 
     fun run(): List<OpenApiBackwardCompatibilityCheckRecord> {
         val requestFamilies = groupScenariosByPathAndMethod(oldFeature)
@@ -25,8 +30,10 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
     }
 
     private fun operationChangeStatus(requestFamily: RequestFamily): ChangeStatus {
-        val newScenariosForOperation = newScenariosByPathAndMethod[requestFamily.path to requestFamily.method].orEmpty()
-        return ScenarioFingerprint.changeStatusBetween(requestFamily.scenarios, newScenariosForOperation)
+        val operationIdentifier = requestFamily.path to requestFamily.method
+        val oldScenariosForOperation = oldChangeTrackingScenariosByPathAndMethod[operationIdentifier] ?: requestFamily.scenarios
+        val newScenariosForOperation = newChangeTrackingScenariosByPathAndMethod[operationIdentifier].orEmpty()
+        return ScenarioFingerprint.changeStatusBetween(oldScenariosForOperation, newScenariosForOperation)
     }
 
     private fun groupScenariosByPathAndMethod(feature: Feature): List<RequestFamily> {

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -10,11 +10,11 @@ import java.util.IdentityHashMap
 
 class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, private val newFeature: Feature) {
     private val newScenariosByMethodAndReqContentType = newFeature.scenarios.groupBy { it.method to it.requestContentType }
-    private val newScenariosByPathAndMethod = newFeature.scenarios.groupBy { it.path to it.method }
     private val oldChangeTrackingScenariosByPathAndMethod = oldFeature.scenariosForChangeTracking()
         .filter { !it.ignoreFailure }
         .groupBy { it.path to it.method }
     private val newChangeTrackingScenariosByPathAndMethod = newFeature.scenariosForChangeTracking()
+        .filter { !it.ignoreFailure }
         .groupBy { it.path to it.method }
 
     fun run(): List<OpenApiBackwardCompatibilityCheckRecord> {
@@ -31,7 +31,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
 
     private fun operationChangeStatus(requestFamily: RequestFamily): (Scenario) -> ChangeStatus {
         val operationIdentifier = requestFamily.path to requestFamily.method
-        val oldScenariosForOperation = oldChangeTrackingScenariosByPathAndMethod[operationIdentifier] ?: requestFamily.scenarios
+        val oldScenariosForOperation = oldChangeTrackingScenariosByPathAndMethod[operationIdentifier].orEmpty()
         val newScenariosForOperation = newChangeTrackingScenariosByPathAndMethod[operationIdentifier].orEmpty()
         return ScenarioFingerprint.changeStatusBetween(oldScenariosForOperation, newScenariosForOperation)
     }

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -3,23 +3,41 @@ package io.specmatic.core
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
 import io.specmatic.test.asserts.toFailure
 import java.util.Collections
 import java.util.IdentityHashMap
 
 class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, private val newFeature: Feature) {
     private val newScenariosByMethodAndReqContentType = newFeature.scenarios.groupBy { it.method to it.requestContentType }
+    private val newScenariosByPathAndMethod = newFeature.scenarios.groupBy { it.path to it.method }
 
     fun run(): List<OpenApiBackwardCompatibilityCheckRecord> {
         val requestFamilies = groupScenariosByPathAndMethod(oldFeature)
         return buildList {
             requestFamilies.forEach { requestFamily ->
-                val requestResults = validateRequestCompatibility(requestFamily).also(::addAll)
-                val responseResults = validateResponseCompatibility(requestFamily, requestResults).also(::addAll)
+                val changeStatus = operationChangeStatus(requestFamily)
+                val requestResults = validateRequestCompatibility(requestFamily, changeStatus).also(::addAll)
+                val responseResults = validateResponseCompatibility(requestFamily, requestResults, changeStatus).also(::addAll)
                 logOperationResult(requestResults.plus(responseResults))
             }
         }
     }
+
+    private fun operationChangeStatus(requestFamily: RequestFamily): ChangeStatus {
+        val newScenariosForOperation = newScenariosByPathAndMethod[requestFamily.path to requestFamily.method].orEmpty()
+        val oldFingerprints = requestFamily.scenarios.map { it.changeFingerprint() }.toSet()
+        val newFingerprints = newScenariosForOperation.map { it.changeFingerprint() }.toSet()
+        return if (oldFingerprints == newFingerprints) ChangeStatus.UNCHANGED else ChangeStatus.CHANGED
+    }
+
+    private fun Scenario.changeFingerprint(): ScenarioFingerprint = ScenarioFingerprint(
+        status = status,
+        requestContentType = requestContentType,
+        responseContentType = responseContentType,
+        httpRequestPattern = httpRequestPattern,
+        httpResponsePattern = httpResponsePattern,
+    )
 
     private fun groupScenariosByPathAndMethod(feature: Feature): List<RequestFamily> {
         return feature.scenarios
@@ -28,7 +46,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
             .map(::RequestFamily)
     }
 
-    private fun validateRequestCompatibility(requestFamily: RequestFamily): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun validateRequestCompatibility(requestFamily: RequestFamily, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         val scenarioPerReqIdentifier = requestFamily.oneScenarioPerReqIdentifiers()
         val positiveVariations = generatePositiveVariations(scenarioPerReqIdentifier)
         val totalPositiveVariations = positiveVariations.size
@@ -36,7 +54,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         logger.boundary()
         logger.log(initialLogMessage(requestFamily, totalPositiveVariations))
         return positiveVariations.withIndex().flatMap { (index, variation) ->
-            evaluateVariation(variation).also {
+            evaluateVariation(variation, changeStatus).also {
                 logProgress(index.inc(), totalPositiveVariations)
             }
         }
@@ -63,27 +81,27 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         logger.log("[Compatibility Check] Verdict: $verdict")
     }
 
-    private fun evaluateVariation(variationFromOldScenario: Scenario): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun evaluateVariation(variationFromOldScenario: Scenario, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         return try {
             val request = variationFromOldScenario.generateHttpRequest(backwardCompatibilityStrategies)
-            requestMatches(request, variationFromOldScenario)
+            requestMatches(request, variationFromOldScenario, changeStatus)
         } catch (contractException: ContractException) {
             val result = contractException.failure()
-            listOf(newRecord(variationFromOldScenario, result))
+            listOf(newRecord(variationFromOldScenario, result, changeStatus))
         } catch (_: StackOverflowError) {
             val result = Result.Failure(STACK_OVERFLOW_MESSAGE)
-            listOf(newRecord(variationFromOldScenario, result))
+            listOf(newRecord(variationFromOldScenario, result, changeStatus))
         } catch (_: EmptyContract) {
             val newFilePath = if (newFeature.path.isNotEmpty()) " at ${newFeature.path}" else ""
             val result = Result.Failure("The contract$newFilePath had no operations")
-            listOf(newRecord(variationFromOldScenario, result))
+            listOf(newRecord(variationFromOldScenario, result, changeStatus))
         } catch (throwable: Throwable) {
             val result = Result.Failure("Exception: ${throwable.localizedMessage}")
-            listOf(newRecord(variationFromOldScenario, result))
+            listOf(newRecord(variationFromOldScenario, result, changeStatus))
         }
     }
 
-    private fun requestMatches(request: HttpRequest, variationFromOldScenario: Scenario): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun requestMatches(request: HttpRequest, variationFromOldScenario: Scenario, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         if (newFeature.scenarios.isEmpty()) throw EmptyContract()
         val identifierMatches = newScenariosByMethodAndReqContentType.findExactOrSingle(
             first = variationFromOldScenario.method,
@@ -93,7 +111,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
 
         if (identifierMatches.isEmpty()) {
             val result = Result.Failure("This API exists in the old contract but not in the new contract")
-            return listOf(newRecord(variationFromOldScenario, result))
+            return listOf(newRecord(variationFromOldScenario, result, changeStatus))
         }
 
         // This is a performance optimization: If Path + Method + RequestContentType has many scenarios,
@@ -108,11 +126,11 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         // This is a performance optimization: As there can be multiple scenarios with responseCode and contentTypes,
         // we can associate first result with remaining avoiding re-valuation as they will share the same request schema as per OAS
         return identifierMatches.map { newScenario ->
-            newRecord(newScenario, matchResult)
+            newRecord(newScenario, matchResult, changeStatus)
         }
     }
 
-    private fun validateResponseCompatibility(requestFamily: RequestFamily, requestResults: List<OpenApiBackwardCompatibilityCheckRecord>): List<OpenApiBackwardCompatibilityCheckRecord> {
+    private fun validateResponseCompatibility(requestFamily: RequestFamily, requestResults: List<OpenApiBackwardCompatibilityCheckRecord>, changeStatus: ChangeStatus): List<OpenApiBackwardCompatibilityCheckRecord> {
         val oldScenarios = requestFamily.oneScenarioPerResIdentifiers()
         val newScenarios = dedupeNewScenariosByIdentity(requestResults)
         val newScenariosByStatusAndResContentType = newScenarios.groupBy { it.status to it.responseContentType }
@@ -121,10 +139,10 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
             val identifierMatches = newScenariosByStatusAndResContentType.findExactOrSingle(oldScenario.status, oldScenario.responseContentType)
             if (identifierMatches.isEmpty()) {
                 val result = Result.Failure("This API exists in the old contract but not in the new contract")
-                return@flatMap listOf(newRecord(oldScenario, result))
+                return@flatMap listOf(newRecord(oldScenario, result, changeStatus))
             }
 
-            identifierMatches.map { newScenario -> checkResponseEncompasses(oldScenario, newScenario) }
+            identifierMatches.map { newScenario -> checkResponseEncompasses(oldScenario, newScenario, changeStatus) }
         }
     }
 
@@ -133,7 +151,7 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         return requestResults.asSequence().map { it.scenario }.filter(seenScenarios::add).toList()
     }
 
-    private fun checkResponseEncompasses(oldScenario: Scenario, newScenario: Scenario): OpenApiBackwardCompatibilityCheckRecord {
+    private fun checkResponseEncompasses(oldScenario: Scenario, newScenario: Scenario, changeStatus: ChangeStatus): OpenApiBackwardCompatibilityCheckRecord {
         return try {
             newRecord(
                 scenario = newScenario,
@@ -141,20 +159,22 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
                     other = newScenario.httpResponsePattern,
                     olderResolver = oldScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
                     newerResolver = newScenario.resolver.copy(mismatchMessages = NewAndOldSpecificationResponseMismatches),
-                )
+                ),
+                changeStatus = changeStatus,
             )
         } catch (_: StackOverflowError) {
-            newRecord(newScenario, Result.Failure(STACK_OVERFLOW_MESSAGE))
+            newRecord(newScenario, Result.Failure(STACK_OVERFLOW_MESSAGE), changeStatus)
         } catch (throwable: Throwable) {
-            newRecord(newScenario, throwable.toFailure())
+            newRecord(newScenario, throwable.toFailure(), changeStatus)
         }
     }
 
-    private fun newRecord(scenario: Scenario, result: Result): OpenApiBackwardCompatibilityCheckRecord {
+    private fun newRecord(scenario: Scenario, result: Result, changeStatus: ChangeStatus): OpenApiBackwardCompatibilityCheckRecord {
         return OpenApiBackwardCompatibilityCheckRecord(
             feature = newFeature,
             scenario = scenario,
-            compatResult = result.updateScenario(scenario).withoutFailureReasons()
+            compatResult = result.updateScenario(scenario).withoutFailureReasons(),
+            changeStatus = changeStatus,
         )
     }
 
@@ -179,10 +199,21 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
     }
 }
 
+private data class ScenarioFingerprint(
+    val status: Int,
+    val requestContentType: String?,
+    val responseContentType: String?,
+    val httpRequestPattern: HttpRequestPattern,
+    val httpResponsePattern: HttpResponsePattern,
+)
+
 private data class RequestFamily(val scenarios: List<Scenario>) {
     private val representativeScenario: Scenario = scenarios.first()
     private val groupedByRequestIdentifiers = scenarios.groupBy { Triple(it.path, it.method, it.requestContentType) }
     private val groupedByResponseIdentifiers = scenarios.groupBy { Pair(it.status, it.responseContentType) }
+
+    val path: String get() = representativeScenario.path
+    val method: String get() = representativeScenario.method
 
     fun oneScenarioPerReqIdentifiers(): List<Scenario> {
         return groupedByRequestIdentifiers.values.mapNotNull { scenarios -> scenarios.firstOrNull() }

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -26,18 +26,8 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
 
     private fun operationChangeStatus(requestFamily: RequestFamily): ChangeStatus {
         val newScenariosForOperation = newScenariosByPathAndMethod[requestFamily.path to requestFamily.method].orEmpty()
-        val oldFingerprints = requestFamily.scenarios.map { it.changeFingerprint() }.toSet()
-        val newFingerprints = newScenariosForOperation.map { it.changeFingerprint() }.toSet()
-        return if (oldFingerprints == newFingerprints) ChangeStatus.UNCHANGED else ChangeStatus.CHANGED
+        return ScenarioFingerprint.changeStatusBetween(requestFamily.scenarios, newScenariosForOperation)
     }
-
-    private fun Scenario.changeFingerprint(): ScenarioFingerprint = ScenarioFingerprint(
-        status = status,
-        requestContentType = requestContentType,
-        responseContentType = responseContentType,
-        httpRequestPattern = httpRequestPattern,
-        httpResponsePattern = httpResponsePattern,
-    )
 
     private fun groupScenariosByPathAndMethod(feature: Feature): List<RequestFamily> {
         return feature.scenarios
@@ -198,14 +188,6 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
         private val backwardCompatibilityStrategies = DefaultStrategies.copy(randomArraySize = BACKWARD_COMPATIBILITY_RANDOM_ARRAY_SIZE)
     }
 }
-
-private data class ScenarioFingerprint(
-    val status: Int,
-    val requestContentType: String?,
-    val responseContentType: String?,
-    val httpRequestPattern: HttpRequestPattern,
-    val httpResponsePattern: HttpResponsePattern,
-)
 
 private data class RequestFamily(val scenarios: List<Scenario>) {
     private val representativeScenario: Scenario = scenarios.first()

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiChangeTrackingSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiChangeTrackingSource.kt
@@ -1,0 +1,27 @@
+package io.specmatic.core
+
+import io.specmatic.conversions.OpenApiSpecification
+
+data class OpenApiChangeTrackingSource(
+    val yamlContent: String,
+    val openApiFilePath: String,
+    val lenientMode: Boolean,
+) {
+    fun scenarios(
+        specmaticConfig: SpecmaticConfig,
+        strictMode: Boolean,
+        exampleDirPaths: List<String>,
+    ): List<Scenario> {
+        return OpenApiSpecification
+            .fromYAMLForChangeTracking(
+                yamlContent = yamlContent,
+                openApiFilePath = openApiFilePath,
+                specmaticConfig = specmaticConfig,
+                strictMode = strictMode,
+                lenientMode = lenientMode,
+                exampleDirPaths = exampleDirPaths,
+            )
+            .toFeature()
+            .scenarios
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
@@ -1,0 +1,30 @@
+package io.specmatic.core
+
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+
+data class ScenarioFingerprint(
+    val status: Int,
+    val requestContentType: String?,
+    val responseContentType: String?,
+    val httpRequestPattern: HttpRequestPattern,
+    val httpResponsePattern: HttpResponsePattern,
+) {
+    companion object {
+        fun from(scenario: Scenario): ScenarioFingerprint = ScenarioFingerprint(
+            status = scenario.status,
+            requestContentType = scenario.requestContentType,
+            responseContentType = scenario.responseContentType,
+            httpRequestPattern = scenario.httpRequestPattern,
+            httpResponsePattern = scenario.httpResponsePattern,
+        )
+
+        fun changeStatusBetween(
+            oldScenarios: Collection<Scenario>,
+            newScenarios: Collection<Scenario>,
+        ): ChangeStatus {
+            val oldFingerprints = oldScenarios.map(::from).toSet()
+            val newFingerprints = newScenarios.map(::from).toSet()
+            return if (oldFingerprints == newFingerprints) ChangeStatus.UNCHANGED else ChangeStatus.CHANGED
+        }
+    }
+}

--- a/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
@@ -9,6 +9,14 @@ data class ScenarioFingerprint(
     val httpRequestPattern: HttpRequestPattern,
     val httpResponsePattern: HttpResponsePattern,
 ) {
+    data class Key(
+        val path: String,
+        val method: String,
+        val requestContentType: String?,
+        val status: Int,
+        val responseContentType: String?,
+    )
+
     companion object {
         fun from(scenario: Scenario): ScenarioFingerprint = ScenarioFingerprint(
             status = scenario.status,
@@ -18,13 +26,24 @@ data class ScenarioFingerprint(
             httpResponsePattern = scenario.httpResponsePattern,
         )
 
+        fun keyOf(scenario: Scenario): Key = Key(
+            path = scenario.path,
+            method = scenario.method,
+            requestContentType = scenario.requestContentType,
+            status = scenario.status,
+            responseContentType = scenario.responseContentType,
+        )
+
         fun changeStatusBetween(
             oldScenarios: Collection<Scenario>,
             newScenarios: Collection<Scenario>,
-        ): ChangeStatus {
-            val oldFingerprints = oldScenarios.map(::from).toSet()
-            val newFingerprints = newScenarios.map(::from).toSet()
-            return if (oldFingerprints == newFingerprints) ChangeStatus.UNCHANGED else ChangeStatus.CHANGED
+        ): (Scenario) -> ChangeStatus {
+            val oldByKey = oldScenarios.associate { keyOf(it) to from(it) }
+            val newByKey = newScenarios.associate { keyOf(it) to from(it) }
+            val statusByKey = (oldByKey.keys + newByKey.keys).associateWith { key ->
+                if (oldByKey[key] == newByKey[key]) ChangeStatus.UNCHANGED else ChangeStatus.CHANGED
+            }
+            return { scenario -> statusByKey[keyOf(scenario)] ?: ChangeStatus.CHANGED }
         }
     }
 }

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -33,6 +33,33 @@ class ScenarioFingerprintTest {
                   description: created
     """.trimIndent()
 
+    private val componentRefSpec = """
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      ${'$'}ref: '#/components/schemas/Order'
+              responses:
+                '201':
+                  description: created
+        components:
+          schemas:
+            Order:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+    """.trimIndent()
+
     @Test
     fun `from copies identifying fields and patterns off the scenario`() {
         val scenario = singleScenarioFrom(baseSpec)
@@ -110,6 +137,18 @@ class ScenarioFingerprintTest {
               path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
               value:
                 type: string
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns CHANGED when a referenced component schema changes`() {
+        val old = scenariosFrom(componentRefSpec)
+        val new = scenariosFrom(componentRefSpec.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/Order/properties/id/type
+              value: integer
         """.trimIndent()))
 
         assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -126,7 +126,7 @@ class ScenarioFingerprintTest {
         val old = scenariosFrom(baseSpec)
         val new = scenariosFrom(baseSpec)
 
-        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
+        assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
     }
 
     @Test
@@ -139,7 +139,7 @@ class ScenarioFingerprintTest {
                 type: string
         """.trimIndent()))
 
-        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.CHANGED)
     }
 
     @Test
@@ -151,7 +151,7 @@ class ScenarioFingerprintTest {
               value: integer
         """.trimIndent()))
 
-        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.CHANGED)
     }
 
     @Test
@@ -172,7 +172,7 @@ class ScenarioFingerprintTest {
               value: integer
         """.trimIndent()))
 
-        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
+        assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
     }
 
     @Test
@@ -185,7 +185,7 @@ class ScenarioFingerprintTest {
                 description: bad request
         """.trimIndent()))
 
-        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.CHANGED)
     }
 
     @Test
@@ -198,12 +198,12 @@ class ScenarioFingerprintTest {
         """.trimIndent()))
         val new = scenariosFrom(baseSpec)
 
-        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(aggregateChangeStatus(old, new)).isEqualTo(ChangeStatus.CHANGED)
     }
 
     @Test
     fun `changeStatusBetween returns UNCHANGED when both sides are empty`() {
-        assertThat(ScenarioFingerprint.changeStatusBetween(emptyList(), emptyList()))
+        assertThat(aggregateChangeStatus(emptyList(), emptyList()))
             .isEqualTo(ChangeStatus.UNCHANGED)
     }
 
@@ -211,10 +211,18 @@ class ScenarioFingerprintTest {
     fun `changeStatusBetween returns CHANGED when an operation appears only on one side`() {
         val onlyOnNew = scenariosFrom(baseSpec)
 
-        assertThat(ScenarioFingerprint.changeStatusBetween(emptyList(), onlyOnNew))
+        assertThat(aggregateChangeStatus(emptyList(), onlyOnNew))
             .isEqualTo(ChangeStatus.CHANGED)
-        assertThat(ScenarioFingerprint.changeStatusBetween(onlyOnNew, emptyList()))
+        assertThat(aggregateChangeStatus(onlyOnNew, emptyList()))
             .isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    private fun aggregateChangeStatus(old: Collection<Scenario>, new: Collection<Scenario>): ChangeStatus {
+        val statusFor = ScenarioFingerprint.changeStatusBetween(old, new)
+        val allScenarios = (old + new).distinctBy(ScenarioFingerprint.Companion::keyOf)
+        if (allScenarios.isEmpty()) return ChangeStatus.UNCHANGED
+        return if (allScenarios.any { statusFor(it) == ChangeStatus.CHANGED }) ChangeStatus.CHANGED
+        else ChangeStatus.UNCHANGED
     }
 
     private fun scenariosFrom(yaml: String): List<Scenario> =

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -1,0 +1,172 @@
+package io.specmatic.core
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.flipkart.zjsonpatch.JsonPatch
+import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ScenarioFingerprintTest {
+
+    private val baseSpec = """
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required: [id]
+                      properties:
+                        id:
+                          type: string
+              responses:
+                '201':
+                  description: created
+    """.trimIndent()
+
+    @Test
+    fun `from copies identifying fields and patterns off the scenario`() {
+        val scenario = singleScenarioFrom(baseSpec)
+
+        val fingerprint = ScenarioFingerprint.from(scenario)
+
+        assertThat(fingerprint.status).isEqualTo(scenario.status)
+        assertThat(fingerprint.requestContentType).isEqualTo(scenario.requestContentType)
+        assertThat(fingerprint.responseContentType).isEqualTo(scenario.responseContentType)
+        assertThat(fingerprint.httpRequestPattern).isEqualTo(scenario.httpRequestPattern)
+        assertThat(fingerprint.httpResponsePattern).isEqualTo(scenario.httpResponsePattern)
+    }
+
+    @Test
+    fun `fingerprints of structurally identical scenarios are equal`() {
+        val first = singleScenarioFrom(baseSpec)
+        val second = singleScenarioFrom(baseSpec)
+
+        assertThat(ScenarioFingerprint.from(first)).isEqualTo(ScenarioFingerprint.from(second))
+    }
+
+    @Test
+    fun `fingerprints differ when request body shape differs`() {
+        val original = singleScenarioFrom(baseSpec)
+        val withExtraField = singleScenarioFrom(baseSpec.applyJsonPatch("""
+            - op: add
+              path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+              value:
+                type: string
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.from(original))
+            .isNotEqualTo(ScenarioFingerprint.from(withExtraField))
+    }
+
+    @Test
+    fun `fingerprints differ when response status differs`() {
+        val original = singleScenarioFrom(baseSpec)
+        val differentStatus = singleScenarioFrom(baseSpec.applyJsonPatch("""
+            - op: move
+              from: /paths/~1orders/post/responses/201
+              path: /paths/~1orders/post/responses/202
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.from(original))
+            .isNotEqualTo(ScenarioFingerprint.from(differentStatus))
+    }
+
+    @Test
+    fun `fingerprints differ when request content type differs`() {
+        val original = singleScenarioFrom(baseSpec)
+        val differentContentType = singleScenarioFrom(baseSpec.applyJsonPatch("""
+            - op: move
+              from: /paths/~1orders/post/requestBody/content/application~1json
+              path: /paths/~1orders/post/requestBody/content/application~1vnd.orders+json
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.from(original))
+            .isNotEqualTo(ScenarioFingerprint.from(differentContentType))
+    }
+
+    @Test
+    fun `changeStatusBetween returns UNCHANGED for identical scenario sets`() {
+        val old = scenariosFrom(baseSpec)
+        val new = scenariosFrom(baseSpec)
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns CHANGED when a structural diff exists`() {
+        val old = scenariosFrom(baseSpec)
+        val new = scenariosFrom(baseSpec.applyJsonPatch("""
+            - op: add
+              path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+              value:
+                type: string
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns CHANGED when a scenario is added`() {
+        val old = scenariosFrom(baseSpec)
+        val new = scenariosFrom(baseSpec.applyJsonPatch("""
+            - op: add
+              path: /paths/~1orders/post/responses/400
+              value:
+                description: bad request
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns CHANGED when a scenario is removed`() {
+        val old = scenariosFrom(baseSpec.applyJsonPatch("""
+            - op: add
+              path: /paths/~1orders/post/responses/400
+              value:
+                description: bad request
+        """.trimIndent()))
+        val new = scenariosFrom(baseSpec)
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns UNCHANGED when both sides are empty`() {
+        assertThat(ScenarioFingerprint.changeStatusBetween(emptyList(), emptyList()))
+            .isEqualTo(ChangeStatus.UNCHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns CHANGED when an operation appears only on one side`() {
+        val onlyOnNew = scenariosFrom(baseSpec)
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(emptyList(), onlyOnNew))
+            .isEqualTo(ChangeStatus.CHANGED)
+        assertThat(ScenarioFingerprint.changeStatusBetween(onlyOnNew, emptyList()))
+            .isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    private fun scenariosFrom(yaml: String): List<Scenario> =
+        OpenApiSpecification.fromYAML(yaml, "test.yaml").toFeature().scenarios
+
+    private fun singleScenarioFrom(yaml: String): Scenario = scenariosFrom(yaml).single()
+
+    private fun String.applyJsonPatch(patch: String): String {
+        val specNode = yamlMapper.readTree(this)
+        val patchNode = yamlMapper.readTree(patch.trimIndent())
+        return yamlMapper.writeValueAsString(JsonPatch.apply(patchNode, specNode)).trim()
+    }
+
+    private val yamlMapper = ObjectMapper(YAMLFactory())
+}

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -33,6 +33,33 @@ class ScenarioFingerprintTest {
                   description: created
     """.trimIndent()
 
+    private val componentRefSpec = """
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      ${'$'}ref: '#/components/schemas/Order'
+              responses:
+                '201':
+                  description: created
+        components:
+          schemas:
+            Order:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+    """.trimIndent()
+
     @Test
     fun `from copies identifying fields and patterns off the scenario`() {
         val scenario = singleScenarioFrom(baseSpec)
@@ -116,6 +143,39 @@ class ScenarioFingerprintTest {
     }
 
     @Test
+    fun `changeStatusBetween returns CHANGED when a referenced component schema changes`() {
+        val old = scenariosFrom(componentRefSpec)
+        val new = scenariosFrom(componentRefSpec.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/Order/properties/id/type
+              value: integer
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns UNCHANGED when an unused component schema changes`() {
+        val specWithUnusedComponent = componentRefSpec.applyJsonPatch("""
+            - op: add
+              path: /components/schemas/Unused
+              value:
+                type: object
+                properties:
+                  name:
+                    type: string
+        """.trimIndent())
+        val old = scenariosFrom(specWithUnusedComponent)
+        val new = scenariosFrom(specWithUnusedComponent.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/Unused/properties/name/type
+              value: integer
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
+    }
+
+    @Test
     fun `changeStatusBetween returns CHANGED when a scenario is added`() {
         val old = scenariosFrom(baseSpec)
         val new = scenariosFrom(baseSpec.applyJsonPatch("""
@@ -158,7 +218,7 @@ class ScenarioFingerprintTest {
     }
 
     private fun scenariosFrom(yaml: String): List<Scenario> =
-        OpenApiSpecification.fromYAML(yaml, "test.yaml").toFeature().scenarios
+        OpenApiSpecification.fromYAML(yaml, "test.yaml").toFeature().scenariosForChangeTracking()
 
     private fun singleScenarioFrom(yaml: String): Scenario = scenariosFrom(yaml).single()
 

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.flipkart.zjsonpatch.JsonPatch
 import io.specmatic.conversions.OpenApiSpecification
+import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import io.specmatic.core.utilities.Flags.Companion.using
 import io.specmatic.core.log.Verbose
@@ -16,8 +17,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.util.stream.Stream
 
 internal class TestBackwardCompatibilityKtTest {
     private fun assertBackwardCompatibilityFailure(results: Results, expectedReport: String) {
@@ -4723,6 +4728,7 @@ paths:
     }
 
     @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class OperationChangeStatus {
         private val baseSpec = """
             openapi: 3.0.0
@@ -4734,7 +4740,7 @@ paths:
                 get:
                   responses:
                     '200':
-                      description: List orders
+                      description: ok
                       content:
                         application/json:
                           schema:
@@ -4758,39 +4764,75 @@ paths:
                               type: string
                   responses:
                     '201':
-                      description: Created
+                      description: created
+              /orders/{id}:
+                get:
+                  parameters:
+                    - name: id
+                      in: path
+                      required: true
+                      schema:
+                        type: string
+                  responses:
+                    '200':
+                      description: ok
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
         """.trimIndent()
 
-        @Test
-        fun `only the patched POST operation is CHANGED, the untouched GET stays UNCHANGED`(@TempDir tempDir: File) {
-            val newerSpecPatch = """
-                - op: add
-                  path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
-                  value:
-                    type: string
-            """.trimIndent()
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("changeStatusCases")
+        fun `change status detection`(case: ChangeStatusCase, @TempDir tempDir: File) {
+            val oldSpec = case.oldPatch?.let { baseSpec.applyJsonPatch(it) } ?: baseSpec
+            val newSpec = case.newPatch?.let { baseSpec.applyJsonPatch(it) } ?: baseSpec
 
-            val operations = runBccAndGetOperations(tempDir, baseSpec, newerSpecPatch)
+            val operations = runBccAndGetOperations(tempDir, oldSpec, newSpec)
+            val op = operations.first {
+                it.path("path").asText() == case.path && it.path("method").asText() == case.method
+            }
 
-            val getOp = operations.first { it.path("method").asText() == "GET" }
-            val postOp = operations.first { it.path("method").asText() == "POST" }
-
-            assertThat(getOp.path("compatibility").path("changeStatus").asText()).isEqualTo("UNCHANGED")
-            assertThat(postOp.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
+            assertThat(op.path("compatibility").path("changeStatus").asText())
+                .isEqualTo(case.expected.name)
         }
 
-        private fun runBccAndGetOperations(tempDir: File, oldSpec: String, newSpecPatch: String): JsonNode {
+        // TODO(product): decide whether new-only operations should surface as CHANGED in the BCC report.
+        // Today OpenApiBackwardCompatibilityChecker iterates over old scenarios only, so an operation
+        // present in the new spec but absent in the old spec produces no record and is not reported.
+        // If we want it to appear (likely as CHANGED + Incompatible "added in new"), the checker must
+        // iterate over the union of (path, method) pairs from old and new.
+        @Test
+        fun `new-only operations are absent from the report today`(@TempDir tempDir: File) {
+            val newSpec = baseSpec.applyJsonPatch("""
+                - op: add
+                  path: /paths/~1health
+                  value:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(tempDir, baseSpec, newSpec).toList()
+
+            val operationKeys = operations.map { "${it.path("method").asText()} ${it.path("path").asText()}" }
+            assertThat(operationKeys).doesNotContain("GET /health")
+        }
+
+        private fun runBccAndGetOperations(tempDir: File, oldSpec: String, newSpec: String): JsonNode {
             val configFile = tempDir.resolve("specmatic.yaml").apply {
                 writeText("""
                 version: 2
                 reportDirPath: ${tempDir.canonicalPath}/reports
                 """.trimIndent())
             }
-            val oldSpecFile = tempDir.resolve("old.yaml").apply { writeText(oldSpec) }
-            val newSpecFile = tempDir.resolve("new.yaml").apply { writeText(oldSpec.applyJsonPatch(newSpecPatch)) }
-
-            val oldFeature = OpenApiSpecification.fromFile(oldSpecFile.canonicalPath).toFeature()
-            val newFeature = OpenApiSpecification.fromFile(newSpecFile.canonicalPath).toFeature()
+            val oldFeature = OpenApiSpecification.fromYAML(oldSpec, "old.yaml").toFeature()
+            val newFeature = OpenApiSpecification.fromYAML(newSpec, "new.yaml").toFeature()
 
             return using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
                 val (_, report) = testBackwardCompatibilityWithReport(oldFeature, newFeature)
@@ -4801,13 +4843,332 @@ paths:
 
         private fun String.applyJsonPatch(patch: String): String {
             val specNode = yamlMapper.readTree(this)
-            val patchNode = yamlMapper.readTree(patch)
-            val patched = JsonPatch.apply(patchNode, specNode)
-            return yamlMapper.writeValueAsString(patched)
+            val patchNode = yamlMapper.readTree(patch.trimIndent())
+            return yamlMapper.writeValueAsString(JsonPatch.apply(patchNode, specNode)).trim()
         }
 
         private val yamlMapper = ObjectMapper(YAMLFactory())
+
+        private fun changeStatusCases(): Stream<ChangeStatusCase> = Stream.of(
+            ChangeStatusCase(
+                name = "1. identical specs are UNCHANGED",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.UNCHANGED,
+            ),
+            ChangeStatusCase(
+                name = "2. add optional request body field",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "3. add required request body field",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/required/-
+                      value: note
+                """,
+            ),
+            ChangeStatusCase(
+                name = "4. remove optional request body field",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "5. remove required request body field",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/required/-
+                      value: note
+                """,
+            ),
+            ChangeStatusCase(
+                name = "6. required request field becomes optional",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/required/-
+                      value: note
+                """,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "7. optional request field becomes required",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                """,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                      value:
+                        type: string
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/required/-
+                      value: note
+                """,
+            ),
+            ChangeStatusCase(
+                name = "8. change request field type",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/id/type
+                      value: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "9. add optional query parameter",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/parameters
+                      value:
+                        - name: limit
+                          in: query
+                          required: false
+                          schema:
+                            type: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "10. add required query parameter",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/parameters
+                      value:
+                        - name: limit
+                          in: query
+                          required: true
+                          schema:
+                            type: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "11. add optional request header",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/parameters
+                      value:
+                        - name: X-Trace-Id
+                          in: header
+                          required: false
+                          schema:
+                            type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "12. add required request header",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/parameters
+                      value:
+                        - name: X-Trace-Id
+                          in: header
+                          required: true
+                          schema:
+                            type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "13. add optional response field",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/note
+                      value:
+                        type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "14. remove response field that old promised",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/note
+                      value:
+                        type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "15. change response field type",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: replace
+                      path: /paths/~1orders/get/responses/200/content/application~1json/schema/items/properties/id/type
+                      value: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "16. add a new response status code",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/responses/400
+                      value:
+                        description: bad request
+                """,
+            ),
+            ChangeStatusCase(
+                name = "17. remove a response status code that existed in old",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/responses/400
+                      value:
+                        description: bad request
+                """,
+            ),
+            ChangeStatusCase(
+                name = "18. add a new request content type",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/text~1plain
+                      value:
+                        schema:
+                          type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "19. remove a request content type from old",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/text~1plain
+                      value:
+                        schema:
+                          type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "20. add a new response content type",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/responses/200/content/text~1plain
+                      value:
+                        schema:
+                          type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "21. remove a response content type from old",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/responses/200/content/text~1plain
+                      value:
+                        schema:
+                          type: string
+                """,
+            ),
+            ChangeStatusCase(
+                name = "22. change path parameter type",
+                path = "/orders/{id}", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: replace
+                      path: /paths/~1orders~1{id}/get/parameters/0/schema/type
+                      value: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "23. add a security scheme requirement",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        securitySchemes:
+                          apiKey:
+                            type: apiKey
+                            in: header
+                            name: X-API-Key
+                    - op: add
+                      path: /paths/~1orders/post/security
+                      value:
+                        - apiKey: []
+                """,
+            ),
+            ChangeStatusCase(
+                name = "24. operation present in old, removed in new",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                    - op: remove
+                      path: /paths/~1orders/post
+                """,
+            ),
+        )
+
     }
+}
+
+internal data class ChangeStatusCase(
+    val name: String,
+    val path: String,
+    val method: String,
+    val expected: ChangeStatus,
+    val oldPatch: String? = null,
+    val newPatch: String? = null,
+) {
+    override fun toString(): String = name
 }
 
 private fun String.openAPIToContract(): Feature {

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5198,15 +5198,10 @@ paths:
                             id: "abc"
                 """,
             ),
-            // TODO(product): refactoring an inline schema into a \$ref (or back) currently registers
-            // as CHANGED because Specmatic's resolved patterns carry a typeAlias derived from the
-            // \$ref name, which the inline form lacks. From a backwards-compatibility standpoint the
-            // schemas are equivalent — consider normalising the fingerprint to drop typeAlias if we
-            // want refactoring-only diffs to surface as UNCHANGED.
             ChangeStatusCase(
-                name = "30. schema referenced via \$ref in old, inlined in new — currently CHANGED",
+                name = "30. schema referenced via \$ref in old, inlined in new",
                 path = "/orders", method = "POST",
-                expected = ChangeStatus.CHANGED,
+                expected = ChangeStatus.UNCHANGED,
                 oldPatch = """
                     - op: add
                       path: /components
@@ -5225,7 +5220,47 @@ paths:
                 """,
             ),
             ChangeStatusCase(
-                name = "31. required array and properties reordered",
+                name = "31. schema referenced via same \$ref has component schema changed",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                    - op: replace
+                      path: /components/schemas/Order/properties/id/type
+                      value: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "32. required array and properties reordered",
                 path = "/orders", method = "POST",
                 expected = ChangeStatus.UNCHANGED,
                 oldPatch = """

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5225,7 +5225,47 @@ paths:
                 """,
             ),
             ChangeStatusCase(
-                name = "31. required array and properties reordered",
+                name = "31. schema referenced via same \$ref has component schema changed",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                    - op: replace
+                      path: /components/schemas/Order/properties/id/type
+                      value: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "32. required array and properties reordered",
                 path = "/orders", method = "POST",
                 expected = ChangeStatus.UNCHANGED,
                 oldPatch = """

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4794,11 +4794,146 @@ paths:
 
             val operations = runBccAndGetOperations(tempDir, oldSpec, newSpec)
             val op = operations.first {
-                it.path("path").asText() == case.path && it.path("method").asText() == case.method
+                it.path("path").asText() == case.path &&
+                it.path("method").asText() == case.method &&
+                (case.responseCode == null || it.path("responseCode").asInt() == case.responseCode) &&
+                (case.requestContentType == null || it.path("contentType").asText() == case.requestContentType) &&
+                (case.responseContentType == null || it.path("responseContentType").asText() == case.responseContentType)
             }
 
             assertThat(op.path("compatibility").path("changeStatus").asText())
                 .isEqualTo(case.expected.name)
+        }
+
+        @Test
+        fun `when only one response status changes, other response statuses stay UNCHANGED`(@TempDir tempDir: File) {
+            val twoStatusSpec = """
+                openapi: 3.0.0
+                info: { title: Orders API, version: 1.0.0 }
+                paths:
+                  /orders:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [id]
+                                properties: { id: { type: string } }
+                        '400':
+                          description: bad
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [message]
+                                properties: { message: { type: string } }
+            """.trimIndent()
+
+            val newSpec = twoStatusSpec.applyJsonPatch("""
+                - op: replace
+                  path: /paths/~1orders/get/responses/400/content/application~1json/schema/properties/message/type
+                  value: integer
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(tempDir, twoStatusSpec, newSpec)
+
+            assertThat(operations.changeStatusFor(method = "GET", responseCode = 200)).isEqualTo("UNCHANGED")
+            assertThat(operations.changeStatusFor(method = "GET", responseCode = 400)).isEqualTo("CHANGED")
+        }
+
+        @Test
+        fun `when only one response content type changes, other response content types stay UNCHANGED`(@TempDir tempDir: File) {
+            val twoContentTypeSpec = """
+                openapi: 3.0.0
+                info: { title: Orders API, version: 1.0.0 }
+                paths:
+                  /orders:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [id]
+                                properties: { id: { type: string } }
+                            application/vnd.orders.v2+json:
+                              schema:
+                                type: object
+                                required: [id]
+                                properties: { id: { type: string } }
+            """.trimIndent()
+
+            val newSpec = twoContentTypeSpec.applyJsonPatch("""
+                - op: replace
+                  path: /paths/~1orders/get/responses/200/content/application~1vnd.orders.v2+json/schema/properties/id/type
+                  value: integer
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(tempDir, twoContentTypeSpec, newSpec)
+
+            assertThat(operations.changeStatusFor(method = "GET", responseCode = 200, responseContentType = "application/json"))
+                .isEqualTo("UNCHANGED")
+            assertThat(operations.changeStatusFor(method = "GET", responseCode = 200, responseContentType = "application/vnd.orders.v2+json"))
+                .isEqualTo("CHANGED")
+        }
+
+        @Test
+        fun `when only one request content type changes, other request content types stay UNCHANGED`(@TempDir tempDir: File) {
+            val twoRequestContentTypeSpec = """
+                openapi: 3.0.0
+                info: { title: Orders API, version: 1.0.0 }
+                paths:
+                  /orders:
+                    post:
+                      requestBody:
+                        required: true
+                        content:
+                          application/json:
+                            schema:
+                              type: object
+                              required: [id]
+                              properties: { id: { type: string } }
+                          application/vnd.orders.v2+json:
+                            schema:
+                              type: object
+                              required: [id]
+                              properties: { id: { type: string } }
+                      responses:
+                        '201': { description: created }
+            """.trimIndent()
+
+            val newSpec = twoRequestContentTypeSpec.applyJsonPatch("""
+                - op: replace
+                  path: /paths/~1orders/post/requestBody/content/application~1vnd.orders.v2+json/schema/properties/id/type
+                  value: integer
+            """.trimIndent())
+
+            val operations = runBccAndGetOperations(tempDir, twoRequestContentTypeSpec, newSpec)
+
+            assertThat(operations.changeStatusFor(method = "POST", contentType = "application/json")).isEqualTo("UNCHANGED")
+            assertThat(operations.changeStatusFor(method = "POST", contentType = "application/vnd.orders.v2+json")).isEqualTo("CHANGED")
+        }
+
+        private fun JsonNode.changeStatusFor(
+            method: String,
+            path: String = "/orders",
+            responseCode: Int? = null,
+            contentType: String? = null,
+            responseContentType: String? = null,
+        ): String {
+            val operation = first {
+                it.path("path").asText() == path &&
+                it.path("method").asText() == method &&
+                (responseCode == null || it.path("responseCode").asInt() == responseCode) &&
+                (contentType == null || it.path("contentType").asText() == contentType) &&
+                (responseContentType == null || it.path("responseContentType").asText() == responseContentType)
+            }
+            return operation.path("compatibility").path("changeStatus").asText()
         }
 
         // TODO(product): decide whether new-only operations should surface as CHANGED in the BCC report.
@@ -5047,10 +5182,13 @@ paths:
                       value: integer
                 """,
             ),
+            // The newly-added 400 row does not appear in today's report (checker iterates old scenarios
+            // only - see `new-only operations are absent from the report today`). The existing 200 row
+            // is identical between old and new, so per-5-tuple it stays UNCHANGED.
             ChangeStatusCase(
-                name = "16. add a new response status code",
-                path = "/orders", method = "GET",
-                expected = ChangeStatus.CHANGED,
+                name = "16. add a new response status code - existing 200 row stays UNCHANGED",
+                path = "/orders", method = "GET", responseCode = 200,
+                expected = ChangeStatus.UNCHANGED,
                 newPatch = """
                     - op: add
                       path: /paths/~1orders/get/responses/400
@@ -5060,7 +5198,7 @@ paths:
             ),
             ChangeStatusCase(
                 name = "17. remove a response status code that existed in old",
-                path = "/orders", method = "GET",
+                path = "/orders", method = "GET", responseCode = 400,
                 expected = ChangeStatus.CHANGED,
                 oldPatch = """
                     - op: add
@@ -5069,10 +5207,12 @@ paths:
                         description: bad request
                 """,
             ),
+            // Newly-added text/plain request row does not appear in today's report; the existing
+            // application/json row is unchanged between old and new.
             ChangeStatusCase(
-                name = "18. add a new request content type",
-                path = "/orders", method = "POST",
-                expected = ChangeStatus.CHANGED,
+                name = "18. add a new request content type - existing json row stays UNCHANGED",
+                path = "/orders", method = "POST", requestContentType = "application/json",
+                expected = ChangeStatus.UNCHANGED,
                 newPatch = """
                     - op: add
                       path: /paths/~1orders/post/requestBody/content/text~1plain
@@ -5081,10 +5221,13 @@ paths:
                           type: string
                 """,
             ),
+            // The removed text/plain row is collapsed into the surviving json row by the checker's
+            // content-type fallback in `findExactOrSingle`, so it never gets its own report row.
+            // The surviving json row is semantically unchanged.
             ChangeStatusCase(
-                name = "19. remove a request content type from old",
-                path = "/orders", method = "POST",
-                expected = ChangeStatus.CHANGED,
+                name = "19. remove a request content type from old - surviving json row stays UNCHANGED",
+                path = "/orders", method = "POST", requestContentType = "application/json",
+                expected = ChangeStatus.UNCHANGED,
                 oldPatch = """
                     - op: add
                       path: /paths/~1orders/post/requestBody/content/text~1plain
@@ -5093,10 +5236,12 @@ paths:
                           type: string
                 """,
             ),
+            // Newly-added text/plain response row does not appear in today's report; the existing
+            // application/json row is unchanged between old and new.
             ChangeStatusCase(
-                name = "20. add a new response content type",
-                path = "/orders", method = "GET",
-                expected = ChangeStatus.CHANGED,
+                name = "20. add a new response content type - existing json row stays UNCHANGED",
+                path = "/orders", method = "GET", responseCode = 200, responseContentType = "application/json",
+                expected = ChangeStatus.UNCHANGED,
                 newPatch = """
                     - op: add
                       path: /paths/~1orders/get/responses/200/content/text~1plain
@@ -5105,10 +5250,11 @@ paths:
                           type: string
                 """,
             ),
+            // Same as #19: the removed text/plain row is collapsed into the surviving json row.
             ChangeStatusCase(
-                name = "21. remove a response content type from old",
-                path = "/orders", method = "GET",
-                expected = ChangeStatus.CHANGED,
+                name = "21. remove a response content type from old - surviving json row stays UNCHANGED",
+                path = "/orders", method = "GET", responseCode = 200, responseContentType = "application/json",
+                expected = ChangeStatus.UNCHANGED,
                 oldPatch = """
                     - op: add
                       path: /paths/~1orders/get/responses/200/content/text~1plain
@@ -5492,6 +5638,9 @@ internal data class ChangeStatusCase(
     val expected: ChangeStatus,
     val oldPatch: String? = null,
     val newPatch: String? = null,
+    val responseCode: Int? = null,
+    val requestContentType: String? = null,
+    val responseContentType: String? = null,
 ) {
     override fun toString(): String = name
 }

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -1,6 +1,9 @@
 package io.specmatic.core
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.flipkart.zjsonpatch.JsonPatch
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import io.specmatic.core.utilities.Flags.Companion.using
@@ -4717,6 +4720,93 @@ paths:
             assertThat(getOperation.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
             assertThat(getOperation.path("compatibility").path("result").asText()).isEqualTo("Compatible")
         }
+    }
+
+    @Nested
+    inner class OperationChangeStatus {
+        private val baseSpec = """
+            openapi: 3.0.0
+            info:
+              title: Orders API
+              version: 1.0.0
+            paths:
+              /orders:
+                get:
+                  responses:
+                    '200':
+                      description: List orders
+                      content:
+                        application/json:
+                          schema:
+                            type: array
+                            items:
+                              type: object
+                              required: [id]
+                              properties:
+                                id:
+                                  type: string
+                post:
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [id]
+                          properties:
+                            id:
+                              type: string
+                  responses:
+                    '201':
+                      description: Created
+        """.trimIndent()
+
+        @Test
+        fun `only the patched POST operation is CHANGED, the untouched GET stays UNCHANGED`(@TempDir tempDir: File) {
+            val newerSpecPatch = """
+                - op: add
+                  path: /paths/~1orders/post/requestBody/content/application~1json/schema/properties/note
+                  value:
+                    type: string
+            """.trimIndent()
+
+            val operations = runBccAndGetOperations(tempDir, baseSpec, newerSpecPatch)
+
+            val getOp = operations.first { it.path("method").asText() == "GET" }
+            val postOp = operations.first { it.path("method").asText() == "POST" }
+
+            assertThat(getOp.path("compatibility").path("changeStatus").asText()).isEqualTo("UNCHANGED")
+            assertThat(postOp.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
+        }
+
+        private fun runBccAndGetOperations(tempDir: File, oldSpec: String, newSpecPatch: String): JsonNode {
+            val configFile = tempDir.resolve("specmatic.yaml").apply {
+                writeText("""
+                version: 2
+                reportDirPath: ${tempDir.canonicalPath}/reports
+                """.trimIndent())
+            }
+            val oldSpecFile = tempDir.resolve("old.yaml").apply { writeText(oldSpec) }
+            val newSpecFile = tempDir.resolve("new.yaml").apply { writeText(oldSpec.applyJsonPatch(newSpecPatch)) }
+
+            val oldFeature = OpenApiSpecification.fromFile(oldSpecFile.canonicalPath).toFeature()
+            val newFeature = OpenApiSpecification.fromFile(newSpecFile.canonicalPath).toFeature()
+
+            return using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+                val (_, report) = testBackwardCompatibilityWithReport(oldFeature, newFeature)
+                val json = OBJECT_MAPPER.valueToTree<JsonNode>(report)
+                json.path("results").path("summary").path("extra").path("executionDetails").first().path("operations")
+            }
+        }
+
+        private fun String.applyJsonPatch(patch: String): String {
+            val specNode = yamlMapper.readTree(this)
+            val patchNode = yamlMapper.readTree(patch)
+            val patched = JsonPatch.apply(patchNode, specNode)
+            return yamlMapper.writeValueAsString(patched)
+        }
+
+        private val yamlMapper = ObjectMapper(YAMLFactory())
     }
 }
 

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4728,6 +4728,71 @@ paths:
     }
 
     @Nested
+    inner class BccIntegrationFromFixtures {
+        @Test
+        fun `report reflects per-5-tuple change status and compatibility result across refs, components, and recursion`(@TempDir tempDir: File) {
+            val oldSpec = readFixture("orders_old.yaml")
+            val newSpec = readFixture("orders_new.yaml")
+
+            val operations = runBccAndGetOperations(tempDir, oldSpec, newSpec)
+
+            // Order gains optional `notes` -> CHANGED + Compatible on every Order-using row
+            operations.assertRow(method = "GET", path = "/orders", responseCode = 200, changeStatus = "CHANGED", result = "Compatible")
+            operations.assertRow(method = "POST", path = "/orders", responseCode = 201, changeStatus = "CHANGED", result = "Compatible")
+            operations.assertRow(method = "GET", path = "/orders/{id}", responseCode = 200, changeStatus = "CHANGED", result = "Compatible")
+
+            // ErrorBrief.code string -> integer is reachable ONLY from GET /orders 400
+            operations.assertRow(method = "GET", path = "/orders", responseCode = 400, changeStatus = "CHANGED", result = "Incompatible")
+
+            // GET /orders/{id} 404 uses ErrorDetailed (untouched) - proves per-5-tuple isolation
+            // even though GET /orders 400 under the same kind of error response did change
+            operations.assertRow(method = "GET", path = "/orders/{id}", responseCode = 404, changeStatus = "UNCHANGED", result = "Compatible")
+
+            // Self-recursive Category gains optional `description`
+            operations.assertRow(method = "GET", path = "/categories", responseCode = 200, changeStatus = "CHANGED", result = "Compatible")
+
+            // Sanity: the report has exactly the rows we asserted above and no more
+            assertThat(operations.toList())
+                .describedAs("expected 6 operation rows in the report")
+                .hasSize(6)
+        }
+
+        private fun JsonNode.assertRow(method: String, path: String, responseCode: Int, changeStatus: String, result: String) {
+            val row = firstOrNull {
+                it.path("method").asText() == method &&
+                it.path("path").asText() == path &&
+                it.path("responseCode").asInt() == responseCode
+            } ?: throw AssertionError("No operation row for $method $path $responseCode. Rows present: ${this.joinToString { "${it.path("method").asText()} ${it.path("path").asText()} ${it.path("responseCode").asInt()}" }}")
+            assertThat(row.path("compatibility").path("changeStatus").asText())
+                .describedAs("changeStatus for $method $path $responseCode")
+                .isEqualTo(changeStatus)
+            assertThat(row.path("compatibility").path("result").asText())
+                .describedAs("result for $method $path $responseCode")
+                .isEqualTo(result)
+        }
+
+        private fun readFixture(name: String): String =
+            javaClass.getResource("/openapi/bcc_integration/$name")!!.readText()
+
+        private fun runBccAndGetOperations(tempDir: File, oldSpec: String, newSpec: String): JsonNode {
+            val configFile = tempDir.resolve("specmatic.yaml").apply {
+                writeText("""
+                version: 2
+                reportDirPath: ${tempDir.canonicalPath}/reports
+                """.trimIndent())
+            }
+            val oldFeature = OpenApiSpecification.fromYAML(oldSpec, "old.yaml").toFeature()
+            val newFeature = OpenApiSpecification.fromYAML(newSpec, "new.yaml").toFeature()
+
+            return using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+                val (_, report) = testBackwardCompatibilityWithReport(oldFeature, newFeature)
+                val json = OBJECT_MAPPER.valueToTree<JsonNode>(report)
+                json.path("results").path("summary").path("extra").path("executionDetails").first().path("operations")
+            }
+        }
+    }
+
+    @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     inner class OperationChangeStatus {
         private val baseSpec = """

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4735,39 +4735,61 @@ paths:
             val newSpec = readFixture("orders_new.yaml")
 
             val operations = runBccAndGetOperations(tempDir, oldSpec, newSpec)
+            val json = "application/json"
 
-            // Order gains optional `notes` -> CHANGED + Compatible on every Order-using row
-            operations.assertRow(method = "GET", path = "/orders", responseCode = 200, changeStatus = "CHANGED", result = "Compatible")
-            operations.assertRow(method = "POST", path = "/orders", responseCode = 201, changeStatus = "CHANGED", result = "Compatible")
-            operations.assertRow(method = "GET", path = "/orders/{id}", responseCode = 200, changeStatus = "CHANGED", result = "Compatible")
+            // NEW-SIDE N1: Order gains optional `notes` -> CHANGED + Compatible on every Order-using row
+            operations.assertRow(OperationKey("GET", "/orders", null, 200, json), changeStatus = "CHANGED", result = "Compatible")
+            operations.assertRow(OperationKey("POST", "/orders", json, 201, json), changeStatus = "CHANGED", result = "Compatible")
+            operations.assertRow(OperationKey("GET", "/orders/{id}", null, 200, json), changeStatus = "CHANGED", result = "Compatible")
 
-            // ErrorBrief.code string -> integer is reachable ONLY from GET /orders 400
-            operations.assertRow(method = "GET", path = "/orders", responseCode = 400, changeStatus = "CHANGED", result = "Incompatible")
+            // NEW-SIDE N2: ErrorBrief.code string -> integer (reachable ONLY from GET /orders 400)
+            operations.assertRow(OperationKey("GET", "/orders", null, 400, json), changeStatus = "CHANGED", result = "Incompatible")
 
-            // GET /orders/{id} 404 uses ErrorDetailed (untouched) - proves per-5-tuple isolation
-            // even though GET /orders 400 under the same kind of error response did change
-            operations.assertRow(method = "GET", path = "/orders/{id}", responseCode = 404, changeStatus = "UNCHANGED", result = "Compatible")
+            // NEW-SIDE N3: Self-recursive Category gains optional `description`
+            operations.assertRow(OperationKey("GET", "/categories", null, 200, json), changeStatus = "CHANGED", result = "Compatible")
 
-            // Self-recursive Category gains optional `description`
-            operations.assertRow(method = "GET", path = "/categories", responseCode = 200, changeStatus = "CHANGED", result = "Compatible")
+            // OLD-SIDE O1 (non-breaking): ErrorDetailed loses optional `traceId`
+            operations.assertRow(OperationKey("GET", "/orders/{id}", null, 404, json), changeStatus = "CHANGED", result = "Compatible")
+
+            // OLD-SIDE O2 (breaking): DELETE /orders/{id} removed from new (no request/response body)
+            operations.assertRow(OperationKey("DELETE", "/orders/{id}", null, 204, null), changeStatus = "CHANGED", result = "Incompatible")
+
+            // OLD-SIDE O3 (breaking): GET /orders 500 response removed from new
+            operations.assertRow(OperationKey("GET", "/orders", null, 500, json), changeStatus = "CHANGED", result = "Incompatible")
+
+            // UNCHANGED 5-tuple sharing a (path, method) with a CHANGED row -
+            // POST /orders 400 uses OrderInput (untouched) for request and ValidationError
+            // (untouched) for response, while POST /orders 201 uses Order (changed) for response.
+            operations.assertRow(OperationKey("POST", "/orders", json, 400, json), changeStatus = "UNCHANGED", result = "Compatible")
+
+            // UNCHANGED standalone operation - GET /health is identical in both specs
+            operations.assertRow(OperationKey("GET", "/health", null, 200, json), changeStatus = "UNCHANGED", result = "Compatible")
 
             // Sanity: the report has exactly the rows we asserted above and no more
             assertThat(operations.toList())
-                .describedAs("expected 6 operation rows in the report")
-                .hasSize(6)
+                .describedAs("expected 10 operation rows in the report")
+                .hasSize(10)
         }
 
-        private fun JsonNode.assertRow(method: String, path: String, responseCode: Int, changeStatus: String, result: String) {
-            val row = firstOrNull {
-                it.path("method").asText() == method &&
-                it.path("path").asText() == path &&
-                it.path("responseCode").asInt() == responseCode
-            } ?: throw AssertionError("No operation row for $method $path $responseCode. Rows present: ${this.joinToString { "${it.path("method").asText()} ${it.path("path").asText()} ${it.path("responseCode").asInt()}" }}")
+        private fun JsonNode.assertRow(key: OperationKey, changeStatus: String, result: String) {
+            val row = firstOrNull { node ->
+                node.path("method").asText() == key.method &&
+                node.path("path").asText() == key.path &&
+                node.path("responseCode").asInt() == key.responseCode &&
+                node.path("contentType").asText().ifEmpty { null } == key.requestContentType &&
+                node.path("responseContentType").asText().ifEmpty { null } == key.responseContentType
+            } ?: throw AssertionError("No operation row matching $key. Rows present:\n" +
+                joinToString("\n") { node ->
+                    "  - method=${node.path("method").asText()} path=${node.path("path").asText()} " +
+                        "reqCT=${node.path("contentType").asText().ifEmpty { "null" }} " +
+                        "status=${node.path("responseCode").asInt()} " +
+                        "resCT=${node.path("responseContentType").asText().ifEmpty { "null" }}"
+                })
             assertThat(row.path("compatibility").path("changeStatus").asText())
-                .describedAs("changeStatus for $method $path $responseCode")
+                .describedAs("changeStatus for $key")
                 .isEqualTo(changeStatus)
             assertThat(row.path("compatibility").path("result").asText())
-                .describedAs("result for $method $path $responseCode")
+                .describedAs("result for $key")
                 .isEqualTo(result)
         }
 
@@ -5695,6 +5717,14 @@ paths:
 
     }
 }
+
+internal data class OperationKey(
+    val method: String,
+    val path: String,
+    val requestContentType: String?,
+    val responseCode: Int,
+    val responseContentType: String?,
+)
 
 internal data class ChangeStatusCase(
     val name: String,

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5713,6 +5713,36 @@ paths:
                             type: string
                 """,
             ),
+            ChangeStatusCase(
+                name = "33. operation path has been modified, parameter name changed",
+                path = "/orders/{orderId}", method = "GET",
+                expected = ChangeStatus.CHANGED,
+                newPatch = """
+                - op: remove
+                  path: /paths/~1orders~1{id}
+                - op: add
+                  path: /paths/~1orders~1{orderId}
+                  value:
+                    get:
+                      parameters:
+                        - name: orderId
+                          in: path
+                          required: true
+                          schema:
+                            type: string
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [id]
+                                properties:
+                                  id:
+                                    type: string
+                """,
+            ),
         )
 
     }

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5260,6 +5260,198 @@ paths:
                 """,
             ),
             ChangeStatusCase(
+                name = "33. self-recursive schema - leaf type changes",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          TreeNode:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                              children:
+                                type: array
+                                items:
+                                  ${'$'}ref: '#/components/schemas/TreeNode'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/TreeNode'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          TreeNode:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: integer
+                              children:
+                                type: array
+                                items:
+                                  ${'$'}ref: '#/components/schemas/TreeNode'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/TreeNode'
+                """,
+            ),
+            ChangeStatusCase(
+                name = "34. mutually recursive schemas - leaf changes on File",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Folder:
+                            type: object
+                            required: [name]
+                            properties:
+                              name:
+                                type: string
+                              files:
+                                type: array
+                                items:
+                                  ${'$'}ref: '#/components/schemas/File'
+                          File:
+                            type: object
+                            required: [name]
+                            properties:
+                              name:
+                                type: string
+                              folder:
+                                ${'$'}ref: '#/components/schemas/Folder'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Folder'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Folder:
+                            type: object
+                            required: [name]
+                            properties:
+                              name:
+                                type: string
+                              files:
+                                type: array
+                                items:
+                                  ${'$'}ref: '#/components/schemas/File'
+                          File:
+                            type: object
+                            required: [name]
+                            properties:
+                              name:
+                                type: integer
+                              folder:
+                                ${'$'}ref: '#/components/schemas/Folder'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Folder'
+                """,
+            ),
+            ChangeStatusCase(
+                name = "35. optional self-recursive parent ref becomes required",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Node:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                              parent:
+                                ${'$'}ref: '#/components/schemas/Node'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Node'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Node:
+                            type: object
+                            required: [id, parent]
+                            properties:
+                              id:
+                                type: string
+                              parent:
+                                ${'$'}ref: '#/components/schemas/Node'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Node'
+                """,
+            ),
+            ChangeStatusCase(
+                name = "36. self-recursive schema identical is UNCHANGED",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.UNCHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          TreeNode:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                              children:
+                                type: array
+                                items:
+                                  ${'$'}ref: '#/components/schemas/TreeNode'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/TreeNode'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          TreeNode:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                              children:
+                                type: array
+                                items:
+                                  ${'$'}ref: '#/components/schemas/TreeNode'
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/TreeNode'
+                """,
+            ),
+            ChangeStatusCase(
                 name = "32. required array and properties reordered",
                 path = "/orders", method = "POST",
                 expected = ChangeStatus.UNCHANGED,

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5155,6 +5155,104 @@ paths:
                       path: /paths/~1orders/post
                 """,
             ),
+            ChangeStatusCase(
+                name = "26. only operation description text changed",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.UNCHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/description
+                      value: List all orders
+                """,
+            ),
+            ChangeStatusCase(
+                name = "27. only operationId renamed",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.UNCHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/operationId
+                      value: listOrders
+                """,
+            ),
+            ChangeStatusCase(
+                name = "28. only tags changed",
+                path = "/orders", method = "GET",
+                expected = ChangeStatus.UNCHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/get/tags
+                      value: [orders]
+                """,
+            ),
+            ChangeStatusCase(
+                name = "29. only request body example added",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.UNCHANGED,
+                newPatch = """
+                    - op: add
+                      path: /paths/~1orders/post/requestBody/content/application~1json/examples
+                      value:
+                        sample:
+                          value:
+                            id: "abc"
+                """,
+            ),
+            // TODO(product): refactoring an inline schema into a \$ref (or back) currently registers
+            // as CHANGED because Specmatic's resolved patterns carry a typeAlias derived from the
+            // \$ref name, which the inline form lacks. From a backwards-compatibility standpoint the
+            // schemas are equivalent — consider normalising the fingerprint to drop typeAlias if we
+            // want refactoring-only diffs to surface as UNCHANGED.
+            ChangeStatusCase(
+                name = "30. schema referenced via \$ref in old, inlined in new — currently CHANGED",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                """,
+            ),
+            ChangeStatusCase(
+                name = "31. required array and properties reordered",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.UNCHANGED,
+                oldPatch = """
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        type: object
+                        required: [id, note]
+                        properties:
+                          id:
+                            type: string
+                          note:
+                            type: string
+                """,
+                newPatch = """
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        type: object
+                        required: [note, id]
+                        properties:
+                          note:
+                            type: string
+                          id:
+                            type: string
+                """,
+            ),
         )
 
     }

--- a/core/src/test/resources/openapi/bcc_integration/orders_new.yaml
+++ b/core/src/test/resources/openapi/bcc_integration/orders_new.yaml
@@ -1,0 +1,138 @@
+openapi: 3.0.0
+info:
+  title: Orders API
+  version: 1.0.0
+paths:
+  /orders:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Order'
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBrief'
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+  /orders/{id}:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetailed'
+  /categories:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Category'
+components:
+  schemas:
+    Order:
+      type: object
+      required: [id, total, customer]
+      properties:
+        id:
+          type: string
+        total:
+          type: number
+        customer:
+          $ref: '#/components/schemas/Customer'
+        # CHANGE 1: Order gains optional `notes` field.
+        # Reachable from: GET /orders 200, POST /orders request + 201, GET /orders/{id} 200.
+        # Expected: CHANGED + Compatible on every Order-using 5-tuple.
+        notes:
+          type: string
+    Customer:
+      # UNCHANGED on purpose - Customer is referenced by Order but not modified itself.
+      # Order-using rows are still CHANGED (because Order changed), but this confirms
+      # we don't spuriously flag Customer-only specs.
+      type: object
+      required: [name, email]
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+    ErrorBrief:
+      type: object
+      required: [code, message]
+      properties:
+        # CHANGE 2: ErrorBrief.code type changes from string -> integer.
+        # Reachable from: GET /orders 400 only (ErrorDetailed is a separate schema).
+        # Expected: CHANGED + Incompatible on GET /orders 400.
+        # Expected: GET /orders/{id} 404 (uses ErrorDetailed) stays UNCHANGED -
+        #   this proves changeStatus is keyed per 5-tuple, not per (path, method).
+        code:
+          type: integer
+        message:
+          type: string
+    ErrorDetailed:
+      # UNCHANGED on purpose - proves per-5-tuple isolation from ErrorBrief change.
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        traceId:
+          type: string
+    Category:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        # CHANGE 3: Category gains optional `description` field on a self-recursive schema.
+        # Reachable from: GET /categories 200 (Category[] with children: [Category]).
+        # Expected: CHANGED + Compatible on GET /categories 200.
+        # Verifies the fingerprint detects changes through a self-recursive $ref cycle.
+        description:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'

--- a/core/src/test/resources/openapi/bcc_integration/orders_new.yaml
+++ b/core/src/test/resources/openapi/bcc_integration/orders_new.yaml
@@ -26,7 +26,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Order'
+              $ref: '#/components/schemas/OrderInput'
       responses:
         '201':
           description: created
@@ -34,6 +34,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
+        # UNCHANGED 5-tuple - request uses OrderInput (untouched), response
+        # uses ValidationError (untouched). See orders_old.yaml for rationale.
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
   /orders/{id}:
     get:
       parameters:
@@ -55,6 +63,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorDetailed'
+  # UNCHANGED operation - identical to old.
+  /health:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
   /categories:
     get:
       responses:
@@ -78,11 +100,24 @@ components:
           type: number
         customer:
           $ref: '#/components/schemas/Customer'
-        # CHANGE 1: Order gains optional `notes` field.
-        # Reachable from: GET /orders 200, POST /orders request + 201, GET /orders/{id} 200.
-        # Expected: CHANGED + Compatible on every Order-using 5-tuple.
+        # NEW-SIDE CHANGE N1: Order gains optional `notes` field.
+        # Reachable only from RESPONSE bodies (POST uses OrderInput for request).
+        # Expected: CHANGED + Compatible on GET /orders 200, POST /orders 201,
+        # GET /orders/{id} 200.
         notes:
           type: string
+    # OrderInput stays untouched - this is what isolates POST /orders 400 as
+    # UNCHANGED even though POST /orders 201 is CHANGED.
+    OrderInput:
+      type: object
+      required: [id, total, customer]
+      properties:
+        id:
+          type: string
+        total:
+          type: number
+        customer:
+          $ref: '#/components/schemas/Customer'
     Customer:
       # UNCHANGED on purpose - Customer is referenced by Order but not modified itself.
       # Order-using rows are still CHANGED (because Order changed), but this confirms
@@ -107,16 +142,24 @@ components:
           type: integer
         message:
           type: string
+    # UNCHANGED component - identical to old.
+    ValidationError:
+      type: object
+      required: [field, reason]
+      properties:
+        field:
+          type: string
+        reason:
+          type: string
     ErrorDetailed:
-      # UNCHANGED on purpose - proves per-5-tuple isolation from ErrorBrief change.
+      # Mirrors OLD-SIDE CHANGE O1: the `traceId` field that old declared as
+      # optional is gone here. See orders_old.yaml for the change rationale.
       type: object
       required: [code, message]
       properties:
         code:
           type: string
         message:
-          type: string
-        traceId:
           type: string
     Category:
       type: object

--- a/core/src/test/resources/openapi/bcc_integration/orders_old.yaml
+++ b/core/src/test/resources/openapi/bcc_integration/orders_old.yaml
@@ -1,0 +1,118 @@
+openapi: 3.0.0
+info:
+  title: Orders API
+  version: 1.0.0
+paths:
+  /orders:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Order'
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorBrief'
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+  /orders/{id}:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetailed'
+  /categories:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Category'
+components:
+  schemas:
+    Order:
+      type: object
+      required: [id, total, customer]
+      properties:
+        id:
+          type: string
+        total:
+          type: number
+        customer:
+          $ref: '#/components/schemas/Customer'
+    Customer:
+      type: object
+      required: [name, email]
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+    ErrorBrief:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+    ErrorDetailed:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        traceId:
+          type: string
+    Category:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'

--- a/core/src/test/resources/openapi/bcc_integration/orders_old.yaml
+++ b/core/src/test/resources/openapi/bcc_integration/orders_old.yaml
@@ -20,13 +20,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBrief'
+        # OLD-SIDE CHANGE O3 (breaking): old declares a 500 response on GET /orders;
+        # new removes it entirely.
+        # Expected: GET /orders 500 row CHANGED + Incompatible
+        # (BCC iterates old scenarios, finds no matching status in new, emits
+        # "exists in old but not in new").
+        '500':
+          description: server error
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [message]
+                properties:
+                  message:
+                    type: string
     post:
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Order'
+              $ref: '#/components/schemas/OrderInput'
       responses:
         '201':
           description: created
@@ -34,6 +49,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Order'
+        # UNCHANGED 5-tuple under a CHANGED (path, method): POST /orders 400
+        # uses OrderInput (untouched) for request and ValidationError (untouched)
+        # for response. Sits alongside POST /orders 201 (CHANGED because Order
+        # in the response gained `notes`). The clearest per-5-tuple demonstration.
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
   /orders/{id}:
     get:
       parameters:
@@ -55,6 +80,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorDetailed'
+    # OLD-SIDE CHANGE O2 (breaking): old declares DELETE /orders/{id}; new removes
+    # the operation entirely.
+    # Expected: DELETE /orders/{id} 204 row CHANGED + Incompatible
+    # (operation removal is the canonical breaking change).
+    delete:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: deleted
+  # UNCHANGED operation: identical in both specs, returns UNCHANGED + Compatible.
+  /health:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status]
+                properties:
+                  status:
+                    type: string
   /categories:
     get:
       responses:
@@ -69,6 +122,20 @@ paths:
 components:
   schemas:
     Order:
+      type: object
+      required: [id, total, customer]
+      properties:
+        id:
+          type: string
+        total:
+          type: number
+        customer:
+          $ref: '#/components/schemas/Customer'
+    # UNCHANGED component: dedicated request-side schema kept separate from
+    # `Order` so that NEW-SIDE CHANGE N1 (adding `notes` to Order) doesn't
+    # propagate into POST /orders' request fingerprint. This is what lets
+    # POST /orders 400 stay UNCHANGED while POST /orders 201 turns CHANGED.
+    OrderInput:
       type: object
       required: [id, total, customer]
       properties:
@@ -94,6 +161,15 @@ components:
           type: string
         message:
           type: string
+    # UNCHANGED component: referenced only by POST /orders 400.
+    ValidationError:
+      type: object
+      required: [field, reason]
+      properties:
+        field:
+          type: string
+        reason:
+          type: string
     ErrorDetailed:
       type: object
       required: [code, message]
@@ -102,6 +178,11 @@ components:
           type: string
         message:
           type: string
+        # OLD-SIDE CHANGE O1 (non-breaking): old declares optional `traceId` on
+        # ErrorDetailed; new removes the field.
+        # Expected: GET /orders/{id} 404 row CHANGED + Compatible
+        # (dropping an optional response field is non-breaking - old clients
+        # never required it to be present).
         traceId:
           type: string
     Category:


### PR DESCRIPTION
Mark an operation as changed in the BCC report if it was edited in the new spec by fingerprinting scenarios and comparing old vs new scenario.