### PR TITLE
Remove compatibility object from BCC CTRF report

### DIFF
--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -516,8 +516,9 @@ class BackwardCompatibilityCheckCommandV2Test {
                 it.path("method").asText() == "GET" && it.path("path").asText() == "/orders"
             }
 
-            assertThat(getOrders.path("compatibility").path("result").asText()).isEqualTo("Compatible")
-            assertThat(getOrders.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
+            assertThat(getOrders.path("status").asText()).isEqualTo("compatible")
+            val qualifiers = getOrders.path("qualifiers").map { it.asText() }
+            assertThat(qualifiers).contains("changed")
         }
 
         private fun fixture(name: String): File =

--- a/core/src/main/kotlin/io/specmatic/core/ChangeStatus.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ChangeStatus.kt
@@ -1,0 +1,6 @@
+package io.specmatic.core
+
+enum class ChangeStatus {
+    CHANGED,
+    UNCHANGED,
+}

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -3,7 +3,6 @@ package io.specmatic.core
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
 import io.specmatic.reporter.internal.dto.operation.APIOperation
 import io.specmatic.reporter.model.BackwardCompatibilityResult
 import io.specmatic.reporter.model.SpecType
@@ -16,7 +15,7 @@ data class OpenApiBackwardCompatibilityCheckRecord(
     val compatResult: Result,
     override val duration: Long = 0,
     override val id: UUID = UUID.randomUUID(),
-    override val changeStatus: ChangeStatus = ChangeStatus.CHANGED,
+    val changeStatus: ChangeStatus = ChangeStatus.CHANGED,
 ) : CtrfBackwardCompatibilityRecord {
     override val specType: SpecType = scenario.specType
     override val repository: String? = scenario.sourceRepository

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecord.kt
@@ -4,7 +4,7 @@ import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.internal.dto.operation.APIOperation
-import io.specmatic.reporter.model.BackwardCompatibilityResult
+import io.specmatic.reporter.model.BackwardCompatibilityStatus
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.test.openAPIOperationFrom
 import java.util.UUID
@@ -34,9 +34,9 @@ data class OpenApiBackwardCompatibilityCheckRecord(
         scenario.responseContentType?.let { contentType -> add("response-content-type:$contentType") }
     }
 
-    override val result: BackwardCompatibilityResult = when (compatResult) {
-        is Result.Success -> BackwardCompatibilityResult.Compatible
-        is Result.Failure -> BackwardCompatibilityResult.Incompatible
+    override val result: BackwardCompatibilityStatus = when (compatResult) {
+        is Result.Success -> BackwardCompatibilityStatus.Compatible
+        is Result.Failure -> BackwardCompatibilityStatus.Incompatible
     }
 
     override val operationQualifiers: List<CtrfOperationQualifiers> = buildList {

--- a/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
+++ b/core/src/main/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityChecker.kt
@@ -3,7 +3,6 @@ package io.specmatic.core
 import io.specmatic.core.log.logger
 import io.specmatic.core.pattern.ContractException
 import io.specmatic.core.pattern.IgnoreUnexpectedKeys
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
 import io.specmatic.test.asserts.toFailure
 import java.util.Collections
 import java.util.IdentityHashMap

--- a/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
+++ b/core/src/main/kotlin/io/specmatic/core/ScenarioFingerprint.kt
@@ -1,7 +1,5 @@
 package io.specmatic.core
 
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
-
 data class ScenarioFingerprint(
     val status: Int,
     val requestContentType: String?,

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -21,12 +21,12 @@ internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature)
     val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
     val endTime = System.currentTimeMillis()
 
-    val result = records.toBackwardCompatibilityStatuss()
+    val result = records.toBackwardCompatibilityStatuses()
     val report = generateBackwardCompatibilityReport(records, startTime, endTime)
     return Pair(result, report)
 }
 
-fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuss(): Results {
+fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Results {
     return filterIsInstance<OpenApiBackwardCompatibilityCheckRecord>()
         .groupBy { it.operations }.values
         .fold(Results()) { acc, recordsForOperation ->

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -21,12 +21,12 @@ internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature)
     val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
     val endTime = System.currentTimeMillis()
 
-    val result = records.toBackwardCompatibilityResults()
+    val result = records.toBackwardCompatibilityStatuss()
     val report = generateBackwardCompatibilityReport(records, startTime, endTime)
     return Pair(result, report)
 }
 
-fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityResults(): Results {
+fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuss(): Results {
     return filterIsInstance<OpenApiBackwardCompatibilityCheckRecord>()
         .groupBy { it.operations }.values
         .fold(Results()) { acc, recordsForOperation ->

--- a/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
@@ -6,7 +6,7 @@ import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
 import io.specmatic.reporter.internal.dto.operation.APIOperation
-import io.specmatic.reporter.model.BackwardCompatibilityResult
+import io.specmatic.reporter.model.BackwardCompatibilityStatus
 
 class BccReportGenerator {
     fun generateReportOperations(tests: List<CtrfBackwardCompatibilityRecord>): List<BaseBccReportOperation> {
@@ -30,10 +30,10 @@ class BccReportGenerator {
         return tests.flatMap { it.operationQualifiers }.distinct()
     }
 
-    private fun backwardCompatibilityResultFrom(tests: List<CtrfBackwardCompatibilityRecord>): BackwardCompatibilityResult {
+    private fun backwardCompatibilityResultFrom(tests: List<CtrfBackwardCompatibilityRecord>): BackwardCompatibilityStatus {
         return when {
-            tests.any { it.result == BackwardCompatibilityResult.Incompatible } -> BackwardCompatibilityResult.Incompatible
-            else -> BackwardCompatibilityResult.Compatible
+            tests.any { it.result == BackwardCompatibilityStatus.Incompatible } -> BackwardCompatibilityStatus.Incompatible
+            else -> BackwardCompatibilityStatus.Compatible
         }
     }
 

--- a/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
+++ b/core/src/main/kotlin/io/specmatic/core/report/BccReportGenerator.kt
@@ -3,10 +3,8 @@ package io.specmatic.core.report
 import io.specmatic.reporter.ctrf.model.BccReportOperation
 import io.specmatic.reporter.ctrf.model.BaseBccReportOperation
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
-import io.specmatic.reporter.ctrf.model.CtrfOperationCompatibility
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.reporter.ctrf.model.CtrfSpecConfig
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
 import io.specmatic.reporter.internal.dto.operation.APIOperation
 import io.specmatic.reporter.model.BackwardCompatibilityResult
 
@@ -24,22 +22,12 @@ class BccReportGenerator {
             operation = groupKey.operation,
             specConfig = groupKey.specConfig,
             qualifiers = operationQualifiersFrom(tests),
-            compatibility = CtrfOperationCompatibility(
-                changeStatus = operationChangeStatus(tests),
-                result = backwardCompatibilityResultFrom(tests),
-            ),
+            status = backwardCompatibilityResultFrom(tests),
         )
     }
 
     private fun operationQualifiersFrom(tests: List<CtrfBackwardCompatibilityRecord>): List<CtrfOperationQualifiers> {
         return tests.flatMap { it.operationQualifiers }.distinct()
-    }
-
-    private fun operationChangeStatus(tests: List<CtrfBackwardCompatibilityRecord>): ChangeStatus {
-        return when {
-            tests.any { it.changeStatus == ChangeStatus.CHANGED } -> ChangeStatus.CHANGED
-            else -> ChangeStatus.UNCHANGED
-        }
     }
 
     private fun backwardCompatibilityResultFrom(tests: List<CtrfBackwardCompatibilityRecord>): BackwardCompatibilityResult {

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -3,7 +3,7 @@ package io.specmatic.core
 import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.core.ChangeStatus
 import io.specmatic.reporter.model.BackwardCompatibilityResult
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.test.openAPIOperationFrom

--- a/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/OpenApiBackwardCompatibilityCheckRecordTest.kt
@@ -4,7 +4,7 @@ import io.specmatic.conversions.OpenApiSpecification
 import io.specmatic.conversions.convertPathParameterStyle
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.core.ChangeStatus
-import io.specmatic.reporter.model.BackwardCompatibilityResult
+import io.specmatic.reporter.model.BackwardCompatibilityStatus
 import io.specmatic.reporter.model.SpecType
 import io.specmatic.test.openAPIOperationFrom
 import org.assertj.core.api.Assertions.assertThat
@@ -36,7 +36,7 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
         assertThat(record.name).isEqualTo(scenario.fullApiDescription)
         assertThat(record.changeStatus).isEqualTo(ChangeStatus.CHANGED)
         assertThat(record.specification).isEqualTo("specs/orders.yaml")
-        assertThat(record.result).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(record.result).isEqualTo(BackwardCompatibilityStatus.Compatible)
         assertThat(record.repository).isEqualTo("https://github.com/example/orders.git")
         assertThat(record.tags).containsExactly(
             "status:200",
@@ -77,7 +77,7 @@ class OpenApiBackwardCompatibilityCheckRecordTest {
         )
 
         assertThat(record.message).contains("breaking change")
-        assertThat(record.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(record.result).isEqualTo(BackwardCompatibilityStatus.Incompatible)
         assertThat(record.operationQualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
     }
 

--- a/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/ScenarioFingerprintTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.flipkart.zjsonpatch.JsonPatch
 import io.specmatic.conversions.OpenApiSpecification
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.core.ChangeStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4711,7 +4711,7 @@ paths:
             assertThat(postOperation.path("qualifiers").map { it.asText() }).containsExactly("changed")
             assertThat(postOperation.path("testIds").isArray).isTrue()
             assertThat(postOperation.path("testIds").size()).isGreaterThan(0)
-            assertThat(postOperation.path("status").asText()).isEqualTo("Incompatible")
+            assertThat(postOperation.path("status").asText()).isEqualTo("incompatible")
 
             val getOperation = operations.first { it.path("method").asText() == "GET" }
             assertThat(getOperation.path("path").asText()).isEqualTo("/orders")
@@ -4721,7 +4721,7 @@ paths:
             assertThat(getOperation.path("qualifiers").map { it.asText() }).containsExactly("changed")
             assertThat(getOperation.path("testIds").isArray).isTrue()
             assertThat(getOperation.path("testIds").size()).isGreaterThan(0)
-            assertThat(getOperation.path("status").asText()).isEqualTo("Compatible")
+            assertThat(getOperation.path("status").asText()).isEqualTo("compatible")
         }
     }
 
@@ -4736,32 +4736,32 @@ paths:
             val json = "application/json"
 
             // NEW-SIDE N1: Order gains optional `notes` -> CHANGED + Compatible on every Order-using row
-            operations.assertRow(OperationKey("GET", "/orders", null, 200, json), changeStatus = "CHANGED", result = "Compatible")
-            operations.assertRow(OperationKey("POST", "/orders", json, 201, json), changeStatus = "CHANGED", result = "Compatible")
-            operations.assertRow(OperationKey("GET", "/orders/{id}", null, 200, json), changeStatus = "CHANGED", result = "Compatible")
+            operations.assertRow(OperationKey("GET", "/orders", null, 200, json), changeStatus = "CHANGED", result = "compatible")
+            operations.assertRow(OperationKey("POST", "/orders", json, 201, json), changeStatus = "CHANGED", result = "compatible")
+            operations.assertRow(OperationKey("GET", "/orders/{id}", null, 200, json), changeStatus = "CHANGED", result = "compatible")
 
             // NEW-SIDE N2: ErrorBrief.code string -> integer (reachable ONLY from GET /orders 400)
-            operations.assertRow(OperationKey("GET", "/orders", null, 400, json), changeStatus = "CHANGED", result = "Incompatible")
+            operations.assertRow(OperationKey("GET", "/orders", null, 400, json), changeStatus = "CHANGED", result = "incompatible")
 
             // NEW-SIDE N3: Self-recursive Category gains optional `description`
-            operations.assertRow(OperationKey("GET", "/categories", null, 200, json), changeStatus = "CHANGED", result = "Compatible")
+            operations.assertRow(OperationKey("GET", "/categories", null, 200, json), changeStatus = "CHANGED", result = "compatible")
 
             // OLD-SIDE O1 (non-breaking): ErrorDetailed loses optional `traceId`
-            operations.assertRow(OperationKey("GET", "/orders/{id}", null, 404, json), changeStatus = "CHANGED", result = "Compatible")
+            operations.assertRow(OperationKey("GET", "/orders/{id}", null, 404, json), changeStatus = "CHANGED", result = "compatible")
 
             // OLD-SIDE O2 (breaking): DELETE /orders/{id} removed from new (no request/response body)
-            operations.assertRow(OperationKey("DELETE", "/orders/{id}", null, 204, null), changeStatus = "CHANGED", result = "Incompatible")
+            operations.assertRow(OperationKey("DELETE", "/orders/{id}", null, 204, null), changeStatus = "CHANGED", result = "incompatible")
 
             // OLD-SIDE O3 (breaking): GET /orders 500 response removed from new
-            operations.assertRow(OperationKey("GET", "/orders", null, 500, json), changeStatus = "CHANGED", result = "Incompatible")
+            operations.assertRow(OperationKey("GET", "/orders", null, 500, json), changeStatus = "CHANGED", result = "incompatible")
 
             // UNCHANGED 5-tuple sharing a (path, method) with a CHANGED row -
             // POST /orders 400 uses OrderInput (untouched) for request and ValidationError
             // (untouched) for response, while POST /orders 201 uses Order (changed) for response.
-            operations.assertRow(OperationKey("POST", "/orders", json, 400, json), changeStatus = "UNCHANGED", result = "Compatible")
+            operations.assertRow(OperationKey("POST", "/orders", json, 400, json), changeStatus = "UNCHANGED", result = "compatible")
 
             // UNCHANGED standalone operation - GET /health is identical in both specs
-            operations.assertRow(OperationKey("GET", "/health", null, 200, json), changeStatus = "UNCHANGED", result = "Compatible")
+            operations.assertRow(OperationKey("GET", "/health", null, 200, json), changeStatus = "UNCHANGED", result = "compatible")
 
             // Sanity: the report has exactly the rows we asserted above and no more
             assertThat(operations.toList())

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4140,7 +4140,7 @@ paths:
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct/openapi_v2.yaml")
         val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
-        val result = bccChecker.run().toBackwardCompatibilityResults()
+        val result = bccChecker.run().toBackwardCompatibilityStatuss()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"
@@ -4331,7 +4331,7 @@ paths:
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/single_req_res_ct_overriden/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/single_req_res_ct_overriden/openapi_v2.yaml")
         val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
-        val result = bccChecker.run().toBackwardCompatibilityResults()
+        val result = bccChecker.run().toBackwardCompatibilityStatuss()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"
@@ -4391,7 +4391,7 @@ paths:
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v2.yaml")
         val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
-        val result = bccChecker.run().toBackwardCompatibilityResults()
+        val result = bccChecker.run().toBackwardCompatibilityStatuss()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4711,8 +4711,7 @@ paths:
             assertThat(postOperation.path("qualifiers").map { it.asText() }).containsExactly("changed")
             assertThat(postOperation.path("testIds").isArray).isTrue()
             assertThat(postOperation.path("testIds").size()).isGreaterThan(0)
-            assertThat(postOperation.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
-            assertThat(postOperation.path("compatibility").path("result").asText()).isEqualTo("Incompatible")
+            assertThat(postOperation.path("status").asText()).isEqualTo("Incompatible")
 
             val getOperation = operations.first { it.path("method").asText() == "GET" }
             assertThat(getOperation.path("path").asText()).isEqualTo("/orders")
@@ -4722,8 +4721,7 @@ paths:
             assertThat(getOperation.path("qualifiers").map { it.asText() }).containsExactly("changed")
             assertThat(getOperation.path("testIds").isArray).isTrue()
             assertThat(getOperation.path("testIds").size()).isGreaterThan(0)
-            assertThat(getOperation.path("compatibility").path("changeStatus").asText()).isEqualTo("CHANGED")
-            assertThat(getOperation.path("compatibility").path("result").asText()).isEqualTo("Compatible")
+            assertThat(getOperation.path("status").asText()).isEqualTo("Compatible")
         }
     }
 
@@ -4785,11 +4783,8 @@ paths:
                         "status=${node.path("responseCode").asInt()} " +
                         "resCT=${node.path("responseContentType").asText().ifEmpty { "null" }}"
                 })
-            assertThat(row.path("compatibility").path("changeStatus").asText())
-                .describedAs("changeStatus for $key")
-                .isEqualTo(changeStatus)
-            assertThat(row.path("compatibility").path("result").asText())
-                .describedAs("result for $key")
+            assertThat(row.path("status").asText())
+                .describedAs("status for $key")
                 .isEqualTo(result)
             val qualifiers = row.path("qualifiers").map { it.asText() }
             if (changeStatus == "CHANGED") {
@@ -4894,8 +4889,9 @@ paths:
                 (case.responseContentType == null || it.path("responseContentType").asText() == case.responseContentType)
             }
 
-            assertThat(op.path("compatibility").path("changeStatus").asText())
-                .isEqualTo(case.expected.name)
+            val qualifiers = op.path("qualifiers").map { it.asText() }
+            val changeStatus = if (qualifiers.contains("changed")) "CHANGED" else "UNCHANGED"
+            assertThat(changeStatus).isEqualTo(case.expected.name)
         }
 
         @Test
@@ -5026,7 +5022,8 @@ paths:
                 (contentType == null || it.path("contentType").asText() == contentType) &&
                 (responseContentType == null || it.path("responseContentType").asText() == responseContentType)
             }
-            return operation.path("compatibility").path("changeStatus").asText()
+            val qualifiers = operation.path("qualifiers").map { it.asText() }
+            return if (qualifiers.contains("changed")) "CHANGED" else "UNCHANGED"
         }
 
         // TODO(product): decide whether new-only operations should surface as CHANGED in the BCC report.

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4140,7 +4140,7 @@ paths:
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct/openapi_v2.yaml")
         val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
-        val result = bccChecker.run().toBackwardCompatibilityStatuss()
+        val result = bccChecker.run().toBackwardCompatibilityStatuses()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"
@@ -4331,7 +4331,7 @@ paths:
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/single_req_res_ct_overriden/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/single_req_res_ct_overriden/openapi_v2.yaml")
         val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
-        val result = bccChecker.run().toBackwardCompatibilityStatuss()
+        val result = bccChecker.run().toBackwardCompatibilityStatuses()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"
@@ -4391,7 +4391,7 @@ paths:
         val specificationV1 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v1.yaml")
         val specificationV2 = OpenApiSpecification.fromFile("src/test/resources/openapi/multi_req_res_ct_overriden/openapi_v2.yaml")
         val bccChecker = OpenApiBackwardCompatibilityChecker(specificationV1.toFeature(), specificationV2.toFeature())
-        val result = bccChecker.run().toBackwardCompatibilityStatuss()
+        val result = bccChecker.run().toBackwardCompatibilityStatuses()
 
         assertThat(result.report()).isEqualToNormalizingNewlines("""
         In scenario "Missing endpoint. Response: A simple string response"

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.flipkart.zjsonpatch.JsonPatch
 import io.specmatic.conversions.OpenApiSpecification
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.core.ChangeStatus
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import io.specmatic.core.utilities.Flags.Companion.using
 import io.specmatic.core.log.Verbose

--- a/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
@@ -50,20 +50,19 @@ class BccReportGeneratorTest {
         assertThat(reportOperations).hasSize(3)
 
         val groupedCreateOrder = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/orders.yaml" }
-        assertThat(groupedCreateOrder.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
         assertThat(groupedCreateOrder.tests).containsExactly(firstRecord, secondRecord)
         assertThat(groupedCreateOrder.qualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
-        assertThat(groupedCreateOrder.compatibility.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(groupedCreateOrder.status).isEqualTo(BackwardCompatibilityResult.Incompatible)
 
         val groupedGetOrders = reportOperations.single { it.operation == getOrders && it.specConfig.specification == "specs/orders.yaml" }
         assertThat(groupedGetOrders.tests).containsExactly(firstRecord)
         assertThat(groupedGetOrders.qualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
-        assertThat(groupedGetOrders.compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(groupedGetOrders.status).isEqualTo(BackwardCompatibilityResult.Compatible)
 
         val groupedPayments = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/payments.yaml" }
         assertThat(groupedPayments.qualifiers).containsExactly(CtrfOperationQualifiers.CHANGED)
         assertThat(groupedPayments.tests).containsExactly(thirdRecord)
-        assertThat(groupedPayments.compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(groupedPayments.status).isEqualTo(BackwardCompatibilityResult.Compatible)
     }
 
     @Test
@@ -166,7 +165,7 @@ class BccReportGeneratorTest {
             )
         ).single()
 
-        assertThat(reportOperation.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(reportOperation.qualifiers).contains(CtrfOperationQualifiers.CHANGED)
     }
 
     @Test
@@ -179,7 +178,7 @@ class BccReportGeneratorTest {
             )
         ).single()
 
-        assertThat(reportOperation.compatibility.changeStatus).isEqualTo(ChangeStatus.UNCHANGED)
+        assertThat(reportOperation.qualifiers).doesNotContain(CtrfOperationQualifiers.CHANGED)
     }
 
     @Test
@@ -194,8 +193,8 @@ class BccReportGeneratorTest {
         val createOrderReport = reportOperations.single { it.operation == createOrder }
         val getOrdersReport = reportOperations.single { it.operation == getOrders }
 
-        assertThat(createOrderReport.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
-        assertThat(getOrdersReport.compatibility.changeStatus).isEqualTo(ChangeStatus.CHANGED)
+        assertThat(createOrderReport.qualifiers).contains(CtrfOperationQualifiers.CHANGED)
+        assertThat(getOrdersReport.qualifiers).contains(CtrfOperationQualifiers.CHANGED)
     }
 
     @Test
@@ -208,7 +207,7 @@ class BccReportGeneratorTest {
             )
         )
 
-        assertThat(reportOperation.single().compatibility.result).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(reportOperation.single().status).isEqualTo(BackwardCompatibilityResult.Compatible)
     }
 
     @Test
@@ -221,7 +220,7 @@ class BccReportGeneratorTest {
             )
         )
 
-        assertThat(reportOperation.single().compatibility.result).isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(reportOperation.single().status).isEqualTo(BackwardCompatibilityResult.Incompatible)
     }
 
     @Test

--- a/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
@@ -3,7 +3,7 @@ package io.specmatic.core.report
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
-import io.specmatic.reporter.internal.dto.bcc.ChangeStatus
+import io.specmatic.core.ChangeStatus
 import io.specmatic.reporter.internal.dto.operation.APIOperation
 import io.specmatic.reporter.model.BackwardCompatibilityResult
 import io.specmatic.reporter.model.OpenAPIOperation
@@ -290,7 +290,6 @@ class BccReportGeneratorTest {
             override val specification: String = specification
             override val operations: Set<APIOperation> = operations
             override val result: BackwardCompatibilityResult = result
-            override val changeStatus: ChangeStatus = changeStatus
             override val operationQualifiers: List<CtrfOperationQualifiers> = effectiveQualifiers
         }
     }

--- a/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/report/BccReportGeneratorTest.kt
@@ -5,7 +5,7 @@ import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.reporter.ctrf.model.CtrfOperationQualifiers
 import io.specmatic.core.ChangeStatus
 import io.specmatic.reporter.internal.dto.operation.APIOperation
-import io.specmatic.reporter.model.BackwardCompatibilityResult
+import io.specmatic.reporter.model.BackwardCompatibilityStatus
 import io.specmatic.reporter.model.OpenAPIOperation
 import io.specmatic.reporter.model.SpecType
 import org.assertj.core.api.Assertions.assertThat
@@ -30,20 +30,20 @@ class BccReportGeneratorTest {
         val firstRecord = testRecord(
             specification = "specs/orders.yaml",
             operations = setOf(createOrder, getOrders),
-            result = BackwardCompatibilityResult.Compatible,
+            result = BackwardCompatibilityStatus.Compatible,
             operationQualifiers = listOf(CtrfOperationQualifiers.WIP),
         )
 
         val secondRecord = testRecord(
             specification = "specs/orders.yaml",
             operations = setOf(createOrder),
-            result = BackwardCompatibilityResult.Incompatible,
+            result = BackwardCompatibilityStatus.Incompatible,
         )
 
         val thirdRecord = testRecord(
             specification = "specs/payments.yaml",
             operations = setOf(createOrder),
-            result = BackwardCompatibilityResult.Compatible,
+            result = BackwardCompatibilityStatus.Compatible,
         )
 
         val reportOperations = generator.generateReportOperations(listOf(firstRecord, secondRecord, thirdRecord))
@@ -52,17 +52,17 @@ class BccReportGeneratorTest {
         val groupedCreateOrder = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/orders.yaml" }
         assertThat(groupedCreateOrder.tests).containsExactly(firstRecord, secondRecord)
         assertThat(groupedCreateOrder.qualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
-        assertThat(groupedCreateOrder.status).isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(groupedCreateOrder.status).isEqualTo(BackwardCompatibilityStatus.Incompatible)
 
         val groupedGetOrders = reportOperations.single { it.operation == getOrders && it.specConfig.specification == "specs/orders.yaml" }
         assertThat(groupedGetOrders.tests).containsExactly(firstRecord)
         assertThat(groupedGetOrders.qualifiers).containsExactly(CtrfOperationQualifiers.WIP, CtrfOperationQualifiers.CHANGED)
-        assertThat(groupedGetOrders.status).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(groupedGetOrders.status).isEqualTo(BackwardCompatibilityStatus.Compatible)
 
         val groupedPayments = reportOperations.single { it.operation == createOrder && it.specConfig.specification == "specs/payments.yaml" }
         assertThat(groupedPayments.qualifiers).containsExactly(CtrfOperationQualifiers.CHANGED)
         assertThat(groupedPayments.tests).containsExactly(thirdRecord)
-        assertThat(groupedPayments.status).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(groupedPayments.status).isEqualTo(BackwardCompatibilityStatus.Compatible)
     }
 
     @Test
@@ -202,12 +202,12 @@ class BccReportGeneratorTest {
         val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
         val reportOperation = generator.generateReportOperations(
             listOf(
-                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Compatible),
-                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Compatible),
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityStatus.Compatible),
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityStatus.Compatible),
             )
         )
 
-        assertThat(reportOperation.single().status).isEqualTo(BackwardCompatibilityResult.Compatible)
+        assertThat(reportOperation.single().status).isEqualTo(BackwardCompatibilityStatus.Compatible)
     }
 
     @Test
@@ -215,12 +215,12 @@ class BccReportGeneratorTest {
         val createOrder = openApiOperation(path = "/orders", method = "POST", responseCode = 201)
         val reportOperation = generator.generateReportOperations(
             listOf(
-                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Compatible),
-                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityResult.Incompatible),
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityStatus.Compatible),
+                testRecord(operations = setOf(createOrder), result = BackwardCompatibilityStatus.Incompatible),
             )
         )
 
-        assertThat(reportOperation.single().status).isEqualTo(BackwardCompatibilityResult.Incompatible)
+        assertThat(reportOperation.single().status).isEqualTo(BackwardCompatibilityStatus.Incompatible)
     }
 
     @Test
@@ -272,7 +272,7 @@ class BccReportGeneratorTest {
         repository: String? = "https://github.com/example/repo.git",
         changeStatus: ChangeStatus = ChangeStatus.CHANGED,
         operationQualifiers: List<CtrfOperationQualifiers> = emptyList(),
-        result: BackwardCompatibilityResult = BackwardCompatibilityResult.Compatible,
+        result: BackwardCompatibilityStatus = BackwardCompatibilityStatus.Compatible,
     ): CtrfBackwardCompatibilityRecord {
         val effectiveQualifiers = buildList {
             addAll(operationQualifiers)
@@ -289,7 +289,7 @@ class BccReportGeneratorTest {
             override val repository: String? = repository
             override val specification: String = specification
             override val operations: Set<APIOperation> = operations
-            override val result: BackwardCompatibilityResult = result
+            override val result: BackwardCompatibilityStatus = result
             override val operationQualifiers: List<CtrfOperationQualifiers> = effectiveQualifiers
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.46.2-SNAPSHOT
 specmaticGradlePluginVersion=0.15.8
-specmaticReporterVersion=0.3.24
+specmaticReporterVersion=0.3.25-SNAPSHOT
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
## Summary
- Stop emitting the nested `compatibility { changeStatus, result }` object on BCC report operations. `result` is now emitted at the top level as `status`.
- `changeStatus` was already captured in the `qualifiers` array as the `"changed"` qualifier (#2510), so the wrapper is redundant.
- Bump `specmaticReporterVersion` to `0.3.25-SNAPSHOT` for the matching schema change in specmatic-reporter.
- Update `TestBackwardCompatibilityKtTest` and `BccReportGeneratorTest` assertions to read `status` and rely on `qualifiers` for change-status checks.
- Move `ChangeStatus` enum out of the reporter dto into specmatic core (`io.specmatic.core.ChangeStatus`). It was always an internal signal used by `ScenarioFingerprint` / `OpenApiBackwardCompatibilityChecker` to populate the `"changed"` qualifier; it never appeared in CTRF output.
- BCC status JSON values are now lowercase (`compatible`/`incompatible`) to match the now-unified CTRF operation-level `status` field shared with `CoverageStatus`.
- Adopt the rename `BackwardCompatibilityResult` → `BackwardCompatibilityStatus` from specmatic-reporter.

## Companion PRs
- specmatic-reporter: https://github.com/specmatic/specmatic-reporter/pull/138
- specmatic-html-reporter: https://github.com/specmatic/specmatic-html-reporter/pull/118

## Test plan
- [x] `./gradlew :specmatic-core:test --tests "io.specmatic.core.report.BccReportGeneratorTest" --tests "io.specmatic.core.TestBackwardCompatibilityKtTest" --tests "io.specmatic.core.OpenApiBackwardCompatibilityCheckRecordTest" --tests "io.specmatic.core.ScenarioFingerprintTest"` (148 passed)