### PR TITLE
Fix BCC change tracking for external refs

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -251,6 +251,12 @@ abstract class BackwardCompatibilityCheckBaseCommand(
                     }
 
                     val newer = getFeatureFromSpecPath(specFilePath)
+                    // The newer feature is parsed while the worktree has the current branch files, but below we
+                    // checkout the base branch before running the comparison. OpenAPI change tracking resolves
+                    // external refs when scenariosForChangeTracking() is first evaluated, so delaying this until
+                    // after checkout races with the branch switch and can build the newer fingerprints from the
+                    // base branch's external files. Materialize it here while the current branch is still checked out.
+                    (newer as? Feature)?.scenariosForChangeTracking()
                     val unusedExamples = getUnusedExamples(newer)
 
                     val repoDirFile = File(effectiveRepoDir).absoluteFile

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -4,11 +4,15 @@ import application.backwardCompatibility.BackwardCompatibilityCheckBaseCommand
 import application.backwardCompatibility.BackwardCompatibilityCheckCommandV2
 import application.backwardCompatibility.BackwardCompatibilityCheckHook
 import application.backwardCompatibility.CompatibilityResult
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every
 import io.mockk.spyk
 import io.specmatic.core.IFeature
 import io.specmatic.core.Results
 import io.specmatic.core.git.SystemGit
+import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
+import io.specmatic.core.utilities.Flags.Companion.using
 import io.specmatic.reporter.backwardcompat.dto.OperationUsageResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -24,6 +28,8 @@ import java.io.File
 import java.nio.file.Paths
 
 class BackwardCompatibilityCheckCommandV2Test {
+    private val objectMapper = ObjectMapper()
+
     @TempDir
     private lateinit var tempDir: File
 
@@ -462,6 +468,77 @@ class BackwardCompatibilityCheckCommandV2Test {
         }
     }
 
+    @Nested
+    inner class ChangeTrackingReportTests {
+        @Test
+        fun `reports external schema changes after command checks out the base branch`() {
+            val apiFile = tempDir.resolve("api.yaml")
+            val componentsFile = tempDir.resolve("components.yaml")
+
+            fixture("api.yaml").copyTo(apiFile)
+            fixture("components_base.yaml").copyTo(componentsFile)
+            commit(tempDir, "Initial contract")
+            val baseBranch = SystemGit(tempDir.absolutePath).currentBranch()
+
+            ProcessBuilder("git", "switch", "-c", "external-ref-change")
+                .directory(tempDir)
+                .inheritIO()
+                .start()
+                .waitFor()
+
+            fixture("components_current.yaml").copyTo(componentsFile, overwrite = true)
+            commit(tempDir, "Add optional field in external schema")
+
+            val configFile = remoteDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    reportDirPath: ${tempDir.resolve("reports").canonicalPath}
+                    """.trimIndent()
+                )
+            }
+
+            val (_, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+                using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+                    BackwardCompatibilityCheckCommandV2().apply {
+                        options.repoDir = tempDir.canonicalPath
+                        options.baseBranch = baseBranch
+                    }.call()
+                }
+            }
+
+            assertThat(exitCode).isEqualTo(0)
+
+            val reportJson = bccReportJson(tempDir.resolve("reports/backward_compatibility"))
+            val operations = reportJson.path("results").path("summary").path("extra").path("executionDetails").first()
+                .path("operations")
+            val getOrders = operations.single {
+                it.path("method").asText() == "GET" && it.path("path").asText() == "/orders"
+            }
+
+            assertThat(getOrders.path("compatibility").path("result").asText()).isEqualTo("Compatible")
+            assertThat(getOrders.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
+        }
+
+        private fun fixture(name: String): File =
+            File("src/test/resources/specifications/bcc_change_tracking_external_refs/$name").canonicalFile
+
+        private fun bccReportJson(reportDir: File): JsonNode {
+            val htmlReport = reportDir.resolve("html/index.html")
+            assertThat(htmlReport).exists()
+
+            val html = htmlReport.readText()
+            val reportLiteral = html
+                .substringAfter("const report = ")
+                .substringBefore("const specmaticConfig =")
+                .trim()
+                .removeSuffix(";")
+                .trim()
+
+            return objectMapper.readTree(reportLiteral)
+        }
+    }
+
     @Test
     fun `should skip asyncapi spec files`() {
         val asyncApiFile = File("src/test/resources/specifications/asyncapi.yaml").canonicalFile
@@ -528,10 +605,13 @@ class BackwardCompatibilityCheckCommandV2Test {
     }
 
     private fun commitAndPush(repoDir: File, commitMessage: String) {
-        ProcessBuilder("git", "add", ".").directory(repoDir).inheritIO().start().waitFor()
-        ProcessBuilder("git", "commit", "-m", commitMessage).directory(repoDir).inheritIO().start().waitFor()
+        commit(repoDir, commitMessage)
         ProcessBuilder("git", "push", "origin", "master").directory(repoDir).inheritIO().start().waitFor()
     }
 
+    private fun commit(repoDir: File, commitMessage: String) {
+        ProcessBuilder("git", "add", ".").directory(repoDir).inheritIO().start().waitFor()
+        ProcessBuilder("git", "commit", "-m", commitMessage).directory(repoDir).inheritIO().start().waitFor()
+    }
 
 }

--- a/application/src/test/resources/specifications/bcc_change_tracking_external_refs/api.yaml
+++ b/application/src/test/resources/specifications/bcc_change_tracking_external_refs/api.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Orders API
+  version: 1.0.0
+paths:
+  /orders:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: './components.yaml#/components/schemas/Order'

--- a/application/src/test/resources/specifications/bcc_change_tracking_external_refs/components_base.yaml
+++ b/application/src/test/resources/specifications/bcc_change_tracking_external_refs/components_base.yaml
@@ -1,0 +1,8 @@
+components:
+  schemas:
+    Order:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string

--- a/application/src/test/resources/specifications/bcc_change_tracking_external_refs/components_current.yaml
+++ b/application/src/test/resources/specifications/bcc_change_tracking_external_refs/components_current.yaml
@@ -1,0 +1,10 @@
+components:
+  schemas:
+    Order:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+        note:
+          type: string


### PR DESCRIPTION
## Summary
- Materialize the newer OpenAPI feature's change-tracking scenarios before the BCC command checks out the base branch.
- Add a command-level regression test that runs through the real temporary git repository, branch switch, base checkout, BCC report generation, and embedded HTML report JSON assertion.

## Bug
During the CLI backward compatibility flow, the newer spec is parsed while the worktree is on the current branch. The command then stashes local changes and checks out the base branch before loading the older spec and running the comparison.

OpenAPI change tracking resolves external refs lazily when scenariosForChangeTracking() is first evaluated. If that first evaluation happens after the checkout, the newer fingerprints can resolve external schema files from the base branch instead of the current branch. That makes external-schema-only changes look unchanged in the BCC report, even though the current branch changed the referenced schema.

## Fix
The command now calls scenariosForChangeTracking() on the newer Feature immediately after parsing it and before any branch checkout. This materializes the newer change-tracking scenarios while the current branch's external files are still present in the worktree, so later comparison/report generation uses the correct fingerprints.

## Verification
- env JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./gradlew :specmatic-executable:test --tests 'application.BackwardCompatibilityCheckCommandV2Test'