### PR TITLE
BCC CTRF rawStatus carries compatible/incompatible

### DIFF
--- a/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
+++ b/core/src/test/kotlin/io/specmatic/core/TestBackwardCompatibilityKtTest.kt
@@ -4839,7 +4839,7 @@ paths:
         }
 
         @Test
-        fun `a breaking wip operation executes and is reported as other while retaining its failed raw status`(@TempDir tempDir: File) {
+        fun `a breaking wip operation executes and is reported as other while retaining its incompatible raw status`(@TempDir tempDir: File) {
             val oldSpec = readFixture("orders_old.yaml")
             val newSpec = readFixture("orders_new.yaml")
 
@@ -4858,9 +4858,9 @@ paths:
                 assertThat(wipTest.path("status").asText()).isEqualTo("other")
             }
             // The WIP operation actually executed and produced a real failure: at least one WIP
-            // test retains a `failed` raw status even though its reported state is `other`.
+            // test retains an `incompatible` raw status even though its reported state is `other`.
             assertThat(wipTests).anySatisfy { wipTest ->
-                assertThat(wipTest.path("rawStatus").asText()).isEqualTo("failed")
+                assertThat(wipTest.path("rawStatus").asText()).isEqualTo("incompatible")
             }
 
             // The WIP failure is counted under `other`, never `failed`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group=io.specmatic
 version=2.46.2-SNAPSHOT
 specmaticGradlePluginVersion=0.15.8
-specmaticReporterVersion=0.3.26
+specmaticReporterVersion=0.3.27-SNAPSHOT
 swaggerParserVersion=2.1.35
 kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=384m


### PR DESCRIPTION
## What

Adopts the BCC CTRF `rawStatus` change from specmatic-reporter: `rawStatus` now carries the domain verdict `compatible`/`incompatible` instead of `passed`/`failed`. Bumps `specmaticReporterVersion` to `0.3.27-SNAPSHOT` and updates the WIP raw-status assertion in `TestBackwardCompatibilityKtTest`.

## Companion PR

specmatic/specmatic-reporter#143 (source change)