### PR TITLE
Add changed qualifier to BCC CTRF operations

### DIFF
--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -42,6 +42,7 @@ data class OpenApiBackwardCompatibilityCheckRecord(
 
     override val operationQualifiers: List<CtrfOperationQualifiers> = buildList {
         if (scenario.ignoreFailure) add(CtrfOperationQualifiers.WIP)
+        if (changeStatus == ChangeStatus.CHANGED) add(CtrfOperationQualifiers.CHANGED)
     }
 
     private fun toOpenApiOperation(scenario: Scenario): Set<APIOperation> = setOf(

--- a/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
@@ -19,28 +19,20 @@ class BccReportGenerator {
 
     private fun reportOperationFrom(groupKey: BccOperationGroupKey, sources: List<BccOperationSource>): BaseBccReportOperation {
         val tests = sources.map { it.test }
-        val changeStatus = operationChangeStatus(tests)
         return BccReportOperation(
             tests = tests,
             operation = groupKey.operation,
             specConfig = groupKey.specConfig,
-            qualifiers = operationQualifiersFrom(tests, changeStatus),
+            qualifiers = operationQualifiersFrom(tests),
             compatibility = CtrfOperationCompatibility(
-                changeStatus = changeStatus,
+                changeStatus = operationChangeStatus(tests),
                 result = backwardCompatibilityResultFrom(tests),
             ),
         )
     }
 
-    private fun operationQualifiersFrom(
-        tests: List<CtrfBackwardCompatibilityRecord>,
-        changeStatus: ChangeStatus,
-    ): List<CtrfOperationQualifiers> {
-        val testQualifiers = tests.flatMap { it.operationQualifiers }
-        val changeQualifier = listOfNotNull(
-            CtrfOperationQualifiers.CHANGED.takeIf { changeStatus == ChangeStatus.CHANGED }
-        )
-        return (testQualifiers + changeQualifier).distinct()
+    private fun operationQualifiersFrom(tests: List<CtrfBackwardCompatibilityRecord>): List<CtrfOperationQualifiers> {
+        return tests.flatMap { it.operationQualifiers }.distinct()
     }
 
     private fun operationChangeStatus(tests: List<CtrfBackwardCompatibilityRecord>): ChangeStatus {

--- a/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
@@ -19,20 +19,28 @@ class BccReportGenerator {
 
     private fun reportOperationFrom(groupKey: BccOperationGroupKey, sources: List<BccOperationSource>): BaseBccReportOperation {
         val tests = sources.map { it.test }
+        val changeStatus = operationChangeStatus(tests)
         return BccReportOperation(
             tests = tests,
             operation = groupKey.operation,
             specConfig = groupKey.specConfig,
-            qualifiers = operationQualifiersFrom(tests),
+            qualifiers = operationQualifiersFrom(tests, changeStatus),
             compatibility = CtrfOperationCompatibility(
-                changeStatus = operationChangeStatus(tests),
+                changeStatus = changeStatus,
                 result = backwardCompatibilityResultFrom(tests),
             ),
         )
     }
 
-    private fun operationQualifiersFrom(tests: List<CtrfBackwardCompatibilityRecord>): List<CtrfOperationQualifiers> {
-        return tests.flatMap { it.operationQualifiers }.distinct()
+    private fun operationQualifiersFrom(
+        tests: List<CtrfBackwardCompatibilityRecord>,
+        changeStatus: ChangeStatus,
+    ): List<CtrfOperationQualifiers> {
+        val testQualifiers = tests.flatMap { it.operationQualifiers }
+        val changeQualifier = listOfNotNull(
+            CtrfOperationQualifiers.CHANGED.takeIf { changeStatus == ChangeStatus.CHANGED }
+        )
+        return (testQualifiers + changeQualifier).distinct()
     }
 
     private fun operationChangeStatus(tests: List<CtrfBackwardCompatibilityRecord>): ChangeStatus {

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -28,7 +28,7 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
 
         assertThat(record.id).isNotNull()
         assertThat(record.message).isEmpty()
-        assertThat(record.operationQualifiers).isEmpty()
+        assertThat(record.operationQualifiers).containsExactly(CtrfOperationQualifiers.CHANGED)
         assertThat(record.duration).isEqualTo(0)
         assertThat(record.branch).isEqualTo("main")
         assertThat(record.specType).isEqualTo(SpecType.OPENAPI)
@@ -78,7 +78,7 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
 
         assertThat(record.message).contains("breaking change")
         assertThat(record.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
-        assertThat(record.operationQualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+        assertThat(record.operationQualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
     }
 
     private fun openApiFeature(): Feature {

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4708,7 +4708,7 @@ paths:
             assertThat(postOperation.path("method").asText()).isEqualTo("POST")
             assertThat(postOperation.path("contentType").asText()).isEqualTo("application/json")
             assertThat(postOperation.path("responseCode").asInt()).isEqualTo(201)
-            assertThat(postOperation.path("qualifiers").size()).isEqualTo(0)
+            assertThat(postOperation.path("qualifiers").map { it.asText() }).containsExactly("changed")
             assertThat(postOperation.path("testIds").isArray).isTrue()
             assertThat(postOperation.path("testIds").size()).isGreaterThan(0)
             assertThat(postOperation.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
@@ -4719,7 +4719,7 @@ paths:
             assertThat(getOperation.path("method").asText()).isEqualTo("GET")
             assertThat(getOperation.path("responseCode").asInt()).isEqualTo(200)
             assertThat(getOperation.path("responseContentType").asText()).isEqualTo("application/json")
-            assertThat(getOperation.path("qualifiers").size()).isEqualTo(0)
+            assertThat(getOperation.path("qualifiers").map { it.asText() }).containsExactly("changed")
             assertThat(getOperation.path("testIds").isArray).isTrue()
             assertThat(getOperation.path("testIds").size()).isGreaterThan(0)
             assertThat(getOperation.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
@@ -4791,6 +4791,12 @@ paths:
             assertThat(row.path("compatibility").path("result").asText())
                 .describedAs("result for $key")
                 .isEqualTo(result)
+            val qualifiers = row.path("qualifiers").map { it.asText() }
+            if (changeStatus == "CHANGED") {
+                assertThat(qualifiers).describedAs("qualifiers for $key").contains("changed")
+            } else {
+                assertThat(qualifiers).describedAs("qualifiers for $key").doesNotContain("changed")
+            }
         }
 
         private fun readFixture(name: String): String =

--- a/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
@@ -52,16 +52,16 @@ class BccReportGeneratorTest {
         val groupedCreateOrder = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/orders.yaml" }
         assertThat(groupedCreateOrder.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
         assertThat(groupedCreateOrder.tests).containsExactly(firstRecord, secondRecord)
-        assertThat(groupedCreateOrder.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+        assertThat(groupedCreateOrder.qualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
         assertThat(groupedCreateOrder.compatibility.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
 
         val groupedGetOrders = reportOperations.single { it.operation == getOrders && it.specConfig.specification == "specs/orders.yaml" }
         assertThat(groupedGetOrders.tests).containsExactly(firstRecord)
-        assertThat(groupedGetOrders.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+        assertThat(groupedGetOrders.qualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
         assertThat(groupedGetOrders.compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
 
         val groupedPayments = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/payments.yaml" }
-        assertThat(groupedPayments.qualifiers).isEmpty()
+        assertThat(groupedPayments.qualifiers).containsExactly(CtrfOperationQualifiers.CHANGED)
         assertThat(groupedPayments.tests).containsExactly(thirdRecord)
         assertThat(groupedPayments.compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
     }
@@ -123,7 +123,37 @@ class BccReportGeneratorTest {
         )
 
         val reportOperation = generator.generateReportOperations(listOf(firstRecord, secondRecord)).single()
+        assertThat(reportOperation.qualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
+    }
+
+    @Test
+    fun `should add changed qualifier when operation has changes`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val reportOperation = generator.generateReportOperations(
+            listOf(
+                testRecord(operations = setOf(createOrder), changeStatus = ChangeStatus.UNCHANGED),
+                testRecord(operations = setOf(createOrder), changeStatus = ChangeStatus.CHANGED),
+            )
+        ).single()
+
+        assertThat(reportOperation.qualifiers).containsExactly(CtrfOperationQualifiers.CHANGED)
+    }
+
+    @Test
+    fun `should omit changed qualifier when operation is unchanged`() {
+        val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
+        val reportOperation = generator.generateReportOperations(
+            listOf(
+                testRecord(
+                    operations = setOf(createOrder),
+                    changeStatus = ChangeStatus.UNCHANGED,
+                    operationQualifiers = listOf(CtrfOperationQualifiers.WIP),
+                ),
+            )
+        ).single()
+
         assertThat(reportOperation.qualifiers).containsExactly(CtrfOperationQualifiers.WIP)
+        assertThat(reportOperation.qualifiers).doesNotContain(CtrfOperationQualifiers.CHANGED)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
@@ -275,6 +275,10 @@ class BccReportGeneratorTest {
         operationQualifiers: List<CtrfOperationQualifiers> = emptyList(),
         result: BackwardCompatibilityResult = BackwardCompatibilityResult.Compatible,
     ): CtrfBackwardCompatibilityRecord {
+        val effectiveQualifiers = buildList {
+            addAll(operationQualifiers)
+            if (changeStatus == ChangeStatus.CHANGED) add(CtrfOperationQualifiers.CHANGED)
+        }
         return object : CtrfBackwardCompatibilityRecord {
             override val id: UUID = id
             override val duration: Long = 100
@@ -288,7 +292,7 @@ class BccReportGeneratorTest {
             override val operations: Set<APIOperation> = operations
             override val result: BackwardCompatibilityResult = result
             override val changeStatus: ChangeStatus = changeStatus
-            override val operationQualifiers: List<CtrfOperationQualifiers> = operationQualifiers
+            override val operationQualifiers: List<CtrfOperationQualifiers> = effectiveQualifiers
         }
     }
 }


### PR DESCRIPTION
We add `Changed` as a qualifier so that it shows up as a pill under remarks in the HTML report. I've tested the report produced by the integration test and it shows up correctly. The `Changed`/`Unchanged` status is left untouched right now in the remaining CTRF so this is a non breaking change.

## Companion PRs

- specmatic/specmatic-reporter#136 — adds the `CHANGED` value to `CtrfOperationQualifiers`.
- specmatic/specmatic-html-reporter#106 — capitalizes qualifier pills in the HTML report so `changed` renders as `Changed`.