### PR TITLE
Alternative 2: Use a separate fully resolved schema for change tracking of refs

### DIFF
--- a/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
+++ b/core/src/main/kotlin/io/specmatic/conversions/OpenApiSpecification.kt
@@ -97,7 +97,8 @@ class OpenApiSpecification(
     private val dictionary: Dictionary = loadDictionary(openApiFilePath, specmaticConfig.getDictionary(), strictMode),
     private val logger: LogStrategy = io.specmatic.core.log.logger,
     private val parseCollectorContext: CollectorContext = CollectorContext(),
-    private val exampleDirPaths: List<String> = emptyList()
+    private val exampleDirPaths: List<String> = emptyList(),
+    private val changeTrackingSource: OpenApiChangeTrackingSource? = null,
 ) : IncludedSpecification, ApiSpecification {
     private val extensibleQueryParams: Boolean = specmaticConfig.getExtensibleQueryParams()
     private val preferEscapedSoapAction: Boolean = specmaticConfig.getEscapeSoapAction()
@@ -335,7 +336,40 @@ class OpenApiSpecification(
                 lenientMode = lenientMode,
                 logger = logger,
                 parseCollectorContext = collectorContext,
-                exampleDirPaths = exampleDirPaths
+                exampleDirPaths = exampleDirPaths,
+                changeTrackingSource = OpenApiChangeTrackingSource(
+                    yamlContent = preprocessedYaml,
+                    openApiFilePath = openApiFilePath.replace("\\", "/"),
+                    lenientMode = lenientMode,
+                ),
+            )
+        }
+
+        internal fun fromYAMLForChangeTracking(
+            yamlContent: String,
+            openApiFilePath: String,
+            specmaticConfig: SpecmaticConfig = SpecmaticConfig(),
+            strictMode: Boolean = false,
+            lenientMode: Boolean = false,
+            exampleDirPaths: List<String> = emptyList(),
+        ): OpenApiSpecification {
+            val parseResult: SwaggerParseResult =
+                OpenAPIV3Parser().readContents(
+                    yamlContent,
+                    null,
+                    resolveFullyReferences(),
+                    openApiFilePath.replace("\\", "/")
+                )
+            val parsedOpenApi: OpenAPI = parseResult.openAPI
+                ?: throw ContractException("Could not parse contract $openApiFilePath for change tracking, please validate the syntax using https://editor.swagger.io")
+
+            return OpenApiSpecification(
+                openApiFilePath,
+                parsedOpenApi,
+                specmaticConfig = specmaticConfig,
+                strictMode = strictMode,
+                lenientMode = lenientMode,
+                exampleDirPaths = exampleDirPaths,
             )
         }
 
@@ -367,6 +401,12 @@ class OpenApiSpecification(
                 it.isResolve = true
                 it.isResolveRequestBody = true
                 it.isResolveResponses = true
+            }
+        }
+
+        private fun resolveFullyReferences(): ParseOptions {
+            return resolveExternalReferences().also {
+                it.isResolveFully = true
             }
         }
 
@@ -526,7 +566,8 @@ class OpenApiSpecification(
             specmaticConfig = specmaticConfig,
             strictMode = strictMode,
             protocol = protocol,
-            exampleDirPaths = exampleDirPaths
+            exampleDirPaths = exampleDirPaths,
+            changeTrackingSource = changeTrackingSource,
         )
 
         return Pair(feature, rootContext.toCollector().toResult())

