### PR TITLE
fix(core): register report config provider

### DIFF
--- a/core/src/main/resources/META-INF/services/io.specmatic.reporter.config.ReportConfigProvider
+++ b/core/src/main/resources/META-INF/services/io.specmatic.reporter.config.ReportConfigProvider
@@ -1,0 +1,1 @@
+io.specmatic.core.config.ConfigValuesProviderImpl


### PR DESCRIPTION
## What
- register `ConfigValuesProviderImpl` as a `ReportConfigProvider` service

## Why
- `specmatic-reporter` discovers the report directory override through Java `ServiceLoader`
- without this service registration it always falls back to `build/reports/specmatic`, even when `specmatic.governance.report.outputDirectory` is configured

## Validation
- verified locally that `send-report` picks up a custom `specmatic.governance.report.outputDirectory` after this change