### PR TITLE
Fix BCC CTRF report dropping all but the last checked spec

### DIFF
--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -5,6 +5,7 @@ import io.specmatic.core.IFeature
 import io.specmatic.core.Results
 import io.specmatic.core.SpecmaticConfig
 import io.specmatic.core.config.LoggingConfiguration
+import io.specmatic.core.generateBackwardCompatibilityReport
 import io.specmatic.core.git.GitCommand
 import io.specmatic.core.git.SystemGit
 import io.specmatic.core.loadSpecmaticConfigIfAvailableElseDefault
@@ -14,6 +15,7 @@ import io.specmatic.license.core.LicenseResolver
 import io.specmatic.license.core.LicensedProduct
 import io.specmatic.license.core.SpecmaticFeature
 import io.specmatic.reporter.backwardcompat.dto.OperationUsageResponse
+import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import picocli.CommandLine.Option
 import java.io.File
 import java.nio.file.Paths
@@ -77,7 +79,7 @@ abstract class BackwardCompatibilityCheckBaseCommand(
     protected val effectiveTargetPath: String by lazy { options.targetPath ?: backwardCompConfig?.targetPath.orEmpty() }
     protected val effectiveStrictMode: Boolean by lazy { options.strictMode ?: backwardCompConfig?.strictMode ?: false }
 
-    abstract fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): Results
+    abstract fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): BackwardCompatibilityCheckResult
     abstract fun File.isValidFileFormat(): Boolean
     abstract fun File.isValidSpec(): Boolean
     abstract fun getFeatureFromSpecPath(path: String): IFeature
@@ -89,10 +91,6 @@ abstract class BackwardCompatibilityCheckBaseCommand(
     open fun regexForMatchingReferred(schemaFileName: String): String = ""
     open fun areExamplesValid(feature: IFeature, which: String): Boolean = true
     open fun getUnusedExamples(feature: IFeature): Set<String> = emptySet()
-
-    // Invoked once after every changed spec has been checked. Subclasses that accumulate report
-    // records across specs override this to emit a single combined report.
-    open fun generateReport() {}
 
     final override fun call(): Int {
         configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = options.debugLog))
@@ -230,6 +228,11 @@ abstract class BackwardCompatibilityCheckBaseCommand(
     val unknownResult =
         Pair<CompatibilityResult, List<OperationUsageResponse>>(CompatibilityResult.UNKNOWN, emptyList())
 
+    data class BackwardCompatibilityCheckResult(
+        val results: Results,
+        val reportRecords: List<CtrfBackwardCompatibilityRecord> = emptyList()
+    )
+
     data class ProcessedSpec(
         val specFilePath: String,
         val backwardCompatibilityResult: Results,
@@ -239,11 +242,13 @@ abstract class BackwardCompatibilityCheckBaseCommand(
         val computedCompatibilityCheckHookResult: Pair<CompatibilityResult, List<OperationUsageResponse>?> = Pair(
             CompatibilityResult.UNKNOWN, emptyList()
         ),
-        val isNewFile: Boolean
+        val isNewFile: Boolean,
+        val reportRecords: List<CtrfBackwardCompatibilityRecord> = emptyList()
     )
 
     private fun runBackwardCompatibilityCheckFor(files: Set<String>, baseBranch: String): CompatibilityReport {
         val treeishWithChanges = getCurrentBranch()
+        val reportStartTime = System.currentTimeMillis()
 
         try {
             // FIRST PASS: collect results without logging. This includes reading newer/older features and running the lightweight compatibility check.
@@ -284,7 +289,8 @@ abstract class BackwardCompatibilityCheckBaseCommand(
 
                     val older = getFeatureFromSpecPath(specFilePath)
 
-                    val backwardCompatibilityResult = checkBackwardCompatibility(older, newer)
+                    val checkResult = checkBackwardCompatibility(older, newer)
+                    val backwardCompatibilityResult = checkResult.results
                     val result =
                         if (backwardCompatibilityResult.successExcludingIgnorableFailures()) CompatibilityResult.PASSED else CompatibilityResult.FAILED
 
@@ -300,7 +306,8 @@ abstract class BackwardCompatibilityCheckBaseCommand(
                         newer = newer,
                         unusedExamples = unusedExamples,
                         precomputedCompatibilityResult = result,
-                        isNewFile = false
+                        isNewFile = false,
+                        reportRecords = checkResult.reportRecords
                     )
                 } finally {
                     gitCommand.checkout(treeishWithChanges)
@@ -326,7 +333,11 @@ abstract class BackwardCompatibilityCheckBaseCommand(
                 }
             }
 
-            generateReport()
+            generateBackwardCompatibilityReport(
+                specsValidatedByHook.flatMap { it.reportRecords },
+                reportStartTime,
+                System.currentTimeMillis()
+            )
 
             return CompatibilityReport(results)
         } finally {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -375,14 +375,19 @@ abstract class BackwardCompatibilityCheckBaseCommand(
                 })
             }
 
-            return futures.map { (processed, future) ->
-                try {
-                    val compatibilityResult = future.get()
-                    processed.copy(computedCompatibilityCheckHookResult = compatibilityResult)
+            val hookResultsBySpec = futures.associate { (processed, future) ->
+                processed.specFilePath to try {
+                    future.get()
                 } catch (e: Throwable) {
                     logger.log(e)
-                    processed.copy(computedCompatibilityCheckHookResult = unknownResult)
+                    unknownResult
                 }
+            }
+
+            return processedSpecs.map { processed ->
+                hookResultsBySpec[processed.specFilePath]
+                    ?.let { processed.copy(computedCompatibilityCheckHookResult = it) }
+                    ?: processed
             }
         } finally {
             executor.shutdown()

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommand.kt
@@ -90,6 +90,10 @@ abstract class BackwardCompatibilityCheckBaseCommand(
     open fun areExamplesValid(feature: IFeature, which: String): Boolean = true
     open fun getUnusedExamples(feature: IFeature): Set<String> = emptySet()
 
+    // Invoked once after every changed spec has been checked. Subclasses that accumulate report
+    // records across specs override this to emit a single combined report.
+    open fun generateReport() {}
+
     final override fun call(): Int {
         configureLogging(LoggingConfiguration.Companion.LoggingFromOpts(debug = options.debugLog))
         addShutdownHook()
@@ -321,6 +325,8 @@ abstract class BackwardCompatibilityCheckBaseCommand(
                     getCompatibilityResultAndLogResults(processed)
                 }
             }
+
+            generateReport()
 
             return CompatibilityReport(results)
         } finally {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -7,6 +7,7 @@ import io.specmatic.core.*
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.license.core.cli.Category
+import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.Command
 import java.io.File
@@ -24,8 +25,22 @@ import kotlin.io.path.pathString
 @Category("Specmatic core")
 class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()): BackwardCompatibilityCheckBaseCommand(options) {
 
+    private val reportRecords = mutableListOf<CtrfBackwardCompatibilityRecord>()
+    private var reportStartTime: Long? = null
+
     override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): Results {
-        return testBackwardCompatibility(oldFeature as Feature, newFeature as Feature)
+        if (reportStartTime == null) reportStartTime = System.currentTimeMillis()
+        val (results, records) = backwardCompatibilityRecords(oldFeature as Feature, newFeature as Feature)
+        reportRecords.addAll(records)
+        return results
+    }
+
+    override fun generateReport() {
+        generateBackwardCompatibilityReport(
+            reportRecords,
+            reportStartTime ?: System.currentTimeMillis(),
+            System.currentTimeMillis()
+        )
     }
 
     companion object {

--- a/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
+++ b/application/src/main/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckCommandV2.kt
@@ -7,7 +7,6 @@ import io.specmatic.core.*
 import io.specmatic.core.log.logger
 import io.specmatic.core.utilities.exceptionCauseMessage
 import io.specmatic.license.core.cli.Category
-import io.specmatic.reporter.ctrf.model.CtrfBackwardCompatibilityRecord
 import io.specmatic.stub.isOpenAPI
 import picocli.CommandLine.Command
 import java.io.File
@@ -25,22 +24,9 @@ import kotlin.io.path.pathString
 @Category("Specmatic core")
 class BackwardCompatibilityCheckCommandV2(options: BackwardCompatibilityCheckOptions = BackwardCompatibilityCheckOptions()): BackwardCompatibilityCheckBaseCommand(options) {
 
-    private val reportRecords = mutableListOf<CtrfBackwardCompatibilityRecord>()
-    private var reportStartTime: Long? = null
-
-    override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): Results {
-        if (reportStartTime == null) reportStartTime = System.currentTimeMillis()
+    override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): BackwardCompatibilityCheckResult {
         val (results, records) = backwardCompatibilityRecords(oldFeature as Feature, newFeature as Feature)
-        reportRecords.addAll(records)
-        return results
-    }
-
-    override fun generateReport() {
-        generateBackwardCompatibilityReport(
-            reportRecords,
-            reportStartTime ?: System.currentTimeMillis(),
-            System.currentTimeMillis()
-        )
+        return BackwardCompatibilityCheckResult(results, records)
     }
 
     companion object {

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -1888,6 +1888,135 @@ class BackwardCompatibilityCheckCommandV2Test {
                 entry(spec2Path, "GET /b -> incompatible")
             )
         }
+
+        @Test
+        fun `hook passing a single failing spec reports the failure but exits successfully`() {
+            fun specWithType(path: String, type: String) = """
+                openapi: 3.0.0
+                info: { title: API, version: 1.0.0 }
+                paths:
+                  $path:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [value]
+                                properties: { value: { type: $type } }
+            """.trimIndent()
+
+            val spec = tempDir.resolve("spec.yaml")
+
+            spec.writeText(specWithType("/a", "string"))
+            commit(tempDir, "Initial contract")
+            val baseBranch = SystemGit(tempDir.absolutePath).currentBranch()
+
+            ProcessBuilder("git", "switch", "-c", "breaking-change")
+                .directory(tempDir)
+                .inheritIO()
+                .start()
+                .waitFor()
+
+            // The spec changes the response body type from string to integer, which is breaking.
+            spec.writeText(specWithType("/a", "integer"))
+            commit(tempDir, "Make the spec breaking")
+
+            val configFile = remoteDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    reportDirPath: ${tempDir.resolve("reports").canonicalPath}
+                    """.trimIndent()
+                )
+            }
+
+            val (stdOut, exitCode) = withRegisteredService(
+                BackwardCompatibilityCheckHook::class.java,
+                AlwaysPassingBackwardCompatibilityCheckHook::class.java
+            ) {
+                captureStandardOutput(redirectStdErrToStdout = true) {
+                    using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+                        BackwardCompatibilityCheckCommandV2().apply {
+                            options.repoDir = tempDir.canonicalPath
+                            options.baseBranch = baseBranch
+                        }.call()
+                    }
+                }
+            }
+
+            val output = stdOut.lineSequence().joinToString("\n") { it.trimEnd() }.replace('\\', '/')
+
+            val specPath = spec.canonicalFile.invariantSeparatorsPath
+            val htmlReportPath = tempDir.resolve("reports/backward_compatibility/html/index.html")
+                .canonicalFile.invariantSeparatorsPath
+
+            // The console output still reports the spec as failing, but the hook passes the
+            // build so the exit code is 0.
+            assertThat(exitCode).isEqualTo(0)
+            assertThat(output).isEqualToNormalizingNewlines("""
+            Checking backward compatibility of the following specs:
+
+              - Specs that have changed:
+                1. $specPath
+
+            --------------------
+
+
+
+            API Specification Summary: $specPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            API Specification Summary: $specPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            [Compatibility Check] Executing 1 scenarios for GET /a against 1 operations
+              - GET /a -> 200 (responseContentType application/json)
+            [Compatibility Check] Verdict: FAIL
+            Validating 1 failed spec(s) with the backward compatibility check hook...
+            Hook validation complete.
+            1. Running the check for $specPath:
+              ________________________________________
+              The Incompatibility Report:
+
+                In scenario "GET /a. Response: ok"
+                API: GET /a -> 200
+
+                  >> RESPONSE.BODY.value
+
+                      This is number in the new specification response but string in the old specification
+
+
+              --------------------
+              Verdict for spec $specPath:
+                (HOOK: PASSED) The hook declared the failing spec as backward compatible
+              --------------------
+
+
+            Generating BCC report for 2 checks and 1 operations...
+            Generating HTML report in $htmlReportPath
+            Files checked: 1 (Passed: 1, Failed: 0)
+            """.trimIndent())
+
+            val reportJson = bccReportJson(tempDir.resolve("reports/backward_compatibility"))
+
+            // The failing operation is still present in the report even though the hook passed the build.
+            val executionDetails = reportJson.path("results").path("summary").path("extra").path("executionDetails")
+            val operationsBySpec = executionDetails.associate { detail ->
+                detail.path("specification").asText().replace('\\', '/') to detail.path("operations").single().let {
+                    "${it.path("method").asText()} ${it.path("path").asText()} -> ${it.path("status").asText()}"
+                }
+            }
+            assertThat(operationsBySpec).containsOnly(
+                entry(specPath, "GET /a -> incompatible")
+            )
+        }
     }
 
     @Test
@@ -2026,4 +2155,26 @@ class MixedResultBackwardCompatibilityCheckHook : BackwardCompatibilityCheckHook
         const val PASSED_SPEC = "hook-passed.yaml"
         const val FAILED_SPEC = "hook-failed.yaml"
     }
+}
+
+class AlwaysPassingBackwardCompatibilityCheckHook : BackwardCompatibilityCheckHook {
+    override fun check(
+        backwardCompatibilityResult: Results,
+        centralRepoUrl: String,
+        specFilePath: String,
+    ): Pair<CompatibilityResult, List<OperationUsageResponse>?> = CompatibilityResult.PASSED to emptyList()
+
+    override fun logStartedMessage(failedSpecs: List<BackwardCompatibilityCheckBaseCommand.ProcessedSpec>) {
+        println("Validating ${failedSpecs.size} failed spec(s) with the backward compatibility check hook...")
+    }
+
+    override fun logCompletedMessage() {
+        println("Hook validation complete.")
+    }
+
+    override fun failedVerdictAndMessage(
+        processedSpec: BackwardCompatibilityCheckBaseCommand.ProcessedSpec,
+        strictMode: Boolean,
+    ): Pair<CompatibilityResult, String> =
+        CompatibilityResult.PASSED to "(HOOK: PASSED) The hook declared the failing spec as backward compatible"
 }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -19,6 +19,7 @@ import io.specmatic.license.core.SpecmaticFeature
 import io.specmatic.license.core.SpecmaticProtocol
 import io.specmatic.reporter.backwardcompat.dto.OperationUsageResponse
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -1684,9 +1685,17 @@ class BackwardCompatibilityCheckCommandV2Test {
 
             val reportJson = bccReportJson(tempDir.resolve("reports/backward_compatibility"))
 
+            // Both specs are present, each reported as incompatible on its own operation.
             val executionDetails = reportJson.path("results").path("summary").path("extra").path("executionDetails")
-            val reportedSpecs = executionDetails.map { it.path("specification").asText() }
-            assertThat(reportedSpecs).containsExactlyInAnyOrder(spec1Path, spec2Path)
+            val operationsBySpec = executionDetails.associate { detail ->
+                detail.path("specification").asText() to detail.path("operations").single().let {
+                    "${it.path("method").asText()} ${it.path("path").asText()} -> ${it.path("status").asText()}"
+                }
+            }
+            assertThat(operationsBySpec).containsOnly(
+                entry(spec1Path, "GET /a -> incompatible"),
+                entry(spec2Path, "GET /b -> incompatible")
+            )
         }
     }
 

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -1688,7 +1688,7 @@ class BackwardCompatibilityCheckCommandV2Test {
             // Both specs are present, each reported as incompatible on its own operation.
             val executionDetails = reportJson.path("results").path("summary").path("extra").path("executionDetails")
             val operationsBySpec = executionDetails.associate { detail ->
-                detail.path("specification").asText() to detail.path("operations").single().let {
+                detail.path("specification").asText().replace('\\', '/') to detail.path("operations").single().let {
                     "${it.path("method").asText()} ${it.path("path").asText()} -> ${it.path("status").asText()}"
                 }
             }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -1534,20 +1534,159 @@ class BackwardCompatibilityCheckCommandV2Test {
 
         private fun fixture(name: String): File =
             File("src/test/resources/specifications/bcc_change_tracking_external_refs/$name").canonicalFile
+    }
 
-        private fun bccReportJson(reportDir: File): JsonNode {
-            val htmlReport = reportDir.resolve("html/index.html")
-            assertThat(htmlReport).exists()
+    @Nested
+    inner class BccReportTests {
+        @Test
+        fun `ctrf report includes every breaking spec when more than one spec is breaking`() {
+            fun specWithType(path: String, type: String) = """
+                openapi: 3.0.0
+                info: { title: API, version: 1.0.0 }
+                paths:
+                  $path:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [value]
+                                properties: { value: { type: $type } }
+            """.trimIndent()
 
-            val html = htmlReport.readText()
-            val reportLiteral = html
-                .substringAfter("const report = ")
-                .substringBefore("const specmaticConfig =")
-                .trim()
-                .removeSuffix(";")
-                .trim()
+            val spec1 = tempDir.resolve("spec1.yaml")
+            val spec2 = tempDir.resolve("spec2.yaml")
 
-            return objectMapper.readTree(reportLiteral)
+            spec1.writeText(specWithType("/a", "string"))
+            spec2.writeText(specWithType("/b", "string"))
+            commit(tempDir, "Initial contract")
+            val baseBranch = SystemGit(tempDir.absolutePath).currentBranch()
+
+            ProcessBuilder("git", "switch", "-c", "breaking-change")
+                .directory(tempDir)
+                .inheritIO()
+                .start()
+                .waitFor()
+
+            // Both specs change the response body type from string to integer, which is breaking.
+            spec1.writeText(specWithType("/a", "integer"))
+            spec2.writeText(specWithType("/b", "integer"))
+            commit(tempDir, "Make both specs breaking")
+
+            val configFile = remoteDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    reportDirPath: ${tempDir.resolve("reports").canonicalPath}
+                    """.trimIndent()
+                )
+            }
+
+            val (stdOut, exitCode) = captureStandardOutput(redirectStdErrToStdout = true) {
+                using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+                    BackwardCompatibilityCheckCommandV2().apply {
+                        options.repoDir = tempDir.canonicalPath
+                        options.baseBranch = baseBranch
+                    }.call()
+                }
+            }
+
+            val output = stdOut.lineSequence().joinToString("\n") { it.trimEnd() }.replace('\\', '/')
+
+            val spec1Path = spec1.canonicalFile.invariantSeparatorsPath
+            val spec2Path = spec2.canonicalFile.invariantSeparatorsPath
+            val htmlReportPath = tempDir.resolve("reports/backward_compatibility/html/index.html")
+                .canonicalFile.invariantSeparatorsPath
+
+            // The console output correctly reports BOTH specs as incompatible.
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(output).isEqualToNormalizingNewlines("""
+            Checking backward compatibility of the following specs:
+
+              - Specs that have changed:
+                1. $spec1Path
+                2. $spec2Path
+
+            --------------------
+
+
+
+            API Specification Summary: $spec1Path
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            API Specification Summary: $spec1Path
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            [Compatibility Check] Executing 1 scenarios for GET /a against 1 operations
+              - GET /a -> 200 (responseContentType application/json)
+            [Compatibility Check] Verdict: FAIL
+
+            API Specification Summary: $spec2Path
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            API Specification Summary: $spec2Path
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            [Compatibility Check] Executing 1 scenarios for GET /b against 1 operations
+              - GET /b -> 200 (responseContentType application/json)
+            [Compatibility Check] Verdict: FAIL
+            1. Running the check for $spec1Path:
+              ________________________________________
+              The Incompatibility Report:
+
+                In scenario "GET /a. Response: ok"
+                API: GET /a -> 200
+
+                  >> RESPONSE.BODY.value
+
+                      This is number in the new specification response but string in the old specification
+
+
+              --------------------
+              Verdict for spec $spec1Path:
+                (INCOMPATIBLE) The changes to the spec are NOT backward compatible with the corresponding spec from main
+              --------------------
+
+
+            2. Running the check for $spec2Path:
+              ________________________________________
+              The Incompatibility Report:
+
+                In scenario "GET /b. Response: ok"
+                API: GET /b -> 200
+
+                  >> RESPONSE.BODY.value
+
+                      This is number in the new specification response but string in the old specification
+
+
+              --------------------
+              Verdict for spec $spec2Path:
+                (INCOMPATIBLE) The changes to the spec are NOT backward compatible with the corresponding spec from main
+              --------------------
+
+
+            Generating BCC report for 4 checks and 2 operations...
+            Generating HTML report in $htmlReportPath
+            Files checked: 2 (Passed: 0, Failed: 2)
+            """.trimIndent())
+
+            val reportJson = bccReportJson(tempDir.resolve("reports/backward_compatibility"))
+
+            val executionDetails = reportJson.path("results").path("summary").path("extra").path("executionDetails")
+            val reportedSpecs = executionDetails.map { it.path("specification").asText() }
+            assertThat(reportedSpecs).containsExactlyInAnyOrder(spec1Path, spec2Path)
         }
     }
 
@@ -1624,6 +1763,21 @@ class BackwardCompatibilityCheckCommandV2Test {
     private fun commit(repoDir: File, commitMessage: String) {
         ProcessBuilder("git", "add", ".").directory(repoDir).inheritIO().start().waitFor()
         ProcessBuilder("git", "commit", "-m", commitMessage).directory(repoDir).inheritIO().start().waitFor()
+    }
+
+    private fun bccReportJson(reportDir: File): JsonNode {
+        val htmlReport = reportDir.resolve("html/index.html")
+        assertThat(htmlReport).exists()
+
+        val html = htmlReport.readText()
+        val reportLiteral = html
+            .substringAfter("const report = ")
+            .substringBefore("const specmaticConfig =")
+            .trim()
+            .removeSuffix(";")
+            .trim()
+
+        return objectMapper.readTree(reportLiteral)
     }
 
 }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -1591,10 +1591,9 @@ class BackwardCompatibilityCheckCommandV2Test {
                 )
             }
 
-            MixedResultBackwardCompatibilityCheckHook.reset()
-
-            val (stdOut, exitCode) = withServiceLoaderEntries(
-                mapOf(BackwardCompatibilityCheckHook::class.java to MixedResultBackwardCompatibilityCheckHook::class.java.name)
+            val (stdOut, exitCode) = withRegisteredService(
+                BackwardCompatibilityCheckHook::class.java,
+                MixedResultBackwardCompatibilityCheckHook::class.java
             ) {
                 captureStandardOutput(redirectStdErrToStdout = true) {
                     using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
@@ -1615,12 +1614,6 @@ class BackwardCompatibilityCheckCommandV2Test {
                 .canonicalFile.invariantSeparatorsPath
 
             assertThat(exitCode).isEqualTo(1)
-            assertThat(MixedResultBackwardCompatibilityCheckHook.checkedSpecs)
-                .containsExactlyInAnyOrder(
-                    MixedResultBackwardCompatibilityCheckHook.PASSED_SPEC,
-                    MixedResultBackwardCompatibilityCheckHook.FAILED_SPEC
-                )
-
             assertThat(output).isEqualToNormalizingNewlines("""
             Checking backward compatibility of the following specs:
 
@@ -1987,15 +1980,12 @@ class BackwardCompatibilityCheckCommandV2Test {
         return objectMapper.readTree(reportLiteral)
     }
 
-    private fun <T> withServiceLoaderEntries(entries: Map<Class<*>, String>, block: () -> T): T {
+    private fun <T> withRegisteredService(service: Class<*>, implementation: Class<*>, block: () -> T): T {
         val previousContextClassLoader = Thread.currentThread().contextClassLoader
         val serviceLoaderDir = Files.createTempDirectory("specmatic-service-loader-test")
-        val servicesDir = serviceLoaderDir.resolve("META-INF/services")
-        Files.createDirectories(servicesDir)
-
-        entries.forEach { (service, implementationClassName) ->
-            Files.writeString(servicesDir.resolve(service.name), "$implementationClassName\n")
-        }
+        val serviceFile = serviceLoaderDir.resolve("META-INF/services/${service.name}")
+        Files.createDirectories(serviceFile.parent)
+        Files.writeString(serviceFile, "${implementation.name}\n")
 
         val classLoader = URLClassLoader(arrayOf(serviceLoaderDir.toUri().toURL()), previousContextClassLoader)
         Thread.currentThread().contextClassLoader = classLoader
@@ -2016,14 +2006,10 @@ class MixedResultBackwardCompatibilityCheckHook : BackwardCompatibilityCheckHook
         backwardCompatibilityResult: Results,
         centralRepoUrl: String,
         specFilePath: String,
-    ): Pair<CompatibilityResult, List<OperationUsageResponse>?> {
-        checkedSpecs.add(specFilePath)
-
-        return when (specFilePath) {
-            PASSED_SPEC -> CompatibilityResult.PASSED to emptyList()
-            FAILED_SPEC -> CompatibilityResult.FAILED to emptyList()
-            else -> CompatibilityResult.UNKNOWN to emptyList()
-        }
+    ): Pair<CompatibilityResult, List<OperationUsageResponse>?> = when (specFilePath) {
+        PASSED_SPEC -> CompatibilityResult.PASSED to emptyList()
+        FAILED_SPEC -> CompatibilityResult.FAILED to emptyList()
+        else -> CompatibilityResult.UNKNOWN to emptyList()
     }
 
     override fun logStartedMessage(failedSpecs: List<BackwardCompatibilityCheckBaseCommand.ProcessedSpec>) {}
@@ -2039,10 +2025,5 @@ class MixedResultBackwardCompatibilityCheckHook : BackwardCompatibilityCheckHook
     companion object {
         const val PASSED_SPEC = "hook-passed.yaml"
         const val FAILED_SPEC = "hook-failed.yaml"
-        val checkedSpecs = java.util.concurrent.CopyOnWriteArrayList<String>()
-
-        fun reset() {
-            checkedSpecs.clear()
-        }
     }
 }

--- a/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
+++ b/application/src/test/kotlin/application/BackwardCompatibilityCheckCommandV2Test.kt
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
 import java.nio.file.Paths
 
 class BackwardCompatibilityCheckCommandV2Test {
@@ -1540,6 +1542,202 @@ class BackwardCompatibilityCheckCommandV2Test {
     @Nested
     inner class BccReportTests {
         @Test
+        fun `ctrf report includes compatible specs when hook validates mixed failures`() {
+            fun specWithType(path: String, type: String, extraProperty: String = "") = """
+                openapi: 3.0.0
+                info: { title: API, version: 1.0.0 }
+                paths:
+                  $path:
+                    get:
+                      responses:
+                        '200':
+                          description: ok
+                          content:
+                            application/json:
+                              schema:
+                                type: object
+                                required: [value]
+                                properties: { value: { type: $type }$extraProperty }
+            """.trimIndent()
+
+            val compatibleSpec = tempDir.resolve("compatible.yaml")
+            val hookPassedSpec = tempDir.resolve(MixedResultBackwardCompatibilityCheckHook.PASSED_SPEC)
+            val hookFailedSpec = tempDir.resolve(MixedResultBackwardCompatibilityCheckHook.FAILED_SPEC)
+
+            compatibleSpec.writeText(specWithType("/compatible", "string"))
+            hookPassedSpec.writeText(specWithType("/hook-passed", "string"))
+            hookFailedSpec.writeText(specWithType("/hook-failed", "string"))
+            commit(tempDir, "Initial contract")
+            val baseBranch = SystemGit(tempDir.absolutePath).currentBranch()
+
+            ProcessBuilder("git", "switch", "-c", "mixed-hook-results")
+                .directory(tempDir)
+                .inheritIO()
+                .start()
+                .waitFor()
+
+            // This spec changes compatibly, while the two hook specs break the response type.
+            compatibleSpec.writeText(specWithType("/compatible", "string", ", note: { type: string }"))
+            hookPassedSpec.writeText(specWithType("/hook-passed", "integer"))
+            hookFailedSpec.writeText(specWithType("/hook-failed", "integer"))
+            commit(tempDir, "Mix compatible and breaking specs")
+
+            val configFile = remoteDir.resolve("specmatic.yaml").apply {
+                writeText(
+                    """
+                    version: 2
+                    reportDirPath: ${tempDir.resolve("reports").canonicalPath}
+                    """.trimIndent()
+                )
+            }
+
+            MixedResultBackwardCompatibilityCheckHook.reset()
+
+            val (stdOut, exitCode) = withServiceLoaderEntries(
+                mapOf(BackwardCompatibilityCheckHook::class.java to MixedResultBackwardCompatibilityCheckHook::class.java.name)
+            ) {
+                captureStandardOutput(redirectStdErrToStdout = true) {
+                    using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+                        BackwardCompatibilityCheckCommandV2().apply {
+                            options.repoDir = tempDir.canonicalPath
+                            options.baseBranch = baseBranch
+                        }.call()
+                    }
+                }
+            }
+
+            val output = stdOut.lineSequence().joinToString("\n") { it.trimEnd() }.replace('\\', '/')
+
+            val compatibleSpecPath = compatibleSpec.canonicalFile.invariantSeparatorsPath
+            val hookPassedSpecPath = hookPassedSpec.canonicalFile.invariantSeparatorsPath
+            val hookFailedSpecPath = hookFailedSpec.canonicalFile.invariantSeparatorsPath
+            val htmlReportPath = tempDir.resolve("reports/backward_compatibility/html/index.html")
+                .canonicalFile.invariantSeparatorsPath
+
+            assertThat(exitCode).isEqualTo(1)
+            assertThat(MixedResultBackwardCompatibilityCheckHook.checkedSpecs)
+                .containsExactlyInAnyOrder(
+                    MixedResultBackwardCompatibilityCheckHook.PASSED_SPEC,
+                    MixedResultBackwardCompatibilityCheckHook.FAILED_SPEC
+                )
+
+            assertThat(output).isEqualToNormalizingNewlines("""
+            Checking backward compatibility of the following specs:
+
+              - Specs that have changed:
+                1. $compatibleSpecPath
+                2. $hookFailedSpecPath
+                3. $hookPassedSpecPath
+
+            --------------------
+
+
+
+            API Specification Summary: $compatibleSpecPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            API Specification Summary: $compatibleSpecPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            [Compatibility Check] Executing 1 scenarios for GET /compatible against 1 operations
+              - GET /compatible -> 200 (responseContentType application/json)
+            [Compatibility Check] Verdict: PASS
+
+            API Specification Summary: $hookFailedSpecPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            API Specification Summary: $hookFailedSpecPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            [Compatibility Check] Executing 1 scenarios for GET /hook-failed against 1 operations
+              - GET /hook-failed -> 200 (responseContentType application/json)
+            [Compatibility Check] Verdict: FAIL
+
+            API Specification Summary: $hookPassedSpecPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            API Specification Summary: $hookPassedSpecPath
+              OpenAPI Version: 3.0.0
+              API Paths: 1, API Operations: 1
+
+
+            [Compatibility Check] Executing 1 scenarios for GET /hook-passed against 1 operations
+              - GET /hook-passed -> 200 (responseContentType application/json)
+            [Compatibility Check] Verdict: FAIL
+            1. Running the check for $compatibleSpecPath:
+              --------------------
+              Verdict for spec $compatibleSpecPath:
+                (COMPATIBLE) The spec is backward compatible with the corresponding spec from main
+              --------------------
+
+
+            2. Running the check for $hookFailedSpecPath:
+              ________________________________________
+              The Incompatibility Report:
+
+                In scenario "GET /hook-failed. Response: ok"
+                API: GET /hook-failed -> 200
+
+                  >> RESPONSE.BODY.value
+
+                      This is number in the new specification response but string in the old specification
+
+
+              --------------------
+              Verdict for spec $hookFailedSpecPath:
+                (HOOK: FAILED)
+              --------------------
+
+
+            3. Running the check for $hookPassedSpecPath:
+              ________________________________________
+              The Incompatibility Report:
+
+                In scenario "GET /hook-passed. Response: ok"
+                API: GET /hook-passed -> 200
+
+                  >> RESPONSE.BODY.value
+
+                      This is number in the new specification response but string in the old specification
+
+
+              --------------------
+              Verdict for spec $hookPassedSpecPath:
+                (HOOK: PASSED)
+              --------------------
+
+
+            Generating BCC report for 6 checks and 3 operations...
+            Generating HTML report in $htmlReportPath
+            Files checked: 3 (Passed: 2, Failed: 1)
+            """.trimIndent())
+
+            val reportJson = bccReportJson(tempDir.resolve("reports/backward_compatibility"))
+            val executionDetails = reportJson.path("results").path("summary").path("extra").path("executionDetails")
+            val operationsBySpec = executionDetails.associate { detail ->
+                detail.path("specification").asText().replace('\\', '/') to detail.path("operations").single().let {
+                    "${it.path("method").asText()} ${it.path("path").asText()} -> ${it.path("status").asText()}"
+                }
+            }
+
+            assertThat(operationsBySpec).containsOnly(
+                entry(compatibleSpecPath, "GET /compatible -> compatible"),
+                entry(hookPassedSpecPath, "GET /hook-passed -> incompatible"),
+                entry(hookFailedSpecPath, "GET /hook-failed -> incompatible")
+            )
+        }
+
+        @Test
         fun `ctrf report includes every breaking spec when more than one spec is breaking`() {
             fun specWithType(path: String, type: String) = """
                 openapi: 3.0.0
@@ -1789,4 +1987,62 @@ class BackwardCompatibilityCheckCommandV2Test {
         return objectMapper.readTree(reportLiteral)
     }
 
+    private fun <T> withServiceLoaderEntries(entries: Map<Class<*>, String>, block: () -> T): T {
+        val previousContextClassLoader = Thread.currentThread().contextClassLoader
+        val serviceLoaderDir = Files.createTempDirectory("specmatic-service-loader-test")
+        val servicesDir = serviceLoaderDir.resolve("META-INF/services")
+        Files.createDirectories(servicesDir)
+
+        entries.forEach { (service, implementationClassName) ->
+            Files.writeString(servicesDir.resolve(service.name), "$implementationClassName\n")
+        }
+
+        val classLoader = URLClassLoader(arrayOf(serviceLoaderDir.toUri().toURL()), previousContextClassLoader)
+        Thread.currentThread().contextClassLoader = classLoader
+
+        return try {
+            block()
+        } finally {
+            Thread.currentThread().contextClassLoader = previousContextClassLoader
+            classLoader.close()
+            serviceLoaderDir.toFile().deleteRecursively()
+        }
+    }
+
+}
+
+class MixedResultBackwardCompatibilityCheckHook : BackwardCompatibilityCheckHook {
+    override fun check(
+        backwardCompatibilityResult: Results,
+        centralRepoUrl: String,
+        specFilePath: String,
+    ): Pair<CompatibilityResult, List<OperationUsageResponse>?> {
+        checkedSpecs.add(specFilePath)
+
+        return when (specFilePath) {
+            PASSED_SPEC -> CompatibilityResult.PASSED to emptyList()
+            FAILED_SPEC -> CompatibilityResult.FAILED to emptyList()
+            else -> CompatibilityResult.UNKNOWN to emptyList()
+        }
+    }
+
+    override fun logStartedMessage(failedSpecs: List<BackwardCompatibilityCheckBaseCommand.ProcessedSpec>) {}
+
+    override fun logCompletedMessage() {}
+
+    override fun failedVerdictAndMessage(
+        processedSpec: BackwardCompatibilityCheckBaseCommand.ProcessedSpec,
+        strictMode: Boolean,
+    ): Pair<CompatibilityResult, String> =
+        processedSpec.computedCompatibilityCheckHookResult.first to "(HOOK: ${processedSpec.computedCompatibilityCheckHookResult.first})"
+
+    companion object {
+        const val PASSED_SPEC = "hook-passed.yaml"
+        const val FAILED_SPEC = "hook-failed.yaml"
+        val checkedSpecs = java.util.concurrent.CopyOnWriteArrayList<String>()
+
+        fun reset() {
+            checkedSpecs.clear()
+        }
+    }
 }

--- a/application/src/test/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommandTest.kt
+++ b/application/src/test/kotlin/application/backwardCompatibility/BackwardCompatibilityCheckBaseCommandTest.kt
@@ -1,7 +1,6 @@
 package application.backwardCompatibility
 
 import io.specmatic.core.IFeature
-import io.specmatic.core.Results
 import io.specmatic.core.utilities.Flags
 import io.specmatic.core.utilities.Flags.Companion.CONFIG_FILE_PATH
 import org.assertj.core.api.Assertions.assertThat
@@ -132,7 +131,7 @@ class BackwardCompatibilityCheckBaseCommandTest {
         fun strictMode() = effectiveStrictMode
         fun git() = gitCommand
 
-        override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): Results {
+        override fun checkBackwardCompatibility(oldFeature: IFeature, newFeature: IFeature): BackwardCompatibilityCheckResult {
             TODO("Not yet implemented")
         }
 

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -40,6 +40,7 @@ fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Res
 }
 
 fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? {
+    if (records.isEmpty()) return null
     if (!Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) return null
     val reportOperations = BccReportGenerator().generateReportOperations(records)
     val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()

--- a/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
+++ b/core/src/main/kotlin/io/specmatic/core/TestBackwardCompatibility.kt
@@ -26,6 +26,11 @@ internal fun testBackwardCompatibilityWithReport(older: Feature, newer: Feature)
     return Pair(result, report)
 }
 
+fun backwardCompatibilityRecords(older: Feature, newer: Feature): Pair<Results, List<CtrfBackwardCompatibilityRecord>> {
+    val records = OpenApiBackwardCompatibilityChecker(older, newer).run()
+    return records.toBackwardCompatibilityStatuses() to records
+}
+
 fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Results {
     return filterIsInstance<OpenApiBackwardCompatibilityCheckRecord>()
         .groupBy { it.operations }.values
@@ -34,7 +39,7 @@ fun List<CtrfBackwardCompatibilityRecord>.toBackwardCompatibilityStatuses(): Res
         }
 }
 
-private fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? {
+fun generateBackwardCompatibilityReport(records: List<CtrfBackwardCompatibilityRecord>, startTime: Long, endTime: Long): CtrfReport? {
     if (!Flags.getBooleanValue(SPECMATIC_BCC_REPORT_FLAG)) return null
     val reportOperations = BccReportGenerator().generateReportOperations(records)
     val reportDir = loadSpecmaticConfigOrDefault(getConfigFileName()).getReportDirPath(BCC_REPORT_DIR_SUFFIX).toFile()

--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4728,6 +4728,23 @@ paths:
         }
     }
 
+    @Test
+    fun `generateBackwardCompatibilityReport returns null and writes nothing when there are no records`(@TempDir tempDir: File) {
+        val configFile = tempDir.resolve("specmatic.yaml").apply {
+            writeText("""
+            version: 2
+            reportDirPath: ${tempDir.canonicalPath}/reports
+            """.trimIndent())
+        }
+
+        using(CONFIG_FILE_PATH to configFile.canonicalPath, "SPECMATIC_BCC_REPORT" to "true") {
+            val report = generateBackwardCompatibilityReport(emptyList(), 0L, 1L)
+
+            assertThat(report).isNull()
+            assertThat(tempDir.resolve("reports")).doesNotExist()
+        }
+    }
+
     @Nested
     inner class BccIntegrationFromFixtures {
         @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.specmatic
-version=2.46.2-SNAPSHOT
+version=2.46.3-SNAPSHOT
 specmaticGradlePluginVersion=0.15.8
 specmaticReporterVersion=0.3.26
 swaggerParserVersion=2.1.35

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.specmatic
-version=2.46.3-SNAPSHOT
+version=2.46.2-SNAPSHOT
 specmaticGradlePluginVersion=0.15.8
 specmaticReporterVersion=0.3.26
 swaggerParserVersion=2.1.35


### PR DESCRIPTION
## Problem

- When the backward-compatibility check (`backward-compatibility-check`) checks more than one changed spec with `SPECMATIC_BCC_REPORT=true`, the generated CTRF/HTML report only ever contains the **last** spec checked. Every earlier spec is silently dropped from `results.summary.extra.executionDetails`, `results.tests`, and the summary counts.

- Also found and fixed another issue related to hook dropping passing scenarios. See test `ctrf report includes compatible specs when hook validates mixed failures` for details.

### Root cause

The report was regenerated and written **once per spec**, inside the per-spec loop: `checkBackwardCompatibility` → `testBackwardCompatibility` → `testBackwardCompatibilityWithReport` → `generateBackwardCompatibilityReport` → `ReportGenerator.generateReportBcc`, which builds the report from only the current spec's records and **overwrites** the same `index.html` / CTRF file each iteration. Last write wins.

### Companion PRs
- https://github.com/specmatic/enterprise/pull/306