--- a/core/src/main/kotlin/io/specmatic/core/Feature.kt
+++ b/core/src/main/kotlin/io/specmatic/core/Feature.kt
@@ -185,8 +185,17 @@ data class Feature(
     val strictMode: Boolean = false,
     val exampleStore: ExampleStore = ExampleStore.empty(),
     val protocol: SpecmaticProtocol,
-    val exampleDirPaths: List<String> = emptyList()
+    val exampleDirPaths: List<String> = emptyList(),
+    val changeTrackingSource: OpenApiChangeTrackingSource? = null,
 ): IFeature {
+    fun scenariosForChangeTracking(): List<Scenario> {
+        return changeTrackingSource?.scenarios(
+            specmaticConfig = specmaticConfig,
+            strictMode = strictMode,
+            exampleDirPaths = exampleDirPaths,
+        ) ?: scenarios
+    }
+
     val inlineNamedStubs: List<NamedStub>
         get() = exampleStore.examples
             .asSequence()
@@ -2549,7 +2558,8 @@ data class Feature(
             flagsBased: FlagsBased = strategiesFromFlags(specmaticConfig),
             strictMode: Boolean = false,
             protocol: SpecmaticProtocol,
-            exampleDirPaths: List<String> = emptyList()
+            exampleDirPaths: List<String> = emptyList(),
+            changeTrackingSource: OpenApiChangeTrackingSource? = null,
         ): Feature {
             val inlineExamples = stubsFromExamples.flatMap { (exampleName, stubs) ->
                 stubs.map { (request, response) ->
@@ -2572,7 +2582,8 @@ data class Feature(
                 flagsBased = flagsBased,
                 strictMode = strictMode,
                 protocol = protocol,
-                exampleDirPaths = exampleDirPaths
+                exampleDirPaths = exampleDirPaths,
+                changeTrackingSource = changeTrackingSource,
             )
         }
 
@@ -2592,7 +2603,8 @@ data class Feature(
             flagsBased: FlagsBased = strategiesFromFlags(specmaticConfig),
             strictMode: Boolean = false,
             protocol: SpecmaticProtocol,
-            exampleDirPaths: List<String> = emptyList()
+            exampleDirPaths: List<String> = emptyList(),
+            changeTrackingSource: OpenApiChangeTrackingSource? = null,
         ): Feature {
             return Feature(
                 scenarios = scenarios,
@@ -2610,7 +2622,8 @@ data class Feature(
                 strictMode = strictMode,
                 exampleStore = ExampleStore.from(inlineExamples, type = ExampleType.INLINE),
                 protocol = protocol,
-                exampleDirPaths = exampleDirPaths
+                exampleDirPaths = exampleDirPaths,
+                changeTrackingSource = changeTrackingSource,
             )
         }
     }

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -11,6 +11,11 @@ import java.util.IdentityHashMap
 class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, private val newFeature: Feature) {
     private val newScenariosByMethodAndReqContentType = newFeature.scenarios.groupBy { it.method to it.requestContentType }
     private val newScenariosByPathAndMethod = newFeature.scenarios.groupBy { it.path to it.method }
+    private val oldChangeTrackingScenariosByPathAndMethod = oldFeature.scenariosForChangeTracking()
+        .filter { !it.ignoreFailure }
+        .groupBy { it.path to it.method }
+    private val newChangeTrackingScenariosByPathAndMethod = newFeature.scenariosForChangeTracking()
+        .groupBy { it.path to it.method }
 
     fun run(): List<OpenApiBackwardCompatibilityCheckRecord> {
         val requestFamilies = groupScenariosByPathAndMethod(oldFeature)
@@ -25,8 +30,10 @@ class OpenApiBackwardCompatibilityChecker(private val oldFeature: Feature, priva
     }
 
     private fun operationChangeStatus(requestFamily: RequestFamily): ChangeStatus {
-        val newScenariosForOperation = newScenariosByPathAndMethod[requestFamily.path to requestFamily.method].orEmpty()
-        return ScenarioFingerprint.changeStatusBetween(requestFamily.scenarios, newScenariosForOperation)
+        val operationIdentifier = requestFamily.path to requestFamily.method
+        val oldScenariosForOperation = oldChangeTrackingScenariosByPathAndMethod[operationIdentifier] ?: requestFamily.scenarios
+        val newScenariosForOperation = newChangeTrackingScenariosByPathAndMethod[operationIdentifier].orEmpty()
+        return ScenarioFingerprint.changeStatusBetween(oldScenariosForOperation, newScenariosForOperation)
     }
 
     private fun groupScenariosByPathAndMethod(feature: Feature): List<RequestFamily> {

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiChangeTrackingSource.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiChangeTrackingSource.kt
@@ -1,0 +1,27 @@
+package io.specmatic.core
+
+import io.specmatic.conversions.OpenApiSpecification
+
+data class OpenApiChangeTrackingSource(
+    val yamlContent: String,
+    val openApiFilePath: String,
+    val lenientMode: Boolean,
+) {
+    fun scenarios(
+        specmaticConfig: SpecmaticConfig,
+        strictMode: Boolean,
+        exampleDirPaths: List<String>,
+    ): List<Scenario> {
+        return OpenApiSpecification
+            .fromYAMLForChangeTracking(
+                yamlContent = yamlContent,
+                openApiFilePath = openApiFilePath,
+                specmaticConfig = specmaticConfig,
+                strictMode = strictMode,
+                lenientMode = lenientMode,
+                exampleDirPaths = exampleDirPaths,
+            )
+            .toFeature()
+            .scenarios
+    }
+}

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -33,6 +33,33 @@ class ScenarioFingerprintTest {
                   description: created
     """.trimIndent()
 
+    private val componentRefSpec = """
+        openapi: 3.0.0
+        info:
+          title: Orders API
+          version: 1.0.0
+        paths:
+          /orders:
+            post:
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      ${'$'}ref: '#/components/schemas/Order'
+              responses:
+                '201':
+                  description: created
+        components:
+          schemas:
+            Order:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+    """.trimIndent()
+
     @Test
     fun `from copies identifying fields and patterns off the scenario`() {
         val scenario = singleScenarioFrom(baseSpec)
@@ -116,6 +143,39 @@ class ScenarioFingerprintTest {
     }
 
     @Test
+    fun `changeStatusBetween returns CHANGED when a referenced component schema changes`() {
+        val old = scenariosFrom(componentRefSpec)
+        val new = scenariosFrom(componentRefSpec.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/Order/properties/id/type
+              value: integer
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.CHANGED)
+    }
+
+    @Test
+    fun `changeStatusBetween returns UNCHANGED when an unused component schema changes`() {
+        val specWithUnusedComponent = componentRefSpec.applyJsonPatch("""
+            - op: add
+              path: /components/schemas/Unused
+              value:
+                type: object
+                properties:
+                  name:
+                    type: string
+        """.trimIndent())
+        val old = scenariosFrom(specWithUnusedComponent)
+        val new = scenariosFrom(specWithUnusedComponent.applyJsonPatch("""
+            - op: replace
+              path: /components/schemas/Unused/properties/name/type
+              value: integer
+        """.trimIndent()))
+
+        assertThat(ScenarioFingerprint.changeStatusBetween(old, new)).isEqualTo(ChangeStatus.UNCHANGED)
+    }
+
+    @Test
     fun `changeStatusBetween returns CHANGED when a scenario is added`() {
         val old = scenariosFrom(baseSpec)
         val new = scenariosFrom(baseSpec.applyJsonPatch("""
@@ -158,7 +218,7 @@ class ScenarioFingerprintTest {
     }
 
     private fun scenariosFrom(yaml: String): List<Scenario> =
-        OpenApiSpecification.fromYAML(yaml, "test.yaml").toFeature().scenarios
+        OpenApiSpecification.fromYAML(yaml, "test.yaml").toFeature().scenariosForChangeTracking()
 
     private fun singleScenarioFrom(yaml: String): Scenario = scenariosFrom(yaml).single()
 

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5198,15 +5198,10 @@ paths:
                             id: "abc"
                 """,
             ),
-            // TODO(product): refactoring an inline schema into a \$ref (or back) currently registers
-            // as CHANGED because Specmatic's resolved patterns carry a typeAlias derived from the
-            // \$ref name, which the inline form lacks. From a backwards-compatibility standpoint the
-            // schemas are equivalent — consider normalising the fingerprint to drop typeAlias if we
-            // want refactoring-only diffs to surface as UNCHANGED.
             ChangeStatusCase(
-                name = "30. schema referenced via \$ref in old, inlined in new — currently CHANGED",
+                name = "30. schema referenced via \$ref in old, inlined in new",
                 path = "/orders", method = "POST",
-                expected = ChangeStatus.CHANGED,
+                expected = ChangeStatus.UNCHANGED,
                 oldPatch = """
                     - op: add
                       path: /components
@@ -5225,7 +5220,47 @@ paths:
                 """,
             ),
             ChangeStatusCase(
-                name = "31. required array and properties reordered",
+                name = "31. schema referenced via same \$ref has component schema changed",
+                path = "/orders", method = "POST",
+                expected = ChangeStatus.CHANGED,
+                oldPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                """,
+                newPatch = """
+                    - op: add
+                      path: /components
+                      value:
+                        schemas:
+                          Order:
+                            type: object
+                            required: [id]
+                            properties:
+                              id:
+                                type: string
+                    - op: replace
+                      path: /paths/~1orders/post/requestBody/content/application~1json/schema
+                      value:
+                        ${'$'}ref: '#/components/schemas/Order'
+                    - op: replace
+                      path: /components/schemas/Order/properties/id/type
+                      value: integer
+                """,
+            ),
+            ChangeStatusCase(
+                name = "32. required array and properties reordered",
                 path = "/orders", method = "POST",
                 expected = ChangeStatus.UNCHANGED,
                 oldPatch = """


### PR DESCRIPTION
https://github.com/specmatic/specmatic/pull/2505 doesn't handle refs. If a ref in a component is changed (see tests in here) than it's reported as unchanged. This PR fixes this resolving the schema fully (all references are inlined) specifically for change tracking.