### PR TITLE
build: bump specmatic reporter to 0.3.23

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.46.2-SNAPSHOT
 specmaticGradlePluginVersion=0.15.8
-specmaticReporterVersion=0.3.23-SNAPSHOT
+specmaticReporterVersion=0.3.23
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
## What
- update specmaticReporterVersion in gradle.properties from 0.3.23-SNAPSHOT to 0.3.23

## Why
- point the build at the released reporter